### PR TITLE
Update pinning workers config to use GCEngine

### DIFF
--- a/docs/configs/worker_pinning.yaml
+++ b/docs/configs/worker_pinning.yaml
@@ -1,5 +1,5 @@
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     max_workers_per_node: 4
 
     # `available_accelerators` may be a natural number or a list of strings.

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -227,7 +227,7 @@ Pinning Workers to devices
 
 Many modern clusters provide multiple accelerators per compute note, yet many applications are best suited to using a
 single accelerator per task. Globus Compute supports pinning each worker to different accelerators using the ``available_accelerators``
-option of the ``HighThroughputEngine``. Provide either the number of accelerators (Globus Compute will assume they are named
+option of the ``GlobusComputeEngine``. Provide either the number of accelerators (Globus Compute will assume they are named
 in integers starting from zero) or a list of the names of the accelerators available on the node. Each Globus Compute worker
 will have the following environment variables set to the worker specific identity assigned:
 ``CUDA_VISIBLE_DEVICES``, ``ROCR_VISIBLE_DEVICES``, ``SYCL_DEVICE_FILTER``.


### PR DESCRIPTION
# Description

We will soon deprecate the `HighThroughputEngine`.

[sc-32323]

## Type of change

- Documentation update
