### PR TITLE
Bump versions for prod release 2.23.0 2024-07-10

### DIFF
--- a/changelog.d/20240410_130138_LeiGlobus_delete_remote_endpoint_sc_31206.rst
+++ b/changelog.d/20240410_130138_LeiGlobus_delete_remote_endpoint_sc_31206.rst
@@ -1,7 +1,0 @@
-.. New Functionality
-.. ^^^^^^^^^^^^^^^^^
-..
-- The ``delete`` command can now delete endpoints by name or UUID from the
-   Compute service remotely when local config files are not available.  Note
-   that without the ``--force`` option the command may exit early if the
-   endpoint is currently running or local config files are corrupted.

--- a/changelog.d/20240617_133114_30907815+rjmello_fix_gcengine_channel_check.rst
+++ b/changelog.d/20240617_133114_30907815+rjmello_fix_gcengine_channel_check.rst
@@ -1,5 +1,0 @@
-Bug Fixes
-^^^^^^^^^
-
-- We no longer raise an exception when using the ``GlobusComputeEngine`` with Parsl
-  providers that do not utilize ``Channel`` objects (e.g., ``KubernetesProvider``).

--- a/changelog.d/20240622_114437_30907815+rjmello_add_bin_paths_to_self_diag.rst
+++ b/changelog.d/20240622_114437_30907815+rjmello_add_bin_paths_to_self_diag.rst
@@ -1,5 +1,0 @@
-New Functionality
-^^^^^^^^^^^^^^^^^
-
-- Included the paths to the ``globus-compute-endpoint`` and ``process_worker_pool.py``
-  executables in the ``self-diagnostic`` command output.

--- a/changelog.d/20240628_090506_30907815+rjmello_bump_parsl_2024_06_10.rst
+++ b/changelog.d/20240628_090506_30907815+rjmello_bump_parsl_2024_06_10.rst
@@ -1,4 +1,0 @@
-Changed
-^^^^^^^
-
-- Bumped ``parsl`` dependency version to 2024.6.10.

--- a/changelog.d/20240702_104011_yadudoc1729_gce_run_tasks_in_working_dir.rst
+++ b/changelog.d/20240702_104011_yadudoc1729_gce_run_tasks_in_working_dir.rst
@@ -1,7 +1,0 @@
-Changed
-^^^^^^^
-
-- ``GlobusComputeEngine.working_dir`` now defaults to ``tasks_working_dir``
-   * When ``working_dir=relative_path``, tasks run in a path relative to the endpoint.run_dir.
-     The default is ``tasks_working_dir`` set relative to endpoint.run_dir.
-   * When ``working_dir=absolute_path``, tasks run in the specified absolute path

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.22.0"
+__version__ = "2.23.0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.22.0",
+    "globus-compute-sdk==2.23.0",
     "globus-compute-common==0.4.1",
     "globus-identity-mapping==0.3.0",
     # table printing used in list-endpoints

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.22.0"
+__version__ = "2.23.0"
 
 
 def compare_versions(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,38 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-2.23.0:
+
+globus-compute-sdk & globus-compute-endpoint v2.23.0
+------------------------------------------------------
+
+- The ``delete`` command can now delete endpoints by name or UUID from the
+  Compute service remotely when local config files are not available.  Note
+  that without the ``--force`` option the command may exit early if the
+  endpoint is currently running or local config files are corrupted.
+
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Included the paths to the ``globus-compute-endpoint`` and ``process_worker_pool.py``
+  executables in the ``self-diagnostic`` command output.
+
+Bug Fixes
+^^^^^^^^^
+
+- We no longer raise an exception when using the ``GlobusComputeEngine`` with Parsl
+  providers that do not utilize ``Channel`` objects (e.g., ``KubernetesProvider``).
+
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version to 2024.6.10.
+
+- ``GlobusComputeEngine.working_dir`` now defaults to ``tasks_working_dir``
+   * When ``working_dir=relative_path``, tasks run in a path relative to the endpoint.run_dir.
+     The default is ``tasks_working_dir`` set relative to endpoint.run_dir.
+   * When ``working_dir=absolute_path``, tasks run in the specified absolute path
+
 .. _changelog-2.22.0:
 
 globus-compute-sdk & globus-compute-endpoint v2.22.0


### PR DESCRIPTION
Collect changelog and bump versions for release

(pip-audit/lint fails until this is released as the current SDK version dependency isn't on PyPI until released)