### PR TITLE
Test already committed work

### DIFF
--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -431,25 +431,28 @@ def test_sends_data_during_registration(
 
     assert mock_gcc.register_endpoint.called
     _a, k = mock_gcc.register_endpoint.call_args
-    for key in (
+    expected_keys = {
         "name",
         "endpoint_id",
-        "display_name",
         "metadata",
         "multi_user",
+        "display_name",
+        "allowed_functions",
+        "auth_policy",
+        "subscription_id",
         "public",
-    ):
-        assert key in k, "Expected minimal top-level fields"
+    }
+    assert expected_keys == k.keys(), "Missing or unexpected keys; update this test?"
 
-    for key in (
+    expected_keys = {
         "endpoint_version",
         "hostname",
         "local_user",
         "config",
         "user_config_template",
         "user_config_schema",
-    ):
-        assert key in k["metadata"], "Expected minimal metadata"
+    }
+    assert expected_keys == k["metadata"].keys(), "Expected minimal metadata"
 
     for key in (
         "type",


### PR DESCRIPTION
The fundamental missing detail was the missing data during function registration -- and that was mistakenly added to PR #1559 (544af0f97558af06a5c3a920095ef11813689fcc).  Follow up with a test change.

[sc-33481]

## Type of change

- Code maintenance/cleanup