### PR TITLE
Create an RPM package of the Endpoint

### DIFF
--- a/compute_endpoint/packaging/Makefile
+++ b/compute_endpoint/packaging/Makefile
@@ -3,8 +3,8 @@
 PYTHON3 := $(shell which /opt/globus-python/bin/python3 python3 | head -1)
 
 PY_FULL_VERSION := $$($(PYTHON3) -c "import sys; print('{}.{}.{}'.format(*sys.version_info))")
-PY_MAJOR_VERSION := $(shell echo $(PY_FULL_VERSION) | cut -d . -f1 )
-PY_MINOR_VERSION := $(shell echo $(PY_FULL_VERSION) | cut -d . -f2 )
+PY_MAJOR_VERSION := $(shell echo -n $(PY_FULL_VERSION) | cut -d . -f1 )
+PY_MINOR_VERSION := $(shell echo -n $(PY_FULL_VERSION) | cut -d . -f2 )
 PY_VERSION := $(PY_MAJOR_VERSION)$(PY_MINOR_VERSION)
 
 VIRTUALENV := venv-$(PY_VERSION)
@@ -15,13 +15,16 @@ VENV_PY := $(shell pwd)/$(VIRTUALENV)/bin/python
 # not so ideal, but at the moment, I don't know how to do better.  Hmm.
 ifeq ($(wildcard $(VENV_PY)),)
 	_DUMMY := $(shell $(PYTHON3) -mvenv "$(VIRTUALENV)")
-	_DUMMY := $(shell $(VENV_PY) -mpip install -U pip setuptools)
+	_DUMMY := $(shell $(VENV_PY) -mpip install -U pip -U setuptools)
 endif
 
+# "package name - dash" and "package name - underscore"
+PKG_NAME_D := $(shell cd ../; $(VENV_PY) setup.py --name)
+PKG_NAME_U := $(shell echo -n $(PKG_NAME_D) | tr '-' '_')
+
 PKG_VERSION := $(shell cd ../; $(VENV_PY) setup.py --version | tr '-' '~')
-PKG_NAME := $(shell cd ../; $(VENV_PY) setup.py --name | tr '-' '_')
-PKG_WHEEL = $(PKG_NAME)-$(PKG_VERSION)-py$(PY_MAJOR_VERSION)-none-any.whl
-PREREQS_TARBALL_NAME = $(PKG_NAME)-prereqs-py$(PY_VERSION)-$(PKG_VERSION).tar.xz
+PKG_WHEEL = $(PKG_NAME_U)-$(PKG_VERSION)-py$(PY_MAJOR_VERSION)-none-any.whl
+PREREQS_TARBALL_NAME = $(PKG_NAME_U)-prereqs-py$(PY_VERSION)-$(PKG_VERSION).tar.xz
 
 OS_CODENAME := $(shell test -f /etc/os-release && . /etc/os-release; echo $${VERSION_CODENAME:-focal})
 
@@ -52,7 +55,8 @@ show_vars:   ##-For debugging, show the Makefile variables; will install a venv
 	@echo "VIRTUALENV           : $(VIRTUALENV)"
 	@echo "VENV_PY              : $(VENV_PY)"
 	@echo "VENV_PIP             : $(VENV_PIP)"
-	@echo "PKG_NAME             : $(PKG_NAME)"
+	@echo "PKG_NAME_D           : $(PKG_NAME_D)"
+	@echo "PKG_NAME_U           : $(PKG_NAME_U)"
 	@echo "PKG_VERSION          : $(PKG_VERSION)"
 	@echo "PREREQS_TARBALL_NAME : $(PREREQS_TARBALL_NAME)"
 	@echo "PKG_WHEEL            : $(PKG_WHEEL)"
@@ -66,10 +70,18 @@ clean:  ##-Remove the venv, build/ dist/, prereqs tarball, and the package wheel
 
 .PHONY: distclean
 distclean: clean  ##-Run `clean` target, then additionally remove venv-*, *tar.xz, *whl
