### PR TITLE
Share task groups among Executor objects

### DIFF
--- a/changelog.d/20240612_140404_30907815+rjmello_pool_result_watchers_sc_33032.rst
+++ b/changelog.d/20240612_140404_30907815+rjmello_pool_result_watchers_sc_33032.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Unless manually specified, all ``Executor`` objects in the same process will
+  share the same task group ID.

--- a/compute_sdk/globus_compute_sdk/sdk/asynchronous/compute_future.py
+++ b/compute_sdk/globus_compute_sdk/sdk/asynchronous/compute_future.py
@@ -14,6 +14,12 @@ class ComputeFuture(Future):
     not be populated immediately, but will appear later when the task is
     submitted to the Globus Compute services."""
 
+    _metadata: dict
+    """Used to store metadata related to this Future. For example, we may
+    store the ID of the submitting Executor, allowing us to tie it back to
+    its origin."""
+
     def __init__(self, task_id: t.Optional[str] = None):
         super().__init__()
         self.task_id = task_id
+        self._metadata = {}

--- a/compute_sdk/tests/integration/test_executor_int.py
+++ b/compute_sdk/tests/integration/test_executor_int.py
@@ -38,7 +38,7 @@ def test_executor_atexit_handler_catches_all_instances(tmp_path):
         """
         import random
         from globus_compute_sdk import Executor
-        from globus_compute_sdk.sdk.executor import _REGISTERED_FXEXECUTORS
+        from globus_compute_sdk.sdk.executor import _REGISTERED_EXECUTORS
 
         gcc = " a fake client"
         num_executors = random.randrange(1, 10)
@@ -48,8 +48,8 @@ def test_executor_atexit_handler_catches_all_instances(tmp_path):
         gce = Executor(client=gcc)
 
         num_executors += 2
-        assert len(_REGISTERED_FXEXECUTORS) == num_executors, (
-            f"Verify test setup: {len(_REGISTERED_FXEXECUTORS)} != {num_executors}"
+        assert len(_REGISTERED_EXECUTORS) == num_executors, (
+            f"Verify test setup: {len(_REGISTERED_EXECUTORS)} != {num_executors}"
         )
         gce.shutdown()  # only shutting down _last_ instance.  Should still exit cleanly
         """


### PR DESCRIPTION
# Description

Unless manually specified, `Executor` objects in the same process will share the same task group ID. To avoid having multiple consumers of the same task group RabbitMQ queue, we create a pool of task group-specific `_ResultWatcher` threads that are shared among `Executor` objects.

[sc-33032]

## Type of change

- New feature (non-breaking change that adds functionality)