### PR TITLE
detach_endpoint isn't a thing on MEP

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -154,8 +154,11 @@ class EndpointManager:
                     name=conf_dir.name,
                     endpoint_id=endpoint_uuid,
                     metadata=EndpointManager.get_metadata(config, conf_dir),
-                    display_name=config.display_name,
                     multi_user=True,
+                    display_name=config.display_name,
+                    allowed_functions=config.allowed_functions,
+                    auth_policy=config.authentication_policy,
+                    subscription_id=config.subscription_id,
                     public=config.public,
                 )
 


### PR DESCRIPTION
Only check the `detach_endpoint` setting for single-user endpoints.  Meanwhile, if unable to write the unit file, share the content with the user.

## Type of change

- Bug fix (non-breaking change that fixes an issue)