### PR TITLE
Log anonymous configuration in debug

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -641,6 +641,18 @@ def _do_start_endpoint(
                     console_enabled=state.log_to_console,
                     no_color=state.no_color,
                 )
+                if config_str is not None:
+                    num_lines = config_str.count("\n") + 1  # +1 == 0-based
+                    _rendered_config = config_str.replace("\n", "\n  | ")
+
+                    log.debug(
+                        f"Begin Compute endpoint configuration ({num_lines:,} lines):"
+                        f"\n  | {_rendered_config}"
+                        f"\nEnd Compute endpoint configuration"
+                    )
+                    del _rendered_config
+            del config_str
+
         except Exception as e:
             if isinstance(e, ClickException):
                 raise

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -456,6 +456,50 @@ a custom ``globus-compute-endpoint`` wrapper:
 
 (The use of ``exec`` is not critical, but keeps the process tree tidy.)
 
+Debugging User Endpoints
+========================
+
+During implementation, most users are accustomed to using the ``--debug`` flag (or
+equivalent) to get more information.  (And usually, caveat emptor, as the amount of
+information can be overwhelming.)  The ``globus-compute-endpoint`` executable similarly
+implements that flag.  However, if applied to the MEP, that flag will not carry-over to
+the child UEP instances.  In particular, the command executed by the MEP is:
+
+.. code-block:: python
+   :caption: arguments to ``os.execvpe``
+
+   proc_args = ["globus-compute-endpoint", "start", ep_name, "--die-with-parent"]
+
+Note the lack of the ``--debug`` flag; by default UEPs will not emit DEBUG level logs.
+To place UEPs into debug mode, use the ``debug`` top-level configuration directive:
+
+.. code-block:: yaml
+   :caption: ``user_config_template.yaml``
+   :emphasize-lines: 1
+
+   debug: true
+   display_name: Debugging template
+   idle_heartbeats_soft: 10
+   idle_heartbeats_hard: 5760
+   engine:
+      ...
+
+Note that this is *also* how to get the UEP to emit its configuration to the log, which
+may be helpful in determining which set of logs are associated with which configuration
+or just generally while implementing and debugging.  The configuration is emitted to the
+logs very early on in the UEP bootup stage; look for the following sentinel lines::
+
+   [TIMESTAMP] DEBUG ... Begin Compute endpoint configuration (5 lines):
+      ...
+   End Compute endpoint configuration
+
+To this end, the authors have found the following command line helpful for pulling out
+the configuration from the logs:
+
+.. code-block:: console
+
+   $ sed -n "/Begin Compute/,/End Compute/p" ~/.globus_compute/uep.[...]/endpoint.log | less
+
 Installing the MEP as a Service
 ===============================
 


### PR DESCRIPTION
If the endpoint configuration is passed in via stdin and the configuration specifies `debug: True`, then emit the entire passed configuration yaml to the logs.

[sc-34149]

## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update