-	rm -rf -- venv-* "$(PKG_NAME)"-*tar.xz "$(PKG_NAME)"-*whl
+	rm -rf -- venv-* "$(PKG_NAME_U)"-*tar.xz "$(PKG_NAME_U)"-*whl
+
+_build_needs:
+	@/bin/echo -e "\033[36;1;40mChecking build dependencies before starting build\033[m ...\n"
+	@[ -x "$$(which git)" ] || { echo "'git' not found; missing 'git' package?"; exit 1; }
+	@[ -x "$$(which xz)" ] || { echo "'xz' not found; missing 'xz' package?"; exit 1; }
+	@[ -x "$$(which sed)" ] || { echo "'sed' not found; missing 'sed' package?"; exit 1; }
+	@[ -x "$$(which tar)" ] || { echo "'tar' not found; missing 'tar' package?"; exit 1; }
+	@[ -x "$(PYTHON3)" ] || { echo "Python interpreter not found ('$(PYTHON3)'); try 'make show_vars' for insight?"; exit 1; }
 
 .PHONY: $(VENV_PY)
-$(VENV_PY):
+$(VENV_PY): _build_needs
 	@if [ "$(PY_MAJOR_VERSION)" -ne 3 ] || [ "$(PY_MINOR_VERSION)" -lt 9 ]; then \
 		echo "Unsupported python version $(PY_FULL_VERSION). At least 3.9 is required."; \
 		echo "To override python path, use the following"; \
@@ -78,7 +90,7 @@ $(VENV_PY):
 	fi
 	$(PYTHON3) -mvenv $(VIRTUALENV)
 	. $(VIRTUALENV)/bin/activate
-	@$(VENV_PY) -m pip install -U pip setuptools
+	@$(VENV_PY) -m pip install -U pip -U setuptools -U build
 
 $(PKG_WHEEL): $(VENV_PY)
 	(   rm -rf build/ \
@@ -86,10 +98,9 @@ $(PKG_WHEEL): $(VENV_PY)
 	 && cd build/compute_endpoint/ \
 	 && echo -n "    Git Tag: " \
 	 && if ! git describe --tags --exact-match; then \
-	   { echo "\nBUILD COMPUTE FROM A RELEASE TAG (current branch: $$(git branch --show-current))"; exit 1; } \
+	   { /bin/echo -e "\nBUILD COMPUTE FROM A RELEASE TAG (current branch: $$(git branch --show-current))"; exit 1; } \
 	    fi \
 	 && rm -rf tests/ \
-	 && $(VENV_PY) -m pip install build \
 	 && $(VENV_PY) -m build --wheel -o ../../ \
 	)
 
@@ -105,23 +116,46 @@ dist: $(PREREQS_TARBALL_NAME)  ##-Make the dist/ directory with prereqs and whee
 	  && mkdir dist/ \
 	  && cp $(PREREQS_TARBALL_NAME) $(PKG_WHEEL) dist/
 
