### PR TITLE
Include MEP files in self diagnostic output

### DIFF
--- a/changelog.d/20240523_121518_30907815+rjmello_self_diag_mep_sc_33745.rst
+++ b/changelog.d/20240523_121518_30907815+rjmello_self_diag_mep_sc_33745.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added multi-user endpoint related files to the `self-diagnostic` command output.

--- a/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
+++ b/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
@@ -154,8 +154,11 @@ def run_self_diagnostic(log_bytes: int = 0):
         "netstat -r",
         "globus-compute-endpoint whoami",
         "globus-compute-endpoint list",
-        cat("~/.globus_compute/*/config.*", wildcard=True),
-        cat("~/.globus_compute/*/endpoint.log", wildcard=True, max_bytes=log_bytes),
+        cat("~/.globus_compute/*/*.yaml", wildcard=True),
+        cat("~/.globus_compute/*/*.py", wildcard=True),
+        cat("~/.globus_compute/*/*.j2", wildcard=True),
+        cat("~/.globus_compute/*/*.json", wildcard=True),
+        cat("~/.globus_compute/*/*.log", wildcard=True, max_bytes=log_bytes),
     ]
 
     for cmd in commands:

--- a/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
+++ b/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
@@ -44,7 +44,7 @@ def cat(path: str, wildcard: bool = False, max_bytes: int = 0):
             hline = "-" * len(cat_cmd)
             click.echo(hline + "\n")
 
-    kernel.display_name = f"func:cat({path})"  # type: ignore
+    kernel.display_name = f"cat({path})"  # type: ignore
     return kernel
 
 
@@ -60,7 +60,7 @@ def test_conn(host: str, port: int, timeout: int = 5):
                 bold=True,
             )
 
-    kernel.display_name = f"func:test_conn({host}, {port})"  # type: ignore
+    kernel.display_name = f"test_conn({host}, {port})"  # type: ignore
     return kernel
 
 
@@ -84,7 +84,7 @@ def test_ssl_conn(host: str, port: int, timeout: int = 5):
                 bold=True,
             )
 
-    kernel.display_name = f"func:test_ssl_conn({host}, {port})"  # type: ignore
+    kernel.display_name = f"test_ssl_conn({host}, {port})"  # type: ignore
     return kernel
 
 
@@ -94,7 +94,7 @@ def get_service_versions(base_url: str):
         res = wc.get_version(service="all")
         click.echo(f"{res}\n")
 
-    kernel.display_name = f"func:get_service_versions({base_url})"  # type: ignore
+    kernel.display_name = f"get_service_versions({base_url})"  # type: ignore
     return kernel
 
 
@@ -159,15 +159,15 @@ def run_self_diagnostic(log_bytes: int = 0):
     ]
 
     for cmd in commands:
-        display_name = (
-            str(cmd)
-            if not callable(cmd)
-            else getattr(cmd, "display_name", f"func:{cmd.__name__}()")
-        )
+        if callable(cmd):
+            display_name = getattr(cmd, "display_name", f"{cmd.__name__}()")
+            display_name = f"python:{display_name}"
+        else:
+            display_name = str(cmd)
+
         click.secho(f"== Diagnostic: {display_name} ==", fg="yellow", bold=True)
 
         if callable(cmd):
             cmd()
-            continue
-
-        _run_command(cmd)
+        else:
+            _run_command(cmd)


### PR DESCRIPTION
# Description

Modified the self diagnostic command to display all files with the expected file extensions, including those related multi-user endpoints.

I also slightly modified the self diagnostic output to clarify which commands use Python functions vs direct shell commands. This follows the hardware report implementation, which uses `python` in the command display names instead of `func`. The latter was somewhat unclear.

[sc-33745]

## Type of change

- New feature (non-breaking change that adds functionality)
