### PR TITLE
Adding lower bound to sphinx dependency

### DIFF
--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -26,7 +26,7 @@ REQUIRES = [
     "texttable>=1.6.7",
 ]
 DOCS_REQUIRES = [
-    "sphinx",
+    "sphinx>=7.3.2",
     "furo==2023.9.10",
 ]
 


### PR DESCRIPTION
# Description

A bug related to themes that inherit from third-party themes, such as Furo, was fixed in `v7.3.2`.

Ref: https://github.com/sphinx-doc/sphinx/pull/11891

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update
