### PR TITLE
Remove SafetyCLI from GH actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,20 +15,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          cache: 'pip'
       - name: install requirements
         run: |
-          python -m pip install -U pip setuptools wheel
+          python -m pip install -U pip
           python -m pip install pre-commit tox
       - name: run pre-commit
         run: pre-commit run -a
-      - name: mypy (sdk)
+      - name: mypy and pip-audit (sdk)
         run: |
           cd compute_sdk
           tox -e mypy
-      - name: mypy (endpoint)
+          tox -e pip-audit
+      - name: mypy and pip-audit (endpoint)
         run: |
           cd compute_endpoint
           tox -e mypy
+          tox -e pip-audit
 
   # ensure docs can build, imitating the RTD build as best we can
   check-docs:
@@ -41,23 +45,6 @@ jobs:
           python-version: "3.11"
       - name: build docs
         run: make docs
-
-  safety-check-endpoint:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: install requirements
-        run: |
-          python -m pip install -U pip setuptools
-          python -m pip install './compute_sdk' './compute_endpoint'
-          python -m pip install safety
-          rm -rf /opt/hostedtoolcache/Python/*/x64/lib/python3.*/site-packages/pip-23.{0,1,2}*
-      - name: run safety check
-        run: safety check
 
   test-sdk:
     timeout-minutes: 5

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -33,47 +33,9 @@ jobs:
         cd smoke_tests
         make staging
 
-  safety-check-sdk:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: main
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '${{ env.TARGET_PYTHON_VERSION }}'
-    - name: install requirements
-      run: |
-        python -m venv .venv
-        .venv/bin/python -m pip install --upgrade pip setuptools wheel
-        .venv/bin/python -m pip install './compute_sdk'
-        .venv/bin/python -m pip install safety
-    - name: run safety check
-      run: .venv/bin/safety check
-
-  safety-check-endpoint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: main
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '${{ env.TARGET_PYTHON_VERSION }}'
-    - name: install requirements
-      run: |
-        python -m venv .venv
-        .venv/bin/python -m pip install --upgrade pip setuptools wheel
-        .venv/bin/python -m pip install './compute_endpoint'
-        .venv/bin/python -m pip install safety
-    - name: run safety check
-      run: .venv/bin/safety check
-
   slack-notify:
     needs:
       - smoke-test-staging
-      - safety-check-sdk
-      - safety-check-endpoint
     if: always()
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -21,6 +21,9 @@ deps =
     ../compute_sdk/
 commands = mypy --install-types --non-interactive -p globus_compute_endpoint {posargs}
 
+[testenv:pip-audit]
+deps = pip-audit
+commands = pip-audit --desc on {posargs}
 
 [testenv:publish-release]
 skip_install = true

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -16,6 +16,10 @@ commands =
 deps = mypy==1.10.0
 commands = mypy -p globus_compute_sdk {posargs}
 
+[testenv:pip-audit]
+deps = pip-audit
+commands = pip-audit --desc on {posargs}
+
 [testenv:publish-release]
 skip_install = true
 deps = build


### PR DESCRIPTION
Dependabot fulfills our use case of SafetyCLI, and even creates PRs automatically.

[sc-33596]

## Type of change

- Code maintenance/cleanup