### PR TITLE
Stop immediately on unrecoverable error

### DIFF
--- a/changelog.d/20240523_154926_kevin_stop_mep_unrecoverable_auth_error.rst
+++ b/changelog.d/20240523_154926_kevin_stop_mep_unrecoverable_auth_error.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Teach MEP to shutdown on an (unrecoverable) AMQP authentication error, rather
+  than attempting to reconnect multiple times.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/command_queue_subscriber.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/command_queue_subscriber.py
@@ -149,6 +149,10 @@ class CommandQueueSubscriber(threading.Thread):
 
     def _on_open_failed(self, mq_conn: pika.BaseConnection, exc: str | Exception):
         count = f"[attempt {self._connection_tries} (of {self.connect_attempt_limit})]"
+        if isinstance(exc, pika.exceptions.ProbableAuthenticationError):
+            count = "[invalid credentials; unrecoverable]"
+            self._connection_tries = self.connect_attempt_limit
+
         pid = f"(pid: {os.getpid()})"
         exc_text = f"Failed to open connection - ({exc.__class__.__name__}) {exc}"
         msg = f"{count} {pid} {exc_text}"


### PR DESCRIPTION
Catch the known `ProbableAuthenticationError` and quit immediately.  Prior to this, the RP and CQS threads would try up to `attempt_limit` times, which could be up to 20 hours before failing.  No good.

[sc-33757]

## Type of change

- Bug fix (non-breaking change that fixes an issue)