### PR TITLE
Bump versions for QA release v2.20.0a1

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.19.0"
+__version__ = "2.20.0a1"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.20.0a1"
+__version__ = "2.20.0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.20.0a1",
+    "globus-compute-sdk==2.20.0",
     "globus-compute-common==0.4.1",
     "globus-identity-mapping==0.3.0",
     # table printing used in list-endpoints

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.19.0",
+    "globus-compute-sdk==2.20.0a1",
     "globus-compute-common==0.4.1",
     "globus-identity-mapping==0.3.0",
     # table printing used in list-endpoints

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.20.0a1"
+__version__ = "2.20.0"
 
 
 def compare_versions(

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.19.0"
+__version__ = "2.20.0a1"
 
 
 def compare_versions(


### PR DESCRIPTION
version changes for alpha release for QA.  Note that we previously used v2.20.0a0 for Globus World testing.