### PR TITLE
Update GCE to run tasks in `tasks_working_dir`

### DIFF
--- a/changelog.d/20240702_104011_yadudoc1729_gce_run_tasks_in_working_dir.rst
+++ b/changelog.d/20240702_104011_yadudoc1729_gce_run_tasks_in_working_dir.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+- ``GlobusComputeEngine.working_dir`` now defaults to ``tasks_working_dir``
+   * When ``working_dir=relative_path``, tasks run in a path relative to the endpoint.run_dir.
+     The default is ``tasks_working_dir`` set relative to endpoint.run_dir.
+   * When ``working_dir=absolute_path``, tasks run in the specified absolute path

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -89,7 +89,7 @@ class GlobusComputeEngineBase(ABC):
         # endpoint interchange happy
         self.container_type: t.Optional[str] = None
         self.run_dir: t.Optional[str] = None
-        self.working_dir: t.Optional[t.Union[str, os.PathLike]] = None
+        self.working_dir: t.Union[str, os.PathLike] = "tasks_working_dir"
         self.run_in_sandbox: bool = False
         # This attribute could be set by the subclasses in their
         # start method if another component insists on owning the queue.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -47,7 +47,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         encrypted: bool = True,
         strategy: str | None = None,
         job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
-        working_dir: str | os.PathLike | None = None,
+        working_dir: str | os.PathLike = "tasks_working_dir",
         run_in_sandbox: bool = False,
         **kwargs,
     ):
@@ -87,9 +87,12 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         encrypted: bool
             Flag to enable/disable encryption (CurveZMQ). Default is True.
 
-        working_dir: str | os.PathLike | None
-            Directory within which functions should execute. When set to None,
-            defaults to the endpoint_dir (~/.globus_compute/<endpoint_name>/)
+        working_dir: str | os.PathLike
+            Directory within which functions should execute, defaults to
+            (~/.globus_compute/<endpoint_name>/tasks_working_dir)
+            If a relative path is supplied, the working dir is set relative
+            to the endpoint.run_dir. If an absolute path is supplied, it is
+            used as is.
 
         run_in_sandbox: bool
             Functions will run in a sandbox directory under the working_dir
@@ -194,11 +197,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         assert endpoint_id, "GCExecutor requires kwarg:endpoint_id at start"
         assert run_dir, "GCExecutor requires kwarg:run_dir at start"
 
-        if self.working_dir:
-            if not os.path.isabs(self.working_dir):
-                self.working_dir = os.path.join(run_dir, self.working_dir)
-        else:
-            self.working_dir = run_dir
+        if not os.path.isabs(self.working_dir):
+            # set relative to run_dir
+            self.working_dir = os.path.join(run_dir, self.working_dir)
 
         self.endpoint_id = endpoint_id
         self.run_dir = run_dir


### PR DESCRIPTION
# Description

By default the working_dir was set to the endpoint_dir, which results in BashFunctions quickly cluttering up the dir.
This change is added to collate output from BashFunctions in one directory.

``GlobusComputeEngine.working_dir`` now defaults to ``tasks_working_dir``
   * When ``working_dir=relative_path``, tasks run in a path relative to the endpoint.run_dir.
     The default is ``tasks_working_dir`` set relative to endpoint.run_dir.
   * When ``working_dir=absolute_path``, tasks run in the specified absolute path

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
