### PR TITLE
Snapshot per-task uep submission configuration

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import copy
 import json
 import logging
 import os
@@ -88,7 +89,7 @@ class _TaskSubmissionInfo:
         self.task_group_uuid = as_optional_uuid(task_group_id)
         self.function_uuid = as_uuid(function_id)
         self.endpoint_uuid = as_uuid(endpoint_id)
-        self.user_endpoint_config = user_endpoint_config
+        self.user_endpoint_config = copy.deepcopy(user_endpoint_config)
         self.args = args
         self.kwargs = kwargs
 

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -149,6 +149,34 @@ def test_task_submission_info_stringification(tg_id, fn_id, ep_id, uep_config):
     assert f"user_endpoint_config={{{uep_config_len}}};"
 
 
+@pytest.mark.parametrize(
+    "tg_id, fn_id, ep_id, uep_config",
+    (
+        (uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), {"heartbeat": 10}),
+        (uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), {}),
+    ),
+)
+def test_task_submission_snapshots_data(tg_id, fn_id, ep_id, uep_config):
+    fut_id = 10
+
+    info = _TaskSubmissionInfo(
+        task_num=fut_id,
+        task_group_id=tg_id,
+        function_id=fn_id,
+        endpoint_id=ep_id,
+        user_endpoint_config=uep_config,
+        args=(),
+        kwargs={},
+    )
+    before_changes = str(info)
+
+    uep_config["something else"] = "abc"
+    uep_config["heartbeat"] = 12345
+
+    after_changes = str(info)
+    assert before_changes == after_changes
+
+
 @pytest.mark.parametrize("argname", ("batch_interval", "batch_enabled"))
 def test_deprecated_args_warned(argname, mocker):
     mock_warn = mocker.patch(f"{_MOCK_BASE}warnings")


### PR DESCRIPTION
We've discussed the ability for users to modify the UEP configuration at submission time, but we've not been explicit that they need create whole new objects when doing so.  So, do what we should have done in the first place, and snapshot the `TaskSubmissionInfo`.

Notably, this does _not_ address the possibility that users modify the args or kwargs to a function, but saving that for a future moment as that potentially comes with some memory concerns.  (This does too, but I think will be minimal compared to the possibility that args/kwargs might be much larger.)

[sc-33284]

## Type of change

- Bug fix (non-breaking change that fixes an issue)