### PR TITLE
Use endpoint CLI to launch worker pool

### DIFF
--- a/changelog.d/20240702_175644_30907815+rjmello_exec_cmd_sc_34376.rst
+++ b/changelog.d/20240702_175644_30907815+rjmello_exec_cmd_sc_34376.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added the ``globus-compute-endpoint python-exec`` command to run Python modules as scripts
+  from the Globus Compute endpoint CLI. The primary use case is to launch Parsl processes
+  without requiring additional commands in the user's ``PATH`` (e.g., ``process_worker_pool.py``).

--- a/changelog.d/20240702_175644_30907815+rjmello_exec_cmd_sc_34376.rst
+++ b/changelog.d/20240702_175644_30907815+rjmello_exec_cmd_sc_34376.rst
@@ -4,3 +4,8 @@ New Functionality
 - Added the ``globus-compute-endpoint python-exec`` command to run Python modules as scripts
   from the Globus Compute endpoint CLI. The primary use case is to launch Parsl processes
   without requiring additional commands in the user's ``PATH`` (e.g., ``process_worker_pool.py``).
+
+Changed
+~~~~~~~
+
+- Worker nodes no longer need to resolve the ``process_worker_pool.py`` command.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -8,6 +8,7 @@ import logging
 import pathlib
 import re
 import shutil
+import subprocess
 import sys
 import textwrap
 import uuid
@@ -908,6 +909,22 @@ def self_diagnostic(compress: bool, log_kb: int):
                 run_self_diagnostic(log_bytes=log_bytes)
 
         click.echo(f"Successfully created {filename}")
+
+
+@app.command(
+    "python-exec",
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+)
+@click.argument("module")
+@click.help_option("-h", "--help")
+@click.pass_context
+def run_python_executable(ctx: click.Context, module: str):
+    """Run a Python module as a script via the Globus Compute endpoint CLI.
+    This helps to minimize PATH issues when launching workers, etc.
+
+    E.g., globus-compute-endpoint python-exec path.to.module --ahoy matey
+    """
+    subprocess.run([sys.executable, "-m", module] + ctx.args)
 
 
 def create_or_choose_auth_project(ac: AuthClient) -> str:

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gce_container.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gce_container.py
@@ -3,6 +3,11 @@ import uuid
 import pytest
 from globus_compute_endpoint.engines import GlobusComputeEngine
 
+_LAUNCH_CMD_PREFIX = (
+    "globus-compute-endpoint python-exec"
+    " parsl.executors.high_throughput.process_worker_pool"
+)
+
 
 def platinfo():
     import platform
@@ -24,7 +29,7 @@ def test_docker(tmp_path):
     container_launch_cmd = gce.executor.launch_cmd
     expected = (
         "docker run --FABRICATED -v /tmp:/tmp -t "
-        "funcx/kube-endpoint:main-3.10 process_worker_pool.py --debug"
+        f"funcx/kube-endpoint:main-3.10 {_LAUNCH_CMD_PREFIX} --debug"
     )
     assert container_launch_cmd.startswith(expected)
 
@@ -42,9 +47,7 @@ def test_apptainer(tmp_path):
     )
     gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
     container_launch_cmd = gce.executor.launch_cmd
-    expected = (
-        "apptainer run --FABRICATED APPTAINER_PATH process_worker_pool.py --debug"
-    )
+    expected = f"apptainer run --FABRICATED APPTAINER_PATH {_LAUNCH_CMD_PREFIX} --debug"
     assert container_launch_cmd.startswith(expected)
 
     gce.shutdown()
@@ -64,7 +67,7 @@ def test_singularity(tmp_path):
     container_launch_cmd = gce.executor.launch_cmd
     expected = (
         "singularity run /home/yadunand/kube-endpoint.py3.9.sif"
-        " process_worker_pool.py --debug"
+        f" {_LAUNCH_CMD_PREFIX} --debug"
     )
     assert container_launch_cmd.startswith(expected)
 
@@ -94,7 +97,7 @@ def test_custom(tmp_path):
     gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
 
     container_launch_cmd = gce.executor.launch_cmd
-    expected = f"FOO {gce.run_dir} process_worker_pool.py"
+    expected = f"FOO {gce.run_dir} {_LAUNCH_CMD_PREFIX}"
     assert container_launch_cmd.startswith(expected)
 
     gce.shutdown()

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -8,6 +8,7 @@ import pathlib
 import random
 import re
 import shlex
+import sys
 import typing as t
 import uuid
 from unittest import mock
@@ -804,6 +805,14 @@ _test_name_or_uuid_decorator__data = [
     ("123", str(uuid.uuid4())),
     ("nice_normal_name", str(uuid.uuid4())),
 ]
+
+
+def test_python_exec(mocker: MockFixture, run_line: t.Callable):
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    run_line("python-exec path.to.module arg --option val")
+    mock_subprocess_run.assert_called_with(
+        [sys.executable, "-m", "path.to.module", "arg", "--option", "val"]
+    )
 
 
 @pytest.mark.parametrize("name,uuid", _test_name_or_uuid_decorator__data)

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -52,7 +52,7 @@ def test_custom(tmp_path):
     assert gce.executor.launch_cmd
     assert gce.executor.launch_cmd.startswith("mycontainer")
     assert f"{tmp_path}:{tmp_path}" in gce.executor.launch_cmd
-    assert "process_worker_pool.py" in gce.executor.launch_cmd
+    assert "process_worker_pool" in gce.executor.launch_cmd
     gce.executor.start.assert_called()
 
 


### PR DESCRIPTION
# Description

This PR adds the `globus-compute-endpoint python-exec` command to run Python modules as scripts via the Globus Compute endpoint CLI.

E.g.,
```bash
globus-compute-endpoint python-exec parsl.executors.high_throughput.process_worker_pool --debug
```

We then use this to launch worker pools without requiring worker nodes to resolve the `process_worker_pool.py` command.

[sc-34376]

## Type of change

- New feature (non-breaking change that adds functionality)
