### PR TITLE
Daemonize threads, and still shutdown gracefully

### DIFF
--- a/changelog.d/20240427_105242_kevin_gracefully_shutdown_after_broken_mq_connection.rst
+++ b/changelog.d/20240427_105242_kevin_gracefully_shutdown_after_broken_mq_connection.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Addressed a hanging bug at endpoint shutdown.


### PR DESCRIPTION
From the problem report, the relevant log lines were:

    ... :08:52,7 INFO MainProcess ... Thread ... .result_publisher:268 _on_queue_verified ResultPublisher<✓; o:1; t:0> Ready to send results to exchange: results
    ... :09:56,3 WARNING MainProcess ... Thread ... .result_publisher:244 _on_channel_closed ResultPublisher<✗; o:0; t:44> Channel closed  [<Channel number=1 CLOSED conn=<SelectConnection CLOSED transport=None params=<URLParameters host=compute.amqps.globus.org port=5671 virtual_host=/ ssl=True>>>
      ((320, 'CONNECTION_FORCED - Node was put into maintenance mode'))]
    ... :10:02,9 INFO MainProcess ... Thread ... .result_publisher:135 run ResultPublisher<✗; o:0; t:44> Opening connection to AMQP service.
    ... :10:03,1 WARNING MainProcess ... Thread ... .result_publisher:181 _on_open_failed ResultPublisher<✗; o:0; t:44> [attempt 1 (of 7200)] (pid: 13336) Failed to open connection - (ProbableAuthenticationError) ConnectionClosedByBroker: (403) 'ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.'
    ... :10:08,9 INFO MainProcess-13336 Thread ... .result_publisher:139 run ResultPublisher<✗; o:0; t:44> Opening connection to AMQP service (second attempt).  Will continue for up to 7200 attempts.  To log all attempts, use `--debug`.

At this point, the RP thread is in the 7200 attempts to reconnect stage.  So, we can expect it to fail completely sometime in the next 20 hours (each retry is `random(0.5, 10)` seconds).

Meanwhile, the main thread has idled out, per configuration:

    ... :10:21,8 INFO MainProcess ... MainThread ... .interchange:572 _main_loop In idle state (due to no task or result movement); shut down in 30s.  (idle_heartbeats_soft)
    ... :10:51,8 INFO MainProcess ... MainThread ... .interchange:582 _main_loop Idle heartbeats reached.  Shutting down.

At which point, it tries to send a "I'm going away" heartbeat message, but that times out because the RP thread is not connected.  The relevant log line:

    ... :10:57,6 ERROR MainProcess ... MainThread ... .interchange:296 start Unhandled exception in main kernel: (TimeoutError)-

Which is us logging that *something* happened, but then ignoring it, because we're in a (coincidentally final) quiesce cycle.  The main thread then shuts down:

    ... :10:57,6 INFO MainProcess ...  MainThread ... .endpoint:592 daemon_launch-
    ---------- Endpoint shutdown: dd6f2673-2119-bebc-893e-1f1c26d18535

But the process is stuck because the RP thread -- not daemonized -- is still alive for another few hours.

Fix is two-fold:

1. Daemonize the threads
2. Don't fail at the timeout and tell the RP thread to shut down

[sc-33289]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
