### PR TITLE
Teach UEP configuration `debug` flag

### DIFF
--- a/changelog.d/20240612_164858_kevin_enable_configurable_interchange_debug.rst
+++ b/changelog.d/20240612_164858_kevin_enable_configurable_interchange_debug.rst
@@ -1,0 +1,8 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Implement ``debug`` as a top-level config boolean for a Compute Endpoint.
+  This flag determines whether debug-level logs are emitted -- the same
+  functionality as the ``--debug`` command line argument to the
+  ``globus-compute-endpoint`` executable.  Note: if this flag is set to
+  ``False`` when the ``--debug`` CLI flag is specified, the CLI wins.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -70,6 +70,14 @@ class Config(RepresentationMixin):
         Path where the endpoint's stderr should be written
         Default: ./interchange.stderr
 
+    debug : bool
+        If set emit debug-level log messages.
+
+        This is a configuration implementation of the CLI's ``--debug`` flag.  Note
+        that if this value is explicitly False, then the CLI flag, if utilized, will
+        still put the EP into "debug mode."  The CLI wins.
+        Default: False
+
     detach_endpoint : Bool
         Should the endpoint daemon be run as a detached process? This is good for
         a real edge node, but an anti-pattern for kubernetes pods
@@ -163,6 +171,7 @@ class Config(RepresentationMixin):
         log_dir=None,
         stdout="./endpoint.log",
         stderr="./endpoint.log",
+        debug: bool = False,
         **kwargs,
     ):
 
@@ -216,6 +225,7 @@ class Config(RepresentationMixin):
         self.log_dir = log_dir
         self.stdout = stdout
         self.stderr = stderr
+        self.debug = debug
 
         # Misc info
         self.display_name = display_name

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -139,6 +139,7 @@ class ConfigModel(BaseConfigModel):
     log_dir: t.Optional[str]
     stdout: t.Optional[str]
     stderr: t.Optional[str]
+    debug: t.Optional[bool]
     amqp_port: t.Optional[int]
 
     _validate_engine = _validate_params("engine")

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -328,7 +328,7 @@ class Endpoint:
 
     def start_endpoint(
         self,
-        endpoint_dir,
+        endpoint_dir: pathlib.Path,
         endpoint_uuid,
         endpoint_config: Config,
         log_to_console: bool,


### PR DESCRIPTION
The `debug` state of the endpoint can now be set by configuration as well as the command line's `--debug`.  Per ticket description, if the CLI flag is specified, the configuration flag is ignored.  "Most specific wins," and the CLI is considered more specific.

[sc-34093]

## Type of change

- New feature (non-breaking change that adds functionality)