### PR TITLE
Update Endpoint to pass on resource_specification to GCEngine

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -391,10 +391,13 @@ class EndpointInterchange:
                     tid: str = prop_headers.get("task_uuid")
 
                     if not fid or not tid:
-                        raise InvalidMessageError("Task message missing headers")
+                        raise InvalidMessageError(
+                            "Task message missing function or task id in headers"
+                        )
 
-                    res_spec_s: str = prop_headers.get("resource_specification", "null")
-                    # guarantee that res_spec is always a dict
+                    res_spec_s: str = (
+                        prop_headers.get("resource_specification") or "null"
+                    )
                     res_spec: dict = json.loads(res_spec_s) or {}
 
                     if fid and not self.function_allowed(fid):

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -198,18 +198,25 @@ class GlobusComputeEngineBase(ABC):
     def _submit(
         self,
         func: t.Callable,
+        resource_specification: t.Dict,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> Future:
         """Subclass should use the internal execution system to implement this"""
         raise NotImplementedError()
 
-    def submit(self, task_id: str, packed_task: bytes) -> Future:
+    def submit(
+        self,
+        task_id: str,
+        packed_task: bytes,
+        resource_specification: t.Dict,
+    ) -> Future:
         """GC Endpoints should submit tasks via this method so that tasks are
         tracked properly.
         Parameters
         ----------
         packed_task: messagepack bytes buffer
+        resource_specification: Dict that specifies resource requirements
         Returns
         -------
         future
@@ -220,10 +227,12 @@ class GlobusComputeEngineBase(ABC):
                 "retry_count": 0,
                 "packed_task": packed_task,
                 "exception_history": [],
+                "resource_specification": resource_specification,
             }
         try:
             future = self._submit(
                 execute_task,
+                resource_specification,
                 task_id,
                 packed_task,
                 self.endpoint_id,

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -231,10 +231,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
     def _submit(
         self,
         func: t.Callable,
+        resource_specification: t.Dict,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> Future:
-        return self.executor.submit(func, {}, *args, **kwargs)
+        return self.executor.submit(func, resource_specification, *args, **kwargs)
 
     @property
     def provider(self):
@@ -380,7 +381,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         if retry_info["retry_count"] < self.max_retries_on_system_failure:
             retry_info["retry_count"] += 1
             retry_info["exception_history"].append(exception)
-            self.submit(task_id, retry_info["packed_task"])
+            self.submit(
+                task_id,
+                retry_info["packed_task"],
+                resource_specification=retry_info["resource_specification"],
+            )
         else:
             # This is a terminal state
             result_bytes = super()._handle_task_exception(

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
@@ -748,7 +748,9 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
 
         return container_loc
 
-    def submit(self, task_id: str, packed_task: bytes) -> HTEXFuture:
+    def submit(
+        self, task_id: str, packed_task: bytes, resource_specification: t.Dict
+    ) -> HTEXFuture:
         """Submits a messagepacked.Task for execution
 
         Parameters

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -92,6 +92,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
     def _submit(
         self,
         func: t.Callable,
+        resource_specification: t.Dict,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> Future:

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -89,6 +89,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
     def _submit(
         self,
         func: t.Callable,
+        resource_specification: t.Dict,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> Future:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_resource_spec.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_resource_spec.py
@@ -1,0 +1,94 @@
+import concurrent.futures
+import logging
+import random
+import uuid
+from queue import Queue
+
+import pytest
+from globus_compute_endpoint.engines import GlobusComputeEngine
+from parsl.executors.high_throughput.mpi_prefix_composer import (
+    InvalidResourceSpecification,
+)
+from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
+from tests.utils import get_env_vars
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def nodeslist(num=100):
+    limit = random.randint(1, num)
+    yield [f"NODE{node_i}" for node_i in range(1, limit)]
+
+
+@pytest.fixture
+def gc_engine_with_mpi(tmp_path, nodeslist):
+    ep_id = uuid.uuid4()
+
+    nodefile_path = tmp_path / "pbs_nodefile"
+    nodes_string = "\n".join(nodeslist)
+    worker_init = f"""
+    echo -e "{nodes_string}" > {nodefile_path} ;
+    export PBS_NODEFILE={nodefile_path}
+    """
+    engine = GlobusComputeEngine(
+        address="127.0.0.1",
+        heartbeat_period=1,
+        heartbeat_threshold=2,
+        enable_mpi_mode=True,
+        mpi_launcher="mpiexec",
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=1,
+            max_blocks=1,
+            worker_init=worker_init,
+            launcher=SimpleLauncher(),
+        ),
+        strategy="none",
+        job_status_kwargs={"max_idletime": 0, "strategy_period": 0.1},
+    )
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
+
+    yield engine, nodeslist
+    engine.shutdown()
+
+
+def test_mpi_res_spec(gc_engine_with_mpi):
+    """Test passing valid MPI Resource spec to mpi enabled engine"""
+    engine, nodes = gc_engine_with_mpi
+
+    for i in range(1, len(nodes) + 1):
+        res_spec = {"num_nodes": i, "num_ranks": random.randint(1, 8)}
+
+        future = engine._submit(get_env_vars, resource_specification=res_spec)
+        assert isinstance(future, concurrent.futures.Future)
+        env_vars = future.result()
+        provisioned_nodes = env_vars["PARSL_MPI_NODELIST"].strip().split(",")
+
+        assert len(provisioned_nodes) == res_spec["num_nodes"]
+        for prov_node in provisioned_nodes:
+            assert prov_node in nodes
+        assert env_vars["PARSL_NUM_NODES"] == str(res_spec["num_nodes"])
+        assert env_vars["PARSL_NUM_RANKS"] == str(res_spec["num_ranks"])
+        assert env_vars["PARSL_MPI_PREFIX"].startswith("mpiexec")
+
+
+def test_no_mpi_res_spec(gc_engine_with_mpi):
+    """Test passing valid MPI Resource spec to mpi enabled engine"""
+    engine, nodes = gc_engine_with_mpi
+
+    res_spec = None
+    with pytest.raises(AttributeError):
+        engine._submit(get_env_vars, resource_specification=res_spec)
+
+
+def test_bad_mpi_res_spec(gc_engine_with_mpi):
+    """Test passing valid MPI Resource spec to mpi enabled engine"""
+    engine, nodes = gc_engine_with_mpi
+
+    res_spec = {"FOO": "BAR"}
+
+    with pytest.raises(InvalidResourceSpecification):
+        engine._submit(get_env_vars, resource_specification=res_spec)

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -67,7 +67,8 @@ def test_engine_submit_init_0(gc_engine_scaling):
 
     # Run a function to trigger scale_out and confirm via breakdown
     param = random.randint(1, 100)
-    future = engine._submit(double, param)
+    resource_spec = {}
+    future = engine._submit(double, resource_spec, param)
     assert isinstance(future, concurrent.futures.Future)
     assert future.result() == param * 2
 
@@ -92,7 +93,8 @@ def test_engine_no_scaling(gc_engine_non_scaling):
 
     # Run a function to trigger scale_out and confirm via breakdown
     param = random.randint(1, 100)
-    future = engine._submit(double, param)
+    resource_spec = {}
+    future = engine._submit(double, resource_spec, param)
     assert isinstance(future, concurrent.futures.Future)
     assert future.result() == param * 2
 

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_htex_regression.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_htex_regression.py
@@ -35,7 +35,10 @@ def test_engine_submit(engine):
             task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
         )
     )