-deb_build_needs:  ##-Check that necessary executables are available before starting the build.
-	@echo "\033[36;1;40mChecking build dependencies before starting build\033[39;49m ...\n"
-	@[ -x "$$(which dpkg-checkbuilddeps)" ] || { echo "Missing 'dpkg-dev' package"; exit 1; }
+deb_build_needs:  ##-Check that necessary executables are available before starting the DEB build.
+	@[ -x "$$(which dpkg-checkbuilddeps)" ] || { echo "'dpkg-checkbuilddeps' not found; missing 'dpkg-dev' package?"; exit 1; }
 	@dpkg-checkbuilddeps
 
 deb: deb_build_needs dist  ##-Build a Debian package of the Globus Compute Endpoint (.deb)
 	(   cd dist/ \
 	 && rm -rf debbuild/ \
-	 && mkdir -p debbuild/globus-compute-endpoint/wheels/ \
-	 && tar -C debbuild/globus-compute-endpoint/wheels/ --strip 1 -xf "$(PREREQS_TARBALL_NAME)" \
-	 && cp -R ../debian debbuild/globus-compute-endpoint/ \
-	 && cp $(PKG_WHEEL) debbuild/globus-compute-endpoint/wheels/ \
-	 && cp ../package_shim.sh debbuild/globus-compute-endpoint/ \
-	 && cd debbuild/globus-compute-endpoint/ \
+	 && mkdir -p debbuild/$(PKG_NAME_D)/wheels/ \
+	 && tar -C debbuild/$(PKG_NAME_D)/wheels/ -xf "$(PREREQS_TARBALL_NAME)" \
+	 && cp $(PKG_WHEEL) debbuild/$(PKG_NAME_D)/wheels/ \
+	 && cp -R ../debian debbuild/$(PKG_NAME_D)/ \
+	 && cp ../package_shim.sh debbuild/$(PKG_NAME_D)/ \
+	 && cd debbuild/$(PKG_NAME_D)/ \
 	 && mv debian/changelog.in.in debian/changelog \
-	 && sed -i -e "s/@VERSION@/$(PKG_VERSION)/g" -e "s/@distro@/$(OS_CODENAME)/g" debian/changelog \
+	 && sed -i debian/changelog \
+	    -e "s/@VERSION@/$(PKG_VERSION)/g" \
+	    -e "s/@distro@/$(OS_CODENAME)/g" \
 	 && dpkg-buildpackage -uc -us \
 	)
 	@echo "\nDEB package successfully built:"
 	@ls -lh dist/debbuild/*deb
+
+rpm_build_needs:  ##-Check that necessary executables are available before starting the RPM build.
+	@[ -x "$$(which rpmbuild)" ] || { echo "'rpmbuild' not found; missing 'rpmdevtools' package?"; exit 1; }
+
+
+rpm: rpm_build_needs dist  ##-Build an RPM package of the Globus Compute Endpoint (.rpm)
+	(   cd dist/ \
+	 && pwd && ls \
+	 && rm -rf rpmbuild/ \
+	 && mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SPECS,SRPMS} rpmbuild/SOURCES/$(PKG_NAME_D)/wheels \
+	 && tar -C rpmbuild/SOURCES/$(PKG_NAME_D)/wheels -xf "$(PREREQS_TARBALL_NAME)" \
+	 && cp $(PKG_WHEEL) rpmbuild/SOURCES/$(PKG_NAME_D)/wheels/ \
+	 && cp ../package_shim.sh rpmbuild/SOURCES/$(PKG_NAME_D)/ \
+	 && sed \
+	    -e "s/@VERSION@/$(PKG_VERSION)/g" \
+	    -e "s/@PACKAGE_NAME@/$(PKG_NAME_D)/g" \
+	    -e "s/@PACKAGE_WHEEL@/$(PKG_WHEEL)/g" \
+	    < ../fedora/$(PKG_NAME_D).spec.in > ./$(PKG_NAME_D).spec \
+	 && HOME="$$(pwd)" rpmbuild -ba ./$(PKG_NAME_D).spec \
+	)
+	@echo -e "\nRPM package successfully built:"
+	@ls -lh dist/rpmbuild/RPMS/**/*rpm

--- a/compute_endpoint/packaging/create-prereqs-tarball.sh
+++ b/compute_endpoint/packaging/create-prereqs-tarball.sh
@@ -58,7 +58,7 @@ shift 1
 
 # RPM and DEB packages don't understand -prerelease bits from semver spec, so
 # replace with ~ that works almost the same
-py_full_version=$(python3 -c "import sys; print('{}.{}.{}'.format(*sys.version_info))")
+py_full_version=$("$PYTHON_BIN" -c "import sys; print('{}.{}.{}'.format(*sys.version_info))")
 [[ -z $py_version ]] && py_version="$(echo "$py_full_version" | cut -d . -f1,2 | tr -d '.')"
 [[ -z $pkg_version ]] && pkg_version="$(cd "$src_dir"; "$PYTHON_BIN" setup.py --version | tr '-' '~')"
 [[ -z $pkg_name ]] && pkg_name="$(cd "$src_dir"; "$PYTHON_BIN" setup.py --name | tr '-' '_')"
