### PR TITLE
Add reference to `self-diagnostic` command in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,5 +32,6 @@ A clear and concise description of what you expected to happen.
 - Where are you running the funcX script from? [e.g. Laptop/Workstation, Login node, Compute node]
 - Where does the endpoint run? [e.g. Laptop/Workstation, Login node]
 - What is your endpoint-uuid?
-- Attach endpoint logs at `~/.globus_compute/<ENDPOINT_NAME>` if this is an endpoint issue.
-  Please let us know if you'd prefer to share logs privately.
+- If this is an endpoint issue, run `globus-compute-endpoint self-diagnostic -z` and attach the resulting zip file.
+  This archive will contain logs, configuration, and machine information; if you'd prefer to share it privately,
+  you can reach the [Compute team via Slack](https://join.slack.com/t/funcx/shared_invite/zt-gfeclqkz-RuKjkZkvj1t~eWvlnZV0KA).


### PR DESCRIPTION
# Description

After a GitHub issue someone opened a while back, I realized that we don't point users toward the self-diagnostic in our bug report template. Fixing that here.

## Type of change

- Documentation update
