### PR TITLE
Updating Midway config to use GCE

### DIFF
--- a/docs/endpoints/configs/midway.yaml
+++ b/docs/endpoints/configs/midway.yaml
@@ -1,7 +1,7 @@
-display_name: Midway3@rcc.uchicago.edu
+label: Midway@RCC.UChicago
 
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     max_workers_per_node: 2
     worker_debug: False
 
@@ -11,7 +11,9 @@ engine:
 
     provider:
         type: SlurmProvider
-        partition: broadwl
+        partition: caslake
+
+        account: {{ ACCOUNT }}
 
         launcher:
             type: SrunLauncher


### PR DESCRIPTION
# Description

Minor doc update for Midway3@RCC to use `GlobusComputeEngine` instead of `HighThroughputEngine`

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
