### PR TITLE
Create docker compose workflow for EP dev

### DIFF
--- a/endpoint_dev.Dockerfile
+++ b/endpoint_dev.Dockerfile
@@ -1,0 +1,20 @@
+ARG PYTHON_VERSION="3.11"
+FROM python:${PYTHON_VERSION}
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y less socat sudo vim
+
+RUN mkdir -p /opt/globus-compute
+COPY . /opt/globus-compute
+
+RUN python -m pip install -U pip
+RUN python -m pip install -e /opt/globus-compute/compute_endpoint
+RUN python -m pip install -e /opt/globus-compute/compute_sdk
+
+ARG LOCAL_USER
+RUN useradd -m ${LOCAL_USER}
+RUN usermod -aG sudo ${LOCAL_USER}
+RUN echo "${LOCAL_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${LOCAL_USER}
+USER ${LOCAL_USER}
+ENV HOME /home/${LOCAL_USER}
+WORKDIR /home/${LOCAL_USER}

--- a/local_dev/.gitignore
+++ b/local_dev/.gitignore
@@ -1,0 +1,1 @@
+docker_data

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -1,0 +1,45 @@
+# Local dev
+
+Tools for local development of Globus Compute.
+
+
+## Docker Compose
+
+Globus Compute endpoints are only supported on Linux, so non-Linux users must utilize Docker containers
+(or similar) for their local development workflow.
+
+Running `docker compose up -d` in this directory will use `endpoint_dev.Dockerfile`, located in the
+project's root directory, to build a Docker image and container with `globus-compute-endpoint` installed.
+
+### Python version
+
+We install Python 3.11 in the Docker image by default, but you can override this via the `PYTHON_VERSION`
+environment variable.
+
+### Local user accounts
+
+By default, the Dockerfile references the `USER` environment variable from the host to create a local
+user account in the Docker image. You can override this by setting the `LOCAL_USER` environment variable
+before building the image.
+
+The local user account will have sudo privileges, allowing you to start endpoints in different contexts.
+
+### Development workflow
+
+We create a bind mount to mount this repo into the container at `/opt/globus-compute`, and run `pip install -e`
+for both the `compute_endpoint` and `compute_sdk` directories. In short, this means that the Docker container
+will immediately reflect any changes made to the repo on your host machine.
+
+### Accessing the host network
+
+Non-Linux users have limited options to expose their host's IP to a Docker container, which is necessary
+when running the Globus Compute services locally. The solution we've chosen is to forward traffic destined
+for the container's loopback (i.e., `localhost`) to `host.docker.internal`, the magic Docker-provided DNS
+name that resolves to the internal IP of the host. By default, we forward all traffic over port `5000` and
+`5672`, but you can modify these via the `WEB_SVC_PORT` and `AMQP_SVC_PORT` environment variables, respectively.
+
+### Persistent data
+
+We enable persistent endpoints by creating bind mounts for the `.globus_compute` directories of the root user
+and generated local user. The source directories for these bind mounts can be found in `./docker_data`, which
+is created by Docker Compose when initially starting the container.

--- a/local_dev/compose.yml
+++ b/local_dev/compose.yml
@@ -1,0 +1,16 @@
+version: "3.10"
+name: globus-compute
+services:
+
+  endpoint:
+    build:
+      context: ../
+      dockerfile: endpoint_dev.Dockerfile
+      args:
+        LOCAL_USER: ${LOCAL_USER:-${USER}}
+    volumes:
+      - ../:/opt/globus-compute
+      - ./docker_data/.globus_compute:/home/${LOCAL_USER:-${USER}}/.globus_compute
+      - ./docker_data/.globus_compute_root:/root/.globus_compute
+    command: bash -c "socat TCP-LISTEN:${WEB_SVC_PORT:-5000},fork TCP:host.docker.internal:${WEB_SVC_PORT:-5000} & \
+                      socat TCP-LISTEN:${AMQP_SVC_PORT:-5672},fork TCP:host.docker.internal:${WEB_SVC_PORT:-5672}"


### PR DESCRIPTION
# Description

Globus Compute endpoints are only supported on Linux, so non-Linux users must utilize Docker containers (or similar) for their local development workflow. This work provides a sensible framework for doing so.

[sc-33088]

## Type of change

- New feature (non-breaking change that adds functionality)