### PR TITLE
Add executable paths to self-diagnostic output

### DIFF
--- a/changelog.d/20240622_114437_30907815+rjmello_add_bin_paths_to_self_diag.rst
+++ b/changelog.d/20240622_114437_30907815+rjmello_add_bin_paths_to_self_diag.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Included the paths to the ``globus-compute-endpoint`` and ``process_worker_pool.py``
+  executables in the ``self-diagnostic`` command output.

--- a/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
+++ b/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
@@ -98,16 +98,25 @@ def get_service_versions(base_url: str):
     return kernel
 
 
+def get_executable_path(exec_name: str):
+    def kernel():
+        path = shutil.which(exec_name)
+        click.echo(f"{path}\n")
+
+    kernel.display_name = f"which({exec_name})"  # type: ignore
+    return kernel
+
+
+def which_python():
+    click.echo(f"{sys.executable}\n")
+
+
 def get_openssl_version():
     click.echo(f"{ssl.OPENSSL_VERSION}\n")
 
 
 def get_python_version():
     click.echo(f"Python version {sys.version}\n")
-
-
-def which_python():
-    click.echo(f"{sys.executable}\n")
 
 
 def _run_command(cmd: str):
@@ -152,6 +161,8 @@ def run_self_diagnostic(log_bytes: int = 0):
         "ifconfig",
         "ip route",
         "netstat -r",
+        get_executable_path("globus-compute-endpoint"),
+        get_executable_path("process_worker_pool.py"),
         "globus-compute-endpoint whoami",
         "globus-compute-endpoint list",
         cat("~/.globus_compute/*/*.yaml", wildcard=True),

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -597,7 +597,7 @@ def test_self_diagnostic(
     res = run_line("self-diagnostic")
     stdout = res.stdout_bytes.decode("utf-8")
 
-    assert stdout.count("== Diagnostic") >= 19
+    assert stdout.count("== Diagnostic") >= 21
     assert stdout.count("Connected successfully") == 2
     assert stdout.count("established SSL connection") == 2
     assert conf_data in stdout
@@ -675,7 +675,7 @@ def test_self_diagnostic_gzip(
     with gzip.open(fname, "rb") as f:
         contents = f.read().decode("utf-8")
 
-    assert contents.count("== Diagnostic") >= 19
+    assert contents.count("== Diagnostic") >= 21
 
 
 @pytest.mark.parametrize("test_data", [(True, 1), (False, 0.5), (False, "")])
@@ -706,7 +706,7 @@ def test_self_diagnostic_log_size(
 
     if should_succeed:
         stdout = run_cmd()
-        assert stdout.count("== Diagnostic") >= 19
+        assert stdout.count("== Diagnostic") >= 21
     else:
         with pytest.raises(AssertionError):
             stdout = run_cmd()


### PR DESCRIPTION
# Description

Included the paths to the ``globus-compute-endpoint`` and ``process_worker_pool.py`` executables in the ``self-diagnostic`` command output. These can help us to identify issues with a user's local environment.

## Type of change

- New feature (non-breaking change that adds functionality)
