### PR TITLE
Expand pyzmq supported versions to <27.0.0

### DIFF
--- a/changelog.d/20240415_191133_30907815+rjmello_extend_pyzmq_version_range.rst
+++ b/changelog.d/20240415_191133_30907815+rjmello_extend_pyzmq_version_range.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Expanded support for `pyzmq` dependency to include versions up to `26.x.x`.

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -31,7 +31,7 @@ REQUIRES = [
     # building from source, which may mean there's an issue in the packaged library
     # further investigation may be needed if the issue persists in the next pyzmq
     # release
-    "pyzmq>=22.0.0,!=22.3.0,<=23.2.0",
+    "pyzmq>=22.0.0,!=22.3.0,<27.0.0",
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver


### PR DESCRIPTION
# Description

We currently only support `pyzmq` versions up to `23.2.0`, but our code is compatible with the latest `26.x.x` versions.

## Type of change

- New feature (non-breaking change that adds functionality)
