### PR TITLE
Support for setting working_dir and sandboxing in ``GlobusComputeEngine``

### DIFF
--- a/changelog.d/20240423_142117_yadudoc1729_gce_working_dir.rst
+++ b/changelog.d/20240423_142117_yadudoc1729_gce_working_dir.rst
@@ -1,0 +1,40 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- ``GlobusComputeEngine`` now supports a ``working_dir`` keyword argument that sets the directory in which
+  all functions will be executed. Relative paths, if set, will be considered relative to the endpoint directory
+  (``~/.globus_compute/<endpoint_name>``). If this option is not set, ``GlobusComputeEngine`` will use the
+  endpoint directory as the working directory. Set this option using ``working_dir: <working_dir_path>``
+  Example config:
+
+  .. code-block:: yaml
+
+    display_name: WorkingDirExample
+    engine:
+      type: GlobusComputeEngine
+      # Run functions in ~/.globus_compute/<EP_NAME>/TASKS
+      working_dir: TASKS
+
+- ``GlobusComputeEngine`` now supports function sandboxing, where each function is executed within a
+  sandbox directory for better isolation. When this option is enabled by setting ``run_in_sandbox: True``
+  a new directory with the function UUID as the name is created in the working directory (configurable with
+  the ``working_dir`` kwarg). Example config:
+
+  .. code-block:: yaml
+
+    display_name: WorkingDirExample
+    engine:
+      type: GlobusComputeEngine
+      # Set working dir to /projects/MY_PROJ
+      working_dir: /projects/MY_PROJ
+      # Enable sandboxing to have functions run under /projects/MY_PROJ/<function_uuid>/
+      run_in_sandbox: True
+
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixed bug where ``GlobusComputeEngine`` set the current working directory to the directory
+  from which the endpoint was started. Now, ``GlobusComputeEngine`` will set the working directory
+  to the endpoint directory (``~/.globus_compute/<endpoint_name>``) by default. This can be configured
+  via the endpoint config.

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import queue
 import threading
 import time
@@ -88,6 +89,8 @@ class GlobusComputeEngineBase(ABC):
         # endpoint interchange happy
         self.container_type: t.Optional[str] = None
         self.run_dir: t.Optional[str] = None
+        self.working_dir: t.Optional[t.Union[str, os.PathLike]] = None
+        self.run_in_sandbox: bool = False
         # This attribute could be set by the subclasses in their
         # start method if another component insists on owning the queue.
         self.results_passthrough: queue.Queue[dict[str, t.Union[bytes, str, None]]] = (
@@ -219,7 +222,14 @@ class GlobusComputeEngineBase(ABC):
                 "exception_history": [],
             }
         try:
-            future = self._submit(execute_task, task_id, packed_task, self.endpoint_id)
+            future = self._submit(
+                execute_task,
+                task_id,
+                packed_task,
+                self.endpoint_id,
+                run_dir=self.working_dir,
+                run_in_sandbox=self.run_in_sandbox,
+            )
         except Exception as e:
             future = Future()
             future.set_exception(e)

