### PR TITLE
Make Executor shutdown idempotent

### DIFF
--- a/changelog.d/20240508_000749_kevin_idempotent_executor_shutdown.rst
+++ b/changelog.d/20240508_000749_kevin_idempotent_executor_shutdown.rst
@@ -1,0 +1,16 @@
+Bug Fixes
+^^^^^^^^^
+
+- Make Executor shutdown idempotent -- if a user manually shut down the
+  Executor within a ``with`` block, the Executor shutdown could hang if there
+  were outstanding task futures.  Now the Executor recognizes that it has
+  already been shutdown once, and the function returns early.
+
+Changed
+^^^^^^^
+
+- Improve Executor shutdown performance by no longer attempting to join the
+  task submitting thread.  This thread is already set to ``daemon=True`` and
+  will correctly stop at Executor shutdown, so observe that ``.join()`` is
+  strictly a waiting operation.  It is not a clue to the Python interpreter to
+  clean up any resources.


### PR DESCRIPTION
At the point an executor has been shutdown, its state has already been set:

* `_stopped` is `True`
* `_result_watcher` is gone (`None`)
* `_task_submitter` is (nominally) stopped

In refactoring for idempotency (early return), realize that there is no use to `.join()` the task submitter thread.  The Python internals already clean up the underlying thread when the thread completes.  All `.join()` does is wait for that -- there is no resource value in waiting, only algorithm logic, if necessary.  Instead, take out the shutdown lock and drain the queue of tasks before sending the poison pill, then stop there.  The thread will either complete or it won't, but because it's `daemon=True`, it won't hold up the shutdown process.

[sc-33249]

## Type of change

- Bug fix (non-breaking change that fixes an issue)