### PR TITLE
Reword default systemd service description

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -11,7 +11,7 @@ from globus_compute_sdk.sdk.login_manager import LoginManager
 _SYSTEMD_UNIT_DIR = pathlib.Path("/etc/systemd/system")
 
 _SYSTEMD_UNIT_TEMPLATE = """[Unit]
-Description=systemd service for Globus Compute Endpoint "{ep_name}"
+Description=Globus Compute Endpoint "{ep_name}"
 After=network.target
 StartLimitIntervalSec=0
 


### PR DESCRIPTION
# Description

This removes the "systemd service" verbiage, which is both redundant and nonstandard (other services do not reference the fact that they are services in their description).

## Type of change

- Documentation update
