### PR TITLE
Update GCE to run tasks in a `tasks` dir

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -198,7 +198,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             if not os.path.isabs(self.working_dir):
                 self.working_dir = os.path.join(run_dir, self.working_dir)
         else:
-            self.working_dir = run_dir
+            # If working_dir is not specified, run task in a "tasks" dir
+            # to collate run outputs in a single dir
+            self.working_dir = os.path.join(run_dir, "tasks")
 
         self.endpoint_id = endpoint_id
         self.run_dir = run_dir

--- a/compute_endpoint/tests/unit/test_gce_run_dir.py
+++ b/compute_endpoint/tests/unit/test_gce_run_dir.py
@@ -1,0 +1,68 @@
+import os.path
+import uuid
+from unittest import mock
+
+from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
+from parsl.executors import HighThroughputExecutor
+
+
+def test_default_working_dir(tmp_path):
+    """Verify that working dir is set to tasks dir in the run_dir by default"""
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        working_dir=None,
+    )
+    gce.executor.start = mock.MagicMock(spec=HighThroughputExecutor)
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    assert gce.executor.run_dir == tmp_path
+    assert gce.working_dir == os.path.join(tmp_path, "tasks")
+
+
+def test_relative_working_dir(tmp_path):
+    """Test working_dir relative to run_dir"""
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        working_dir="relative_path",
+    )
+    gce.executor.start = mock.MagicMock(spec=HighThroughputExecutor)
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    assert gce.run_dir == gce.executor.run_dir
+    assert gce.working_dir == os.path.join(tmp_path, "relative_path")
+
+
+def test_absolute_working_dir(tmp_path):
+    """Test absolute path for working_dir"""
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        working_dir="/absolute/path",
+    )
+    gce.executor.start = mock.MagicMock(spec=HighThroughputExecutor)
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    assert gce.run_dir == gce.executor.run_dir
+    assert gce.working_dir == "/absolute/path"
+
+
+def test_submit_pass(tmp_path):
+    """Test absolute path for working_dir"""
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        working_dir=None,
+    )
+    gce.executor.start = mock.Mock(spec=HighThroughputExecutor)
+    gce.executor.submit = mock.Mock(spec=HighThroughputExecutor.start)
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+
+    gce.submit(
+        task_id=uuid.uuid4(),
+        packed_task=b"PACKED_TASK",
+        resource_specification={},
+    )
+
+    gce.executor.submit.assert_called()
+    flag = False
+    for call in gce.executor.submit.call_args_list:
+        args, kwargs = call
+        assert "run_dir" in kwargs
+        assert kwargs["run_dir"] == os.path.join(tmp_path, "tasks")
+        flag = True
+    assert flag, "Call args parsing failed, did not find run_dir"


### PR DESCRIPTION
# Description

Update GCE to run tasks in a `tasks` dir

* When no GCE(working_dir) is specified, tasks run in endpoint.run_dir/tasks dir
* When GCE(working_dir=relative_path), tasks run in a path relative to the endpoint.run_dir.
* When GCE(working_dir=absolute_path), tasks run in the specified absolute path.

Fixes # (issue)

Clutter in the endpoint

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
