### PR TITLE
Change version mismatch message, add logic to ignore Python micro # if desired

### DIFF
--- a/compute_sdk/tests/unit/test_util.py
+++ b/compute_sdk/tests/unit/test_util.py
@@ -1,0 +1,41 @@
+import pytest
+from globus_compute_sdk.sdk.utils import check_version
+
+
+@pytest.mark.parametrize(
+    ("sdk_py", "worker_py", "check_micro", "should_warn"),
+    (
+        ["3.11.8", "3.10.8", False, True],
+        ["3.11.8", "3.10.8", True, True],
+        ["3.11.8", "3.11.7", False, False],
+        ["3.11.8", "3.11.7", True, True],
+        ["3.11.8", None, False, True],
+        ["3.11.8", None, True, True],
+    ),
+)
+def test_check_py_version(mocker, sdk_py, worker_py, check_micro, should_warn):
+    mock_details = mocker.patch("globus_compute_sdk.sdk.utils.get_env_details")
+    mock_details.return_value = {
+        "os": "some-64bit",
+        "dill_version": "0.3.5.1",
+        "python_version": sdk_py,
+        "globus_compute_sdk_version": "2.22.0",
+    }
+    task_details = {
+        "os": "Linux-5.19.0-1025-aws-x86_64-with-glibc2.35",
+        "python_version": worker_py,
+        "dill_version": "0.3.5.1",
+        "globus_compute_sdk_version": "2.3.2",
+        "task_transitions": {
+            "execution-start": 1692742841.843334,
+            "execution-end": 1692742846.123456,
+        },
+    }
+    if worker_py is None:
+        del task_details["python_version"]
+
+    result = check_version(task_details, check_py_micro=check_micro)
+    if should_warn:
+        assert result and "environment differences detected" in result
+    else:
+        assert result is None


### PR DESCRIPTION
Our typical warning message:

Warning - dependency versions are mismatched between local SDK and remote worker on endpoint f93919c6-ceb7-4833-1dfe-ef3edbbea706: local SDK uses Python 3.11.9/Dill 0.3.6 but worker used 3.11.8/0.3.6
(worker SDK version: 2.22.0; worker OS: Linux-5.10.217-205.860.amzn2.x86_64-x86_64-with-glibc2.36)

has come up a few times when users were unsure about its actual impact. It is also displayed with minor PY version mismatches when that may not impact serialization.

We should make the message more clear, and possibly avoid minor version mismatches triggering the warning.

For now, until more team members give input, this PR leaves the micro-version checking logic alone, and only updates the warning message itself to be more helpful.