--- a/compute_endpoint/globus_compute_endpoint/engines/helper.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/helper.py
@@ -28,6 +28,8 @@ def execute_task(
     task_body: bytes,
     endpoint_id: t.Optional[uuid.UUID],
     result_size_limit: int = 10 * 1024 * 1024,
+    run_dir: t.Optional[t.Union[str, os.PathLike]] = None,
+    run_in_sandbox: bool = False,
 ) -> bytes:
     """Execute task is designed to enable any executor to execute a Task payload
     and return a Result payload, where the payload follows the globus-compute protocols
@@ -38,6 +40,9 @@ def execute_task(
     task_body: packed message as bytes
     endpoint_id: uuid string or None
     result_size_limit: result size in bytes
+    run_dir: directory to run function in
+    run_in_sandbox: if enabled run task under run_dir/<task_uuid>
+
     Returns
     -------
     messagepack packed Result
@@ -50,6 +55,13 @@ def execute_task(
         str,
         uuid.UUID | str | tuple[str, str] | list[TaskTransition] | dict[str, str],
     ]
+
+    if run_dir:
+        os.makedirs(run_dir, exist_ok=True)
+        os.chdir(run_dir)
+        if run_in_sandbox:
+            os.makedirs(str(task_id))  # task_id is expected to be unique
+            os.chdir(str(task_id))
 
     env_details = get_env_details()
     try:

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -1,0 +1,137 @@
+import os
+import uuid
+
+import pytest
+from globus_compute_common import messagepack
+from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
+from globus_compute_endpoint.engines.helper import execute_task
+from globus_compute_sdk.serialize import ComputeSerializer
+from tests.utils import ez_pack_function
+
+
+@pytest.fixture()
+def reset_cwd():
+    cwd = os.getcwd()
+    yield
+    os.chdir(cwd)
+
+
+def get_cwd():
+    import os
+
+    return os.getcwd()
+
+
+def test_working_dir_default(tmp_path):
+
+    gce = GlobusComputeEngine()
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    assert gce.working_dir == tmp_path
+    gce.shutdown()
+
+
+def test_working_dir_user_set(tmp_path):
+
+    gce = GlobusComputeEngine(working_dir="/tmp")
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    assert gce.working_dir == "/tmp"
+    gce.shutdown()
+
+
+def test_working_dir_relative(tmp_path):
+
+    gce = GlobusComputeEngine(working_dir="foobar")
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    assert gce.working_dir == os.path.join(tmp_path, "foobar")
+    gce.shutdown()
+
+
+def test_execute_task_working_dir(tmp_path, reset_cwd):
+
+    task_id = uuid.uuid4()
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(serializer, get_cwd, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(
+            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
+        )
+    )
+
+    assert os.getcwd() != tmp_path.name
+
+    packed_result = execute_task(
+        task_id,
+        task_message,
+        uuid.uuid4(),
+        run_dir=tmp_path,
+    )
+
+    message = messagepack.unpack(packed_result)
+    assert message.task_id == task_id
+    assert message.data
+    result = serializer.deserialize(message.data)
+    assert result == tmp_path.__fspath__()
+    assert os.getcwd() == tmp_path.__fspath__()
+
+
+def test_non_existent_relative_working_dir(tmp_path, reset_cwd):
+    """This tests for execute_task creating a non-existent working dir
+    when a relative path is specified to the CWD"""
+
+    task_id = uuid.uuid4()
+    os.chdir(tmp_path)
+    target_dir = f"{uuid.uuid4()}"
+    abs_target_dir = os.path.abspath(target_dir)
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(serializer, get_cwd, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(
+            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
+        )
+    )
+
+    assert os.getcwd() != target_dir
+
+    packed_result = execute_task(
+        task_id,
+        task_message,
+        uuid.uuid4(),
+        run_dir=target_dir,
+    )
+
+    message = messagepack.unpack(packed_result)
+    assert message.task_id == task_id
+    assert message.data
+    result = serializer.deserialize(message.data)
+
+    assert result == abs_target_dir
+
+
+def test_sandbox(tmp_path, reset_cwd):
+
+    task_id = uuid.uuid4()
+    os.chdir(tmp_path)
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(serializer, get_cwd, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(
+            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
+        )
+    )
+
+    assert os.getcwd() != tmp_path
+
+    packed_result = execute_task(
+        task_id,
+        task_message,
+        uuid.uuid4(),
+        run_dir=tmp_path,
+        run_in_sandbox=True,
+    )
+
+    message = messagepack.unpack(packed_result)
+    assert message.task_id == task_id
+    assert message.data
+    result = serializer.deserialize(message.data)
+
+    assert result == os.path.join(tmp_path, str(task_id))


### PR DESCRIPTION
# Description

This PR fixes the issue where the endpoints using ``GCE`` would have functions run in the directory from which the endpoint was started rather than some well-defined location. This PR adds support for setting a ``working_dir`` option to 
configure function's working directory and for functions that create files a new sandboxing feature is added. Setting ``run_in_sandbox: True`` each function executes in a sandbox directory set to function_uuid as the name. 

Here's a config example:
``` yaml
    display_name: WorkingDirExample
    engine:
      type: GlobusComputeEngine
      # Set working dir to /projects/MY_PROJ
      working_dir: /projects/MY_PROJ
      # Enable sandboxing to have functions run under /projects/MY_PROJ/<function_uuid>/
      run_in_sandbox: True
```
[sc-32391]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)