@@ -90,15 +90,12 @@ done > dependent-prereqs.txt
 
 modified_time="$(TZ=UTC0 date --rfc-3339=seconds)"
 
-(find "$download_dir/" -print0 | TZ=UTC0 tar --format=posix \
+TZ=UTC0 tar -C "$download_dir/" --format=posix \
   --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime,delete=mtime \
-  --null \
   --mtime="$modified_time" \
   --numeric-owner \
   --owner=0 \
   --group=0 \
   --mode="go-rwx,u+rw" \
-  --files-from - \
-  -cf - \
+  -cf - . \
   | xz -9
-)

--- a/compute_endpoint/packaging/debian/changelog.in.in
+++ b/compute_endpoint/packaging/debian/changelog.in.in
@@ -5,4 +5,4 @@ globus-compute-endpoint (@VERSION@.@distro@) @distro@; urgency=low
   * Includes support for multi-user Globus Compute Endpoints; see
     https://globus-compute.readthedocs.io/ for more information.
 
- -- Maintainer: Globus Support <support@globus.org>  Wed, 21 Feb 2024 14:01:30 -0500
+ -- Maintainer: Globus Support <support@globus.org>  Mon, 08 Apr 2024 11:01:30 -0500

--- a/compute_endpoint/packaging/debian/rules
+++ b/compute_endpoint/packaging/debian/rules
@@ -15,25 +15,20 @@ export DEB_BUILD_OPTIONS
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 name := globus-compute-endpoint
-versionedname := $(name)
-VIRTUAL_ENV := /opt/globus
+VIRTUAL_ENV := /opt/$(name)/venv-py39
 TMP_BUILD_DIR := debian/$(name)-tmp
 TMP_VIRTUAL_ENV := $(TMP_BUILD_DIR)$(VIRTUAL_ENV)
-DEST_ROOT := debian/$(versionedname)
+DEST_ROOT := debian/$(name)
 DEST_VIRTUAL_ENV := $(DEST_ROOT)$(VIRTUAL_ENV)
+PYTHON3 := /opt/globus-python/bin/python3
 
 _sysconfdir=/etc
 _sbindir=/usr/sbin
-_mandir=/usr/share/man
-_var=/var
 _unitdir=/lib/systemd/system
-_docdir=/usr/share/doc
-_httpd_confdir=$(_sysconfdir)/apache2/conf-available
-_completion_dir="${_sysconfdir}/bash_completion.d"
 
 .PHONY: override_dh_auto_configure
 override_dh_auto_configure:
-	/opt/globus-python/bin/python3 -mvenv $${PWD}/$(TMP_VIRTUAL_ENV)
+	$(PYTHON3) -mvenv $${PWD}/$(TMP_VIRTUAL_ENV)
 	. "$(TMP_VIRTUAL_ENV)/bin/activate"; \
 	set -x; \
 	python3 -mpip install --no-index --no-cache-dir -I --compile -U wheels/pip-*.whl; \
@@ -50,11 +45,10 @@ override_dh_shlibdeps:    # empty == we're ignoring it for our purposes.
 override_dh_auto_install:
 	set -ex; \
 	. "$(TMP_VIRTUAL_ENV)/bin/activate"; \
-	/opt/globus-python/bin/python3 -mvenv $${PWD}/$(TMP_VIRTUAL_ENV) ; \
+	$(PYTHON3) -mvenv $${PWD}/$(TMP_VIRTUAL_ENV) ; \
 	install -d -m 755 \
 	  "$(DEST_VIRTUAL_ENV)" \
 	  "$(DEST_ROOT)$(_sbindir)" \
-	  "$(DEST_ROOT)$(_mandir)" \
 	  "$(DEST_ROOT)$(_unitdir)"; \
 	install -m 755 "$${PWD}/package_shim.sh" "$(DEST_ROOT)$(_sbindir)/$(name)"
 	sed -i "$(DEST_ROOT)$(_sbindir)/$(name)" -e "s|@VIRTUAL_ENV@|$(VIRTUAL_ENV)|"
