### PR TITLE
add --include-deps to pipx install examples

### DIFF
--- a/docs/endpoints/single_user.rst
+++ b/docs/endpoints/single_user.rst
@@ -18,7 +18,7 @@ For those just looking for the quickstart commands:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint
+   $ python3 -m pipx install globus-compute-endpoint --include-deps
 
    $ globus-compute-endpoint configure my_first_endpoint
 
@@ -37,7 +37,7 @@ recommend use of |pipx for library isolation|_:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint
+   $ python3 -m pipx install globus-compute-endpoint --include-deps
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ how to download and configure an endpoint for local (multi-process) execution:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint
+   $ python3 -m pipx install globus-compute-endpoint --include-deps
 
    $ globus-compute-endpoint configure
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -64,7 +64,7 @@ The Globus Compute endpoint can be installed using `Pipx <https://pypa.github.io
 
 .. code-block:: console
 
-  $ python3 -m pipx install --include-deps globus-compute-endpoint
+  $ python3 -m pipx install globus-compute-endpoint --include-deps
 
 or
 


### PR DESCRIPTION
We added --include-deps last week but the change was lost in the rewrite, adding it back in.