### PR TITLE
Package systemd unit

### DIFF
--- a/changelog.d/20240429_144311_chris_package_systemd_unit.rst
+++ b/changelog.d/20240429_144311_chris_package_systemd_unit.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added ``enable-on-boot`` and ``disable-on-boot`` commands to the
+  ``globus-compute-endpoint`` CLI, which contain packaged commands and configuration
+  for managing systemd units for Compute endpoints.

--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -97,7 +97,7 @@ def enable_on_boot(ep_dir: pathlib.Path):
         raise ClickException(f"{e}\n\nUnable to create unit file. Are you root?")
 
     print(
-        "Systemd service installed. Run"
+        f"Systemd service installed at {unit_file_path}. Run"
         f"\n\tsudo systemctl enable {service_name} --now"
         "\nto enable the service and start the endpoint."
     )

--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -1,0 +1,129 @@
+import getpass
+import os
+import pathlib
+import shutil
+import textwrap
+
+from click import ClickException
+from globus_compute_endpoint.endpoint.config.utils import get_config
+from globus_compute_endpoint.endpoint.endpoint import Endpoint
+from globus_compute_sdk.sdk.login_manager import LoginManager
+
+_SYSTEMD_UNIT_DIR = pathlib.Path("/etc/systemd/system")
+
+_SYSTEMD_UNIT_TEMPLATE = """[Unit]
+Description=systemd service for Globus Compute Endpoint "{ep_name}"
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+ExecStart={gce_exe} start {ep_name}
+User={user_account}
+Type=simple
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+_DISABLE_SYSTEMD_COMMANDS = """systemctl stop {service_name}
+systemctl disable {service_name}
+rm {unit_file_path}"""
+
+
+def _systemd_service_name(ep_name: str) -> str:
+    return f"globus-compute-endpoint-{ep_name}"
+
+
+def _systemd_available() -> bool:
+    return _SYSTEMD_UNIT_DIR.exists()
+
+
+def enable_on_boot(ep_dir: pathlib.Path):
+    if not _systemd_available():
+        raise ClickException(
+            "Systemd not found. On-boot persistence is currently only implemented for"
+            " systemd; check this machine's init system documentation for alternatives."
+        )
+
+    ep_name = ep_dir.name
+
+    config = get_config(ep_dir)
+    if config.detach_endpoint:
+        # config.py takes priority if it exists
+        if os.path.isfile(ep_dir / "config.py"):
+            # can't give users a nice packaged command to run here, so just tell them
+            msg = (
+                f"Persistent endpoints cannot run in detached mode. Update {ep_name}'s"
+                " config to set detach_endpoint=False and try again."
+            )
+        else:
+            # _can_ give a nice packaged command if they use yaml, though
+            msg = (
+                "Persistent endpoints cannot run in detached mode. Run the following"
+                f" command to update {ep_name}'s config:"
+                f"\n\techo 'detach_endpoint: false' >> {ep_dir / 'config.yaml'}"
+            )
+        raise ClickException(msg)
+
+    if Endpoint.check_pidfile(ep_dir)["active"]:
+        raise ClickException(
+            "Cannot enable on-boot persistence for an endpoint that is currently"
+            f" running. Stop endpoint {ep_name} and try again."
+        )
+
+    # ensure that credentials exist when systemd tries to start endpoint, so that
+    # auth login flow doesn't run under systemd
+    LoginManager().ensure_logged_in()
+
+    service_name = _systemd_service_name(ep_name)
+    unit_file_path = _SYSTEMD_UNIT_DIR / f"{service_name}.service"
+    unit_file_text = _SYSTEMD_UNIT_TEMPLATE.format(
+        ep_name=ep_name,
+        gce_exe=shutil.which("globus-compute-endpoint"),
+        user_account=getpass.getuser(),
+    )
+
+    try:
+        with open(unit_file_path, "x") as unit_file:
+            unit_file.write(unit_file_text)
+    except FileExistsError:
+        raise ClickException(
+            "Cannot create systemd unit file -"
+            f" a file with the name {unit_file_path} already exists"
+        )
+    except PermissionError as e:
+        raise ClickException(f"{e}\n\nUnable to create unit file. Are you root?")
+
+    print(
+        "Systemd service installed. Run"
+        f"\n\tsudo systemctl enable {service_name} --now"
+        "\nto enable the service and start the endpoint."
+    )
+
+
+def disable_on_boot(ep_dir: pathlib.Path):
+    if not _systemd_available():
+        raise ClickException(
+            "Systemd not found. On-boot persistence is currently only implemented for"
+            " systemd; check this machine's init system documentation for alternatives."
+        )
+
+    ep_name = ep_dir.name
+    service_name = _systemd_service_name(ep_name)
+    unit_file_path = _SYSTEMD_UNIT_DIR / f"{service_name}.service"
+
+    if not unit_file_path.exists():
+        raise ClickException(
+            "There does not appear to be an existing systemd unit for endpoint"
+            f" {ep_name} (unit file {unit_file_path} not found)"
+        )
+
+    commands = textwrap.indent(
+        _DISABLE_SYSTEMD_COMMANDS.format(
+            service_name=service_name, unit_file_path=unit_file_path
+        ),
+        "\t",
+    )
+    print(f"Run the following to disable on-boot-persistence:\n{commands}")

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -16,6 +16,7 @@ from datetime import datetime
 import click
 from click import ClickException
 from click_option_group import optgroup
+from globus_compute_endpoint.boot_persistence import disable_on_boot, enable_on_boot
 from globus_compute_endpoint.endpoint.config.utils import get_config, load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.endpoint.utils import (
@@ -907,6 +908,24 @@ def create_auth_policy(
         return resp["policy"]["id"]
     except GlobusAPIError as e:
         raise ClickException(f"Unable to create authentication policy: [{e.text}]")
+
+
+@app.command(
+    "enable-on-boot",
+    help="Enable on-boot persistence; restarts the endpoint when the machine restarts.",
+)
+@name_or_uuid_arg
+def enable_on_boot_cmd(ep_dir: pathlib.Path):
+    enable_on_boot(ep_dir)
+
+
+@app.command(
+    "disable-on-boot",
+    help="Disable on-boot persistence.",
+)
+@name_or_uuid_arg
+def disable_on_boot_cmd(ep_dir: pathlib.Path):
+    disable_on_boot(ep_dir)
 
 
 def cli_run():

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -120,7 +120,7 @@ def get_config(endpoint_dir: pathlib.Path) -> Config:
                 "\n1. Please create a configuration template with:"
                 f"\n\t{configure_command}"
                 "\n2. Update the configuration"
-                "\n3. Start the endpoint\n"
+                "\n3. Try again\n"
             )
         raise ClickException(msg) from err
 

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -1,0 +1,166 @@
+import os
+import pathlib
+
+import pytest
+from click import ClickException
+from globus_compute_endpoint.boot_persistence import (
+    _systemd_service_name,
+    disable_on_boot,
+    enable_on_boot,
+)
+from globus_compute_endpoint.endpoint.endpoint import Endpoint
+from pyfakefs import fake_filesystem as fakefs
+
+_MOCK_BASE = "globus_compute_endpoint.boot_persistence."
+
+
+@pytest.fixture
+def ep_name(randomstring):
+    return randomstring()
+
+
+@pytest.fixture
+def fake_ep_dir(fs: fakefs.FakeFilesystem, ep_name) -> pathlib.Path:
+    ep_dir = pathlib.Path.home() / ".globus_compute" / ep_name
+    fs.create_dir(ep_dir)
+    ep_config = Endpoint._config_file_path(ep_dir)
+    ep_config.write_text(
+        """
+detach_endpoint: false
+display_name: null
+engine:
+    type: GlobusComputeEngine
+    provider:
+        type: LocalProvider
+        init_blocks: 1
+        min_blocks: 0
+        max_blocks: 1
+        """
+    )
+    return ep_dir
+
+
+@pytest.fixture
+def systemd_unit_dir(fs: fakefs.FakeFilesystem, mocker):
+    unit_dir = pathlib.Path("/etc/systemd/system")
+    mocker.patch(f"{_MOCK_BASE}_SYSTEMD_UNIT_DIR", unit_dir)
+    fs.create_dir(unit_dir)
+
+    return unit_dir
+
+
+def test_enable_on_boot_happy_path(
+    fake_ep_dir, systemd_unit_dir, ep_name, mocker, capsys
+):
+    mock_login_manager = mocker.patch(f"{_MOCK_BASE}LoginManager")
+    mock_ensure_logged_in = mock_login_manager.return_value.ensure_logged_in
+
+    enable_on_boot(fake_ep_dir)
+
+    mock_ensure_logged_in.assert_called_once()
+
+    assert any(ep_name in f for f in os.listdir(systemd_unit_dir))
+
+    out = capsys.readouterr().out
+    assert "Systemd service installed" in out
+    assert "systemctl" in out
+    assert ep_name in out
+
+
+def test_enable_on_boot_no_systemd(fake_ep_dir, mocker):
+    mocker.patch(f"{_MOCK_BASE}_systemd_available", return_value=False)
+
+    with pytest.raises(ClickException) as e:
+        enable_on_boot(fake_ep_dir)
+
+    assert "Systemd not found" in str(e)
+
+
+def test_enable_on_boot_detach_endpoint(
+    fake_ep_dir, systemd_unit_dir, fs: fakefs.FakeFilesystem
+):
+    cfg = fake_ep_dir / "config.yaml"
+    old_text = cfg.read_text()
+    new_text = "\n".join(x for x in old_text.split("\n") if "detach_endpoint" not in x)
+    fs.remove(cfg)
+    cfg.write_text(new_text)
+
+    with pytest.raises(ClickException) as e:
+        enable_on_boot(fake_ep_dir)
+
+    assert "cannot run in detached mode" in str(e)
+
+
+@pytest.mark.parametrize("exists", [True, False])
+def test_enable_on_boot_active_ep(fake_ep_dir, systemd_unit_dir, mocker, exists):
+    mocker.patch(f"{_MOCK_BASE}LoginManager")
+    mocker.patch(
+        f"{_MOCK_BASE}Endpoint.check_pidfile",
+        return_value={"exists": exists, "active": True},
+    )
+
+    with pytest.raises(ClickException) as e:
+        enable_on_boot(fake_ep_dir)
+
+    assert "currently running" in str(e)
+
+
+def test_enable_on_boot_service_file_already_exists(
+    fake_ep_dir, systemd_unit_dir, ep_name, randomstring, mocker
+):
+    mocker.patch(f"{_MOCK_BASE}LoginManager")
+    unit = systemd_unit_dir / f"{_systemd_service_name(ep_name)}.service"
+    unit.write_text(randomstring())
+
+    with pytest.raises(ClickException) as e:
+        enable_on_boot(fake_ep_dir)
+
+    assert "already exists" in str(e)
+    assert ep_name in str(e)
+
+
+def test_enable_on_boot_no_perms(
+    fake_ep_dir, systemd_unit_dir, fs: fakefs.FakeFilesystem, mocker
+):
+    mocker.patch(f"{_MOCK_BASE}LoginManager")
+    os.chmod(systemd_unit_dir, fakefs.PERM_READ)
+
+    with pytest.raises(ClickException) as e:
+        enable_on_boot(fake_ep_dir)
+
+    assert "Unable to create unit file" in str(e)
+
+
+def test_disable_on_boot_happy_path(
+    fake_ep_dir, systemd_unit_dir, fs: fakefs.FakeFilesystem, capsys, ep_name
+):
+    fs.create_file(systemd_unit_dir / f"{_systemd_service_name(ep_name)}.service")
+
+    disable_on_boot(fake_ep_dir)
+
+    out = capsys.readouterr().out
+    assert "Run the following to disable on-boot-persistence" in out
+    assert "systemctl" in out
+    assert ep_name in out
+
+
+def test_disable_on_boot_no_systemd(fake_ep_dir, mocker):
+    mocker.patch(f"{_MOCK_BASE}_systemd_available", return_value=False)
+
+    with pytest.raises(ClickException) as e:
+        disable_on_boot(fake_ep_dir)
+
+    assert "Systemd not found" in str(e)
+
+
+def test_disable_on_boot_checks_for_existing_unit_file(
+    fake_ep_dir, systemd_unit_dir, fs: fakefs.FakeFilesystem
+):
+    service_path = systemd_unit_dir / f"{_systemd_service_name(ep_name)}.service"
+    if fs.exists(service_path):
+        fs.remove(service_path)
+
+    with pytest.raises(ClickException) as e:
+        disable_on_boot(fake_ep_dir)
+
+    assert "existing systemd unit" in str(e)

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -267,50 +267,25 @@ Here's an example:
 Restarting endpoint when machine restarts
 -----------------------------------------
 
-To ensure that a compute endpoint comes back online when its host machine restarts, a
-systemd service can be configured to run the endpoint.
-
-1. Ensure the endpoint isn't running:
-
-   .. code-block:: console
-
-      $ globus-compute-endpoint stop <my-endpoint-name>
-
-2. Update the endpoint's ``config.yaml`` to set ``detach_endpoint`` to ``false``
-
-3. Create a service file at ``/etc/systemd/system/my-globus-compute-endpoint.service``,
-   and populate it with the following settings:
-
-   .. code-block:: cfg
-
-      [Unit]
-      Description=Globus Compute Endpoint systemd service
-      After=network.target
-      StartLimitIntervalSec=0
-
-      [Service]
-      ExecStart=</full/path/to/globus-compute-endpoint/executable> start <my-endpoint-name>
-      User=<user_account>
-      Type=simple
-      Restart=always
-      RestartSec=1
-
-      [Install]
-      WantedBy=multi-user.target
-
-4. Enable the service and start the endpoint:
-
-   .. code-block:: console
-
-      $ sudo systemctl enable my-globus-compute-endpoint.service --now
-
-To edit an existing systemd service, make changes to the service file and then run the
-following:
+Run ``globus-compute-endpoint enable-on-boot`` to install a systemd unit file:
 
 .. code-block:: console
 
-   $ sudo systemctl daemon-reload
-   $ sudo systemctl restart my-globus-compute-endpoint.service
+   $ globus-compute-endpoint enable-on-boot my-endpoint
+   Systemd service installed. Run
+      sudo systemctl enable globus-compute-endpoint-my-endpoint.service --now
+   to enable the service and start the endpoint.
+
+Run ``globus-compute-endpoint disable-on-boot`` for commands to disable and uninstall
+the service:
+
+.. code-block:: console
+
+   $ globus-compute-endpoint disable-on-boot my-endpoint
+   Run the following to disable on-boot-persistence:
+      systemctl stop globus-compute-endpoint-my-endpoint
+      systemctl disable globus-compute-endpoint-my-endpoint
+      rm /etc/systemd/system/globus-compute-endpoint-my-endpoint.service
 
 
 AMQP Port


### PR DESCRIPTION
# Description

Adds two commands, `enable-on-boot` and `disable-on-boot`, for managing systemd services for the endpoint. They're intended for interactive use rather than automation, so they don't directly call `systemctl`, rather they print out commands the admins can run. They also verify that the endpoint and the system are set up properly to enable/disable a systemd unit, and `enable-on-boot` automatically creates a unit file in the right place.

[sc-32913]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
