### PR TITLE
Use `time.monotonic` for timing

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -473,8 +473,8 @@ class EndpointManager:
                     os.setresuid(proc_uid, proc_uid, -1)
                     os.setresgid(proc_gid, proc_gid, -1)
 
-            deadline = time.time() + 10
-            while self._children and time.time() < deadline:
+            deadline = time.monotonic() + 10
+            while self._children and time.monotonic() < deadline:
                 time.sleep(0.5)
                 self.wait_for_children()
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -649,7 +649,7 @@ def test_children_signaled_at_shutdown(
     em.wait_for_children = noop
     mock_os = mocker.patch(f"{_MOCK_BASE}os")
     mock_time = mocker.patch(f"{_MOCK_BASE}time")
-    mock_time.time.side_effect = [0, 10, 20, 30]  # don't _actually_ wait.
+    mock_time.monotonic.side_effect = [0, 10, 20, 30]  # don't _actually_ wait.
     mock_os.getuid.side_effect = ["us"]  # fail if called more than once; intentional
     mock_os.getgid.side_effect = ["us"]  # fail if called more than once; intentional
     mock_os.getpgid = lambda pid: pid


### PR DESCRIPTION
This is not an external interface; it's utilized strictly for timing.

## Type of change

- Code maintenance/cleanup
