### PR TITLE
Send information about a user's runtime environment to MEP config renderer

### DIFF
--- a/changelog.d/20240627_181028_chris_mep_config_user_runtime.rst
+++ b/changelog.d/20240627_181028_chris_mep_config_user_runtime.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The engine that renders user endpoint config files now receives information about
+  the runtime environment used to submit tasks, such as Python environment and Globus
+  Compute SDK version, via the ``user_runtime`` variable. For a complete list of the
+  fields that are sent, `reference the documentation on batch.UserRuntime. <https://globus-compute.readthedocs.io/en/latest/reference/client.html#globus_compute_sdk.sdk.batch.UserRuntime>`_

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -973,8 +973,9 @@ class EndpointManager:
             (gc_dir / ep_name).mkdir(mode=0o700, parents=True, exist_ok=True)
 
             user_opts = kwargs.get("user_opts", {})
+            user_runtime = kwargs.get("user_runtime", {})
             user_config = render_config_user_template(
-                self._config, template_str, user_config_schema, user_opts
+                self._config, template_str, user_config_schema, user_opts, user_runtime
             )
             stdin_data_dict = {
                 "amqp_creds": kwargs.get("amqp_creds"),

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import typing as t
 import uuid
 import warnings
@@ -21,8 +22,9 @@ from globus_compute_sdk.sdk.web_client import (
 )
 from globus_compute_sdk.serialize import ComputeSerializer, SerializationStrategy
 from globus_compute_sdk.version import __version__, compare_versions
+from globus_sdk.version import __version__ as __version_globus__
 
-from .batch import Batch
+from .batch import Batch, UserRuntime
 from .login_manager import LoginManager, LoginManagerProtocol, requires_login
 from .utils import get_env_var_with_deprecation
 
@@ -400,6 +402,11 @@ class Client:
             user_endpoint_config,
             create_websocket_queue,
             serializer=self.fx_serializer,
+            user_runtime=UserRuntime(
+                globus_compute_sdk_version=__version__,
+                globus_sdk_version=__version_globus__,
+                python_version=sys.version,
+            ),
         )
 
     @requires_login

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -1,9 +1,10 @@
+import sys
 import uuid
 from unittest import mock
 
 import globus_compute_sdk as gc
 import pytest
-from globus_compute_sdk import ContainerSpec
+from globus_compute_sdk import ContainerSpec, __version__
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.login_manager import LoginManager
 from globus_compute_sdk.sdk.utils import get_env_details
@@ -13,6 +14,7 @@ from globus_compute_sdk.sdk.web_client import (
 )
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.serialize.concretes import SELECTABLE_STRATEGIES
+from globus_sdk import __version__ as __version_globus__
 
 
 @pytest.fixture(autouse=True)
@@ -207,6 +209,17 @@ def test_batch_respects_serialization_strategy(gcc, strategy):
     expected = {fn_id: [ser.pack_buffers([ser.serialize(args), ser.serialize(kwargs)])]}
 
     assert tasks == expected
+
+
+def test_batch_includes_user_runtime_info(gcc):
+    batch = gcc.create_batch()
+    payload = batch.prepare()
+
+    assert payload["user_runtime"] == {
+        "globus_compute_sdk_version": __version__,
+        "globus_sdk_version": __version_globus__,
+        "python_version": sys.version,
+    }
 
 
 def test_build_container(mocker, gcc, randomstring):

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -295,7 +295,7 @@ motivated administrator.  The initial user config template implements two
 user-specifiable variables, ``endpoint_setup`` and ``worker_init``.  Both of these
 default to the empty string if not specified by the user (i.e., ``...|default()``).
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
    endpoint_setup: {{ endpoint_setup|default() }}
    engine:
@@ -807,7 +807,7 @@ administrator could use the following user configuration template
 ``debug-scaling`` queue, and pre-select the obvious defaults (`per the
 documentation <https://docs.alcf.anl.gov/polaris/running-jobs/>`_):
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
    display_name: Polaris at ALCF - debug-scaling queue
    engine:

--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -8,3 +8,7 @@ The Globus Compute Client
 .. autoclass:: globus_compute_sdk.sdk.container_spec.ContainerSpec
     :members:
     :member-order: bysource
+
+.. autoclass:: globus_compute_sdk.sdk.batch.UserRuntime
+    :members:
+    :member-order: bysource


### PR DESCRIPTION
# Description

When submitting a task, the SDK now collects information about the user's runtime environment, such as Python version and Compute SDK version, which is sent alongside the task submission. In the case where this submission is to an MEP, the web service will (in a separate PR) include the new information in the MEP submission request. Then, the MEP renders the config template with that information as a variable named `user_runtime`. As documented here, this enables a workflow where admins can run UEPs under different Python versions depending on how the task was submitted.

[sc-34336](https://app.shortcut.com/globus/story/34336/send-information-about-a-user-s-runtime-environment-to-mep-config-renderer)

## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update