-    future = engine.submit(str(task_id), task_message)
+    resource_spec = {}
+    future = engine.submit(
+        str(task_id), task_message, resource_specification=resource_spec
+    )
     packed_result = future.result()
 
     # Confirm that the future got the right answer

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -44,7 +44,7 @@ def test_success_after_1_fail(gc_engine_with_retries, tmp_path):
     task_message = messagepack.pack(
         messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
     )
-    engine.submit(task_id, task_message)
+    engine.submit(task_id, task_message, resource_specification={})
 
     flag = False
     for _i in range(20):
@@ -75,7 +75,7 @@ def test_repeated_fail(gc_engine_with_retries, tmp_path):
     task_message = messagepack.pack(
         messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
     )
-    engine.submit(task_id, task_message)
+    engine.submit(task_id, task_message, resource_specification={})
 
     flag = False
     for _i in range(30):

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -70,7 +70,8 @@ def test_engine_submit(engine_type: GlobusComputeEngineBase, engine_runner):
     engine = engine_runner(engine_type)
 
     param = random.randint(1, 100)
-    future = engine._submit(double, param)
+    resource_spec = {}
+    future = engine._submit(double, resource_spec, param)
     assert isinstance(future, concurrent.futures.Future)
 
     # 5-seconds is nominally "overkill," but gc on CI appears to need (at least) >1s

--- a/compute_endpoint/tests/unit/test_htex.py
+++ b/compute_endpoint/tests/unit/test_htex.py
@@ -183,7 +183,7 @@ def test_engine_submit_container_location(
     mock_put = mocker.patch.object(engine.outgoing_q, "put")
 
     engine.container_type = container_type
-    engine.submit(str(task_id), task_message)
+    engine.submit(str(task_id), task_message, {})
 
     a, _ = mock_put.call_args
     unpacked_msg = InternalTask.unpack(a[0])

--- a/compute_endpoint/tests/utils.py
+++ b/compute_endpoint/tests/utils.py
@@ -125,3 +125,9 @@ def succeed_after_n_runs(dirpath: pathlib.Path, fail_count: int = 1):
         os.killpg(manager_pgid, signal.SIGKILL)
 
     return f"Success on attempt: {prior_run_count+1}"
+
+
+def get_env_vars():
+    import os
+
+    return os.environ


### PR DESCRIPTION
# Description

This PR updates the Endpoint Interchange to pull the `resource_specification` for tasks from the RMQ message headers and pass those along to the GlobusComputeEngine. EngineBase is updated to allow passing resource_specification when `engine.submit` is called. If no `resource_specification` is passed, none is passed along to the engine retaining old behavior.

This functionality is not user-facing until a follow-up PR introduces `BashFunctions` and `MPIFunctions`, so I'm leaving out docs/changelog entries.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
