### PR TITLE
Updating Bridges2 config to use GCE

### DIFF
--- a/docs/configs/bridges-2.yaml
+++ b/docs/configs/bridges-2.yaml
@@ -1,5 +1,5 @@
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     max_workers_per_node: 2
     worker_debug: False
 
@@ -9,7 +9,7 @@ engine:
 
     provider:
         type: SlurmProvider
-        partition: RM
+        partition: RM-small
 
         launcher:
             type: SrunLauncher
@@ -25,7 +25,7 @@ engine:
 
         # Scale between 0-1 blocks with 2 nodes per block
         nodes_per_block: 2
-        init_blocks: 1
+        init_blocks: 0
         min_blocks: 0
         max_blocks: 1
 


### PR DESCRIPTION
# Description

Adding a tested config from Bridges@PSC that updates the config to use GCE instead of HighThroughputEngine.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
