### PR TITLE
Refactor endpoint delete to account for local, remote, or both

### DIFF
--- a/changelog.d/20240410_130138_LeiGlobus_delete_remote_endpoint_sc_31206.rst
+++ b/changelog.d/20240410_130138_LeiGlobus_delete_remote_endpoint_sc_31206.rst
@@ -1,0 +1,7 @@
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+- The ``delete`` command can now delete endpoints by name or UUID from the
+   Compute service remotely when local config files are not available.  Note
+   that without the ``--force`` option the command may exit early if the
+   endpoint is currently running or local config files are corrupted.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -655,62 +655,74 @@ class Endpoint:
 
     @staticmethod
     def delete_endpoint(
-        endpoint_dir: pathlib.Path, endpoint_config: Config | None, force: bool = False
+        ep_dir: pathlib.Path | None,
+        ep_config: Config | None = None,
+        force: bool = False,
+        ep_uuid: str | None = None,
     ):
-        ep_name = endpoint_dir.name
+        ep_name = None
 
-        if not endpoint_dir.exists():
-            log.warning(f"Endpoint <{ep_name}> does not exist")
+        if ep_dir:
+            ep_name = str(ep_dir)
+        elif ep_uuid:
+            ep_name = ep_uuid
+        else:
+            log.warning("Name or UUID is needed to delete an Endpoint")
             exit(-1)
 
-        endpoint_id = Endpoint.get_endpoint_id(endpoint_dir)
-        if endpoint_id is None:
-            log.warning(
-                f"Configuration for endpoint <{ep_name}> could not be found, it "
-                "might not have been initialized locally"
-            )
-            if not force:
-                exit(-1)
+        # If we have the UUID, do the online status check/deletion first
+        if ep_uuid:
+            try:
+                gc_client = Endpoint.get_funcx_client(ep_config)
+                status = gc_client.get_endpoint_status(ep_uuid)
+                if status.get("status") == "online":
+                    if not force:
+                        log.warning(
+                            f"Endpoint {ep_uuid} is currently running.  To proceed "
+                            "with deletion, first suspend it with the command "
+                            "`globus-compute-endpoint stop --remote {ep_uuid}` or "
+                            "ignore the current status with `delete --force`"
+                        )
+                        exit(-1)
+                    if ep_dir:
+                        # Stop endpoint to handle process cleanup
+                        Endpoint.stop_endpoint(ep_dir, ep_config, remote=False)
 
-        # Delete endpoint from web service
-        try:
-            fx_client = Endpoint.get_funcx_client(endpoint_config)
-            fx_client.delete_endpoint(endpoint_id)
-            log.info(f"Endpoint <{ep_name}> has been deleted from the web service")
-        except AuthAPIError:
-            # Send to the exception handler
-            raise
-        except GlobusAPIError as e:
-            log.warning(
-                f"Endpoint <{ep_name}> could not be deleted from the web service"
-                f"  [{e.text}]"
-            )
-            if not force:
-                log.critical("Exiting without deleting the endpoint")
-                exit(os.EX_UNAVAILABLE)
-        except NetworkError as e:
-            log.warning(
-                f"Endpoint <{ep_name}> could not be deleted from the web service"
-                f"  [{e}]"
-            )
-            if not force:
-                msg = (
-                    "globus-compute-endpoint is unable to reach the Globus Compute "
-                    "service due to a network error.\n"
-                    "Please ensure the Globus Compute service address is reachable, "
-                    "then attempt to delete the endpoint again."
+                gc_client.delete_endpoint(ep_uuid)
+                log.info(f"Endpoint {ep_uuid} has been deleted from the web service")
+            except AuthAPIError:
+                # Send to the exception handler
+                raise
+            except GlobusAPIError as e:
+                # GlobusAPIError is more known, handled slightly differently
+                log.warning(
+                    f"Endpoint {ep_uuid} could not be deleted from the web service: "
+                    f"[{e.text}]"
                 )
-                print(msg)
-                log.critical(msg)
-                exit(os.EX_TEMPFAIL)
+                if ep_dir and not force:
+                    log.critical("Exiting without deleting the local endpoint")
+                    exit(os.EX_UNAVAILABLE)
+            except NetworkError as e:
+                # NetworkError is unexpected, user can probably retry
+                log.warning(
+                    f"Endpoint {ep_uuid} could not be deleted from the web service: "
+                    f"  [{e}]"
+                )
+                if not force:
+                    msg = (
+                        "globus-compute-endpoint is unable to reach the Globus "
+                        "Compute service due to a network error.\n"
+                        "Please ensure the Globus Compute service address is "
+                        "reachable, then attempt to delete the endpoint again."
+                    )
+                    print(msg)
+                    log.critical(msg)
+                    exit(os.EX_TEMPFAIL)
 
-        # Stop endpoint to handle process cleanup
-        Endpoint.stop_endpoint(endpoint_dir, None)
-
-        # Delete endpoint directory
-        shutil.rmtree(endpoint_dir)
-
-        log.info(f"Endpoint <{ep_name}> has been deleted.")
+        if ep_dir and ep_dir.exists():
+            # Delete endpoint directory
+            shutil.rmtree(ep_dir)
+            log.info(f"Endpoint {ep_name} has been deleted from {ep_dir}")
 
     @staticmethod
     def check_pidfile(endpoint_dir: pathlib.Path):

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -678,10 +678,9 @@ class Endpoint:
                 if status.get("status") == "online":
                     if not force:
                         log.warning(
-                            f"Endpoint {ep_uuid} is currently running.  To proceed "
-                            "with deletion, first suspend it with the command "
-                            "`globus-compute-endpoint stop --remote {ep_uuid}` or "
-                            "ignore the current status with `delete --force`"
+                            f"Endpoint {ep_uuid} is currently running.  To "
+                            "proceed with deletion, first stop the endpoint, "
+                            "or ignore the current status with `delete --force`"
                         )
                         exit(-1)
                     if ep_dir:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -49,7 +49,7 @@ def test_non_configured_endpoint(mocker, tmp_path):
     with mock.patch.dict(os.environ, env):
         result = CliRunner().invoke(app, ["start", "newendpoint"])
         assert "newendpoint" in result.stdout
-        assert "not configured" in result.stdout
+        assert "no endpoint configuration" in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/compute_endpoint/tests/unit/test_logging_config.py
+++ b/compute_endpoint/tests/unit/test_logging_config.py
@@ -60,7 +60,7 @@ def test_file_config_rotates_at_reasonable_size(fs):
 
 def test_file_config_does_not_rotate_unrotatable_sc30480(anon_pipe):
     read_h, write_h = anon_pipe
-    if platform.system() == "darwin":
+    if platform.system() == "Darwin":
         # macOS doesn't have /proc, /dev is equivalent for this test
         logp = pathlib.Path(f"/dev/fd/{write_h}")
     else:


### PR DESCRIPTION
This adds functionality to delete endpoints when a local config is not present.

It differs from the original story in that this no longer uses t he --remote option, but just as part of normal delete, with the usual --yes and --force options behaving as they should intuitively.

A few notes:

- Modified ``get_ep_dir_by_name_or_uuid()`` to take an extra parameter with default so it doesn't raise if an UUID is specified that does not exist on the system, and also to pass the uuid on as an argument
- Added a new wrapper ``name_or_uuid_arg_non_local`` that takes advantage of the above without affecting the existing ``name_or_uuid_arg``
- Note that the happy deletion path calls the Globus Compute Client's ``delete_endpoint()`` which has the same name but is a direct API call via ``web_client.delete_endpoint()``
- Overall logic paths for delete were refactored so a few tests changed and quite a few more added.