### PR TITLE
Fix OpenSUSE rpm builds

### DIFF
--- a/compute_endpoint/packaging/Makefile
+++ b/compute_endpoint/packaging/Makefile
@@ -1,6 +1,8 @@
 .DEFAULT: help
 
-PYTHON3 := $(shell command -v /opt/globus-python/bin/python3)
+# Work with the (apparently) different setup in OpenSUSE, where `make` doesn't
+# invoke /bin/sh in the same manner as other platforms.
+PYTHON3 := $$($(SHELL) -c "command -v /opt/globus-python/bin/python3")
 
 PY_FULL_VERSION := $$($(PYTHON3) -c "import sys; print('{}.{}.{}'.format(*sys.version_info))")
 PY_MAJOR_VERSION := $(shell echo -n $(PY_FULL_VERSION) | cut -d . -f1 )
@@ -150,8 +152,7 @@ deb: deb_build_needs dist  ##-Build a Debian package of the Globus Compute Endpo
 	@ls -lh dist/debbuild/*deb
 
 rpm_build_needs:  ##-Check that necessary executables are available before starting the RPM build.
-	@[ -x "$$(command -v rpmbuild)" ] || { echo "'rpmbuild' not found; missing 'rpmdevtools' package?"; exit 1; }
-
+	@[ -x "$$(command -v rpmbuild)" ] || { echo "'rpmbuild' not found; missing 'rpmdevtools' or 'rpm-build' package(s)?"; exit 1; }
 
 rpm: rpm_build_needs dist  ##-Build an RPM package of the Globus Compute Endpoint (.rpm)
 	(   cd dist/ \
@@ -167,7 +168,7 @@ rpm: rpm_build_needs dist  ##-Build an RPM package of the Globus Compute Endpoin
 	    -e "s/@PACKAGE_WHEEL@/$(PKG_WHEEL)/g" \
 	    -e "s/@PIP_NAME@/$(PIP_NAME_D)/g" \
 	    < ../fedora/$(PKG_NAME).spec.in > ./$(PKG_NAME).spec \
-	 && HOME="$$(pwd)" rpmbuild -ba ./$(PKG_NAME).spec \
+	 && HOME="$$(pwd)" rpmbuild --define "_topdir $$(pwd)/rpmbuild" -ba ./$(PKG_NAME).spec \
 	)
 	@echo -e "\nRPM package successfully built:"
 	@ls -lh dist/rpmbuild/RPMS/**/*rpm

--- a/compute_endpoint/packaging/fedora/globus-compute-agent.spec.in
+++ b/compute_endpoint/packaging/fedora/globus-compute-agent.spec.in
@@ -60,8 +60,7 @@ rm -rf "%{DEST_VIRTUAL_ENV}"
 
 %build
 . "%{DEST_VIRTUAL_ENV}/bin/activate"
-python3 -mpip uninstall -y pip
-unzip -d "%{DEST_VIRTUAL_ENV}"/lib/python*/site-packages %{wheels}/pip-*-py3-none-any.whl
+python3 -mpip install --no-index --no-cache-dir -I --compile -U %{wheels}/pip-*.whl
 deactivate
 
 %install


### PR DESCRIPTION
OpenSUSE ... just likes to be different.  Per the Fedora spec, `HOME="$$(pwd)"` should be enough, but, per the output of `rpm --showrc | grep topdir`, it's clearly not in OpenSUSE's case.  #smh

Meanwhile, OpenSUSE's `make` implementation differs from (apparently) all others in that `$(shell ...)` does not accept `-c`.  Workaround that by manually invoking the shell.

Finally, reduce a dependency on `unzip` by bringing the `pip` update inline with the DEB package installation procedure: properly install via `pip` rather than the naive wheel unzipping.

[sc-33089]

## Type of change

- Bug fix (non-breaking change that fixes an issue)