### PR TITLE
Update quickstart to specify --include-deps

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -64,7 +64,7 @@ The Globus Compute endpoint can be installed using `Pipx <https://pypa.github.io
 
 .. code-block:: console
 
-  $ python3 -m pipx install globus-compute-endpoint
+  $ python3 -m pipx install --include-deps globus-compute-endpoint
 
 or
 


### PR DESCRIPTION
# Description

Includes the --include-deps flag in the quickstart example to install the endpoint.

## Type of change
- Documentation update
