### PR TITLE
Enable GCEngine to support providers w/o a channel

### DIFF
--- a/changelog.d/20240617_133114_30907815+rjmello_fix_gcengine_channel_check.rst
+++ b/changelog.d/20240617_133114_30907815+rjmello_fix_gcengine_channel_check.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- We no longer raise an exception when using the ``GlobusComputeEngine`` with Parsl
+  providers that do not utilize ``Channel`` objects (e.g., ``KubernetesProvider``).

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -212,7 +212,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             )
 
         if (
-            self.executor.provider.channel
+            getattr(self.executor.provider, "channel", None)
             and not self.executor.provider.channel.script_dir
         ):
             self.executor.provider.channel.script_dir = script_dir


### PR DESCRIPTION
# Description

Some Parsl providers do not utilize `Channel` objects to communicate with resource managers (e.g., `KubernetesProvider`).

## Type of change

- Bug fix (non-breaking change that fixes an issue)
