### PR TITLE
Bump parsl dependency version to 2024.6.10

### DIFF
--- a/changelog.d/20240628_090506_30907815+rjmello_bump_parsl_2024_06_10.rst
+++ b/changelog.d/20240628_090506_30907815+rjmello_bump_parsl_2024_06_10.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version to 2024.6.10.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -225,7 +225,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.executor.start()
         self._status_report_thread.start()
         # Add executor to poller *after* executor has started
-        self.job_status_poller = JobStatusPoller(dfk=None, **self._job_status_kwargs)
+        self.job_status_poller = JobStatusPoller(**self._job_status_kwargs)
         self.job_status_poller.add_executors([self.executor])
 
     def _submit(

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.3.18",
+    "parsl==2024.6.10",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -124,6 +124,7 @@ def engine_runner(tmp_path, engine_heartbeat, reporting_period=0.1) -> t.Callabl
                 address="127.0.0.1",
                 heartbeat_period=engine_heartbeat,
                 heartbeat_threshold=2,
+                job_status_kwargs=dict(max_idletime=0, strategy_period=0.1),
             )
         else:
             raise NotImplementedError(f"Unimplemented: {engine_type.__name__}")


### PR DESCRIPTION
# Description

Bumped parsl dependency to version 2024.6.10. This required a couple of minor changes:

* As of Parsl PR https://github.com/Parsl/parsl/pull/3283, the initial HTEX block scale out occurs on the first strategy poll, not at HTEX start. Thus, our tests should use a small strategy period to speed them up and avoid timeouts.

* As of Parsl PR https://github.com/Parsl/parsl/pull/3338, the `dfk` argument for `JobStatusPoller` initialization is no longer supported.

## Type of change

- Code maintenance/cleanup