@@ -72,12 +66,12 @@ override_dh_auto_install:
 	rm -rf $(DEST_VIRTUAL_ENV)/systemd \
 	  $(DEST_VIRTUAL_ENV)/lib/python*/site-packages/tests; \
 	sed -i "$(DEST_VIRTUAL_ENV)/bin/activate" -e "s|^VIRTUAL_ENV=.*|VIRTUAL_ENV=$(VIRTUAL_ENV)|"; \
-	ln -s "python$$(/opt/globus-python/bin/python3 -c 'import sys,platform; sys.stdout.write(".".join(platform.python_version_tuple()[:2]))')" "$(DEST_VIRTUAL_ENV)/lib/python"; \
+	ln -s "python$$($(PYTHON3) -c 'import sys; print("{}.{}".format(*sys.version_info))')" "$(DEST_VIRTUAL_ENV)/lib/python"; \
 	:
 
 .PHONY: override_dh_python3
 override_dh_python3:
-	dh_python3 --shebang=/opt/globus/bin/python
+	dh_python3 --shebang=$(PYTHON3)
 
 .PHONY: override_dh_builddeb
 override_dh_builddeb:

--- a/compute_endpoint/packaging/fedora/globus-compute-endpoint.spec.in
+++ b/compute_endpoint/packaging/fedora/globus-compute-endpoint.spec.in
@@ -1,0 +1,118 @@
+Name:           @PACKAGE_NAME@
+%define         _build_id_links         none
+%global         debug_package           %{nil}
+%global         version                 @VERSION@
+%global         pythonversion           py39
+%global         VIRTUAL_ENV             /opt/%{name}/venv-%{pythonversion}
+%global         src_dir                 %{_sourcedir}/%{name}
+%global         wheels                  %{src_dir}/wheels
+%global         package_executable      %{name}
+%global         globus_python3_version  3.9
+%global         __python                /opt/globus-python/bin/python3
+
+# We don't put our bits in the standard locations, so python_provides generation
+# is not useful (and super slow anyway!)
+%global __python_provides %{nil}
+
+# Don't generate automatic library requires/depends, since those shouldn't be visible
+# outside of this package
+%global __requires_exclude_from ^%{VIRTUAL_ENV}/.*$
+
+# Do not check .so files in an application-specific library directory
+# or any files in the application's data directory for provides
+%global __provides_exclude_from ^%{VIRTUAL_ENV}/.*\\.so.*$
+
+Version:        @VERSION@
+Release:        1%{?dist}
+Vendor:         %{?vendor}%{!?vendor:Unknown}
+Summary:        Globus Compute Endpoint agent for system-level installs
+
+Conflicts:      %{name} < %{version}
+Requires:       globus-python >= %{globus_python3_version}
+Requires(pre):  /usr/sbin/useradd, /usr/bin/getent
+Requires(postun): /usr/sbin/userdel
+
+Group:          System Environment/Daemons
+
+License:        Apache 2.0
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+
+BuildRequires:  globus-python >= %{globus_python3_version}
+BuildRequires:  file
+
+%description
+An agent to receive tasks as sent from the Globus Compute SDK.
+This module is intended for system administrators; end-users will most-likely
+want to install the `%{name}` directly from PyPI.
+
+%prep
+%global DEST_VIRTUAL_ENV "$PWD/TMP_RPM_BUILD_ROOT%{VIRTUAL_ENV}"
+
+[ -f %{wheels}/@PACKAGE_WHEEL@ ] || {
+    C="" R=""
+    [ -t 2 ] && { C="\033[91;1;40m"; R="\033[m"; }
+    >&2 echo -e "${C}Main source wheel not found.  Reminder: the Makefile sets that up.  (Hint: make rpm)${R}";
+    exit 1
+}
+
+rm -rf "%{DEST_VIRTUAL_ENV}"
+%__python -mvenv "%{DEST_VIRTUAL_ENV}"
+
+%build
+. "%{DEST_VIRTUAL_ENV}/bin/activate"
+python3 -mpip uninstall -y pip
+unzip -d "%{DEST_VIRTUAL_ENV}"/lib/python*/site-packages %{wheels}/pip-*-py3-none-any.whl
+deactivate
+
+%install
+. "%{DEST_VIRTUAL_ENV}/bin/activate"
+python3 -mpip install --pre --compile --no-index --no-cache-dir -I --find-links=file://%{wheels} %{name}
+
+tar -C "${PWD}/TMP_RPM_BUILD_ROOT" -cf - . | tar -C "${RPM_BUILD_ROOT}" -xf -
+
+# Rewrite shbang or exec lines that refer to our build root
+for script in "${RPM_BUILD_ROOT}%{VIRTUAL_ENV}/bin/"*; do
+    if [ ! -L "$script" ] && [ -f "$script" ]; then
+        shbang="$(head -2c "$script")"
+        if [ "$shbang" = "#!" ]; then
+            sed -i "$script" -e "1,2s|${PWD}/TMP_RPM_BUILD_ROOT||"
+        fi
+    fi
+done
+
+deactivate
+sed -i "${RPM_BUILD_ROOT}%{VIRTUAL_ENV}/bin/activate" \
+    -e "s|^VIRTUAL_ENV=.*|VIRTUAL_ENV=%{VIRTUAL_ENV}|"
+
+rm -f $RPM_BUILD_ROOT%{VIRTUAL_ENV}/lib/python
+ln -s "python%{globus_python3_version}" "$RPM_BUILD_ROOT%{VIRTUAL_ENV}/lib/python"
+
+install -d -m 755 ${RPM_BUILD_ROOT}%{_sbindir}
+install -m 755 %{src_dir}/package_shim.sh "${RPM_BUILD_ROOT}%{_sbindir}/%{package_executable}"
+sed -i "${RPM_BUILD_ROOT}%{_sbindir}/%{package_executable}" -e "s|@VIRTUAL_ENV@|%{VIRTUAL_ENV}|"
+
+rm -rf ${RPM_BUILD_ROOT}%{VIRTUAL_ENV}%{_sysconfdir} ${RPM_BUILD_ROOT}%{VIRTUAL_ENV}%{_var}
+
+%pre
+
+%post
+
+%preun
+
+%postun
+
+%posttrans
+
+%files
+
+%defattr(-,root,root,-)
+%dir %{VIRTUAL_ENV}
+%{VIRTUAL_ENV}/*
+%{_sbindir}/%{package_executable}
+
+%changelog
+* Mon Apr 08 2024 Globus Support <support@globus.org> - @VERSION@-%{release}
+  * Initial release as an RPM package
+
+  * Includes support for multi-user Globus Compute Endpoints; see
+    https://globus-compute.readthedocs.io/ for more information.


### PR DESCRIPTION
The individual pieces and parts are laid out in the Makefile, extending the same workflow as introduced in [funcx sc-29028]/[sc-32395]/#1492.  Thus:

```console
$ make rpm
...
RPM package successfully built:
-rw-r--r-- 1 root root 16M Apr  7 15:31 dist/rpmbuild/RPMS/x86_64/globus-compute-endpoint-2.17.0-1.fc39.x86_64.rpm
```

Additional items from the Makefile which may be useful for debugging or development are accessible from a naked `make` invocation or `make help`.

The resulting `.rpm` has a dependency on Globus' Python[1], and will install the Globus Compute Endpoint agent code into `/opt/globus/`, as well as a symlink `/opt/globus/bin/globus-compute-endpoint` into `/usr/sbin/`.

Meanwhile, while lurking in the RPM build innards, realize that `/opt/globus/` is a venv for GCS, so set install directory for both DEB and RPM to `/opt/globus-compute-endpoint/venv-py<version>/`

[1] https://downloads.globus.org/globus-connect-server/stable/rpm/ (and drill down to the appropriate **/x86_64/ directory)

[sc-32394]
[sc-29027]

## Type of change

- New feature (non-breaking change that adds functionality)