### PR TITLE
Convert `TaskQueueSubscriber` to a thread

### DIFF
--- a/changelog.d/20240710_113622_30907815+rjmello_tqs_thread_sc_34463.rst
+++ b/changelog.d/20240710_113622_30907815+rjmello_tqs_thread_sc_34463.rst
@@ -1,0 +1,7 @@
+Bug Fixes
+^^^^^^^
+
+- Pulling tasks from RabbitMQ is now performed via a thread within the main endpoint
+  process, rather than a separate process. This reduces the endpoint's overall memory
+  footprint and fixes sporadic issues in which the formerly forked process would inherit
+  thread locks.

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -196,7 +196,7 @@ def test_no_idle_if_not_configured(
     ei = ep_ix_factory(config=mock_conf)
     ei.results_passthrough = mocker.Mock(spec=queue.Queue)
     ei.results_passthrough.get.side_effect = queue.Empty
-    ei.pending_task_queue = mocker.Mock(spec=queue.Queue)
+    ei.pending_task_queue = mocker.Mock(spec=queue.SimpleQueue)
     ei.pending_task_queue.get.side_effect = queue.Empty
     ei._quiesce_event = mock_quiesce
 
@@ -223,7 +223,7 @@ def test_soft_idle_honored(
 
     ei.results_passthrough = mocker.Mock(spec=queue.Queue)
     ei.results_passthrough.get.side_effect = (msg, queue.Empty)
-    ei.pending_task_queue = mocker.Mock(spec=queue.Queue)
+    ei.pending_task_queue = mocker.Mock(spec=queue.SimpleQueue)
     ei.pending_task_queue.get.side_effect = queue.Empty
 
     ei._quiesce_event = mock_quiesce
@@ -300,7 +300,7 @@ def test_unidle_updates_proc_title(
     ei._quiesce_event = mock_quiesce
     ei.results_passthrough = mocker.Mock(spec=queue.Queue)
     ei.results_passthrough.get.side_effect = queue.Empty
-    ei.pending_task_queue = mocker.Mock(spec=queue.Queue)
+    ei.pending_task_queue = mocker.Mock(spec=queue.SimpleQueue)
     ei.pending_task_queue.get.side_effect = queue.Empty
 
     main_thread_may_continue = threading.Event()
@@ -343,7 +343,7 @@ def test_sends_final_status_message_on_shutdown(
     ei = ep_ix_factory(config=mock_conf)
     ei.results_passthrough = mocker.Mock(spec=queue.Queue)
     ei.results_passthrough.get.side_effect = queue.Empty
-    ei.pending_task_queue = mocker.Mock(spec=queue.Queue)
+    ei.pending_task_queue = mocker.Mock(spec=queue.SimpleQueue)
     ei.pending_task_queue.get.side_effect = queue.Empty
     ei._quiesce_event = mock_quiesce
     ei._main_loop()
@@ -367,7 +367,7 @@ def test_gracefully_handles_final_status_message_timeout(
     ei = ep_ix_factory(config=mock_conf)
     ei.results_passthrough = mocker.Mock(spec=queue.Queue)
     ei.results_passthrough.get.side_effect = queue.Empty
-    ei.pending_task_queue = mocker.Mock(spec=queue.Queue)
+    ei.pending_task_queue = mocker.Mock(spec=queue.SimpleQueue)
     ei.pending_task_queue.get.side_effect = queue.Empty
     ei._quiesce_event = mock_quiesce
 
@@ -392,7 +392,7 @@ def test_faithfully_handles_status_report_messages(
 
     ep_ix.results_passthrough = mocker.Mock(spec=queue.Queue)
     ep_ix.results_passthrough.get.side_effect = (status_report_msg, queue.Empty)
-    ep_ix.pending_task_queue = mocker.Mock(spec=queue.Queue)
+    ep_ix.pending_task_queue = mocker.Mock(spec=queue.SimpleQueue)
     ep_ix.pending_task_queue.get.side_effect = queue.Empty
     ep_ix._quiesce_event = mock_quiesce
 

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import queue
 
 
 def test_simple_roundtrip(
@@ -9,24 +10,24 @@ def test_simple_roundtrip(
     start_result_q_publisher,
     randomstring,
 ):
-    task_q, result_q = multiprocessing.Queue(), multiprocessing.Queue()
+    task_q, result_q = queue.SimpleQueue(), multiprocessing.Queue()
 
     # Start the publishers *first* as that route creates the queues
     task_pub = start_task_q_publisher()
     result_pub = start_result_q_publisher()
 
-    task_sub = start_task_q_subscriber(queue=task_q)
+    task_sub = start_task_q_subscriber(task_queue=task_q)
     result_sub = start_result_q_subscriber(queue=result_q)
 
     message = f"Hello test_simple_roundtrip: {randomstring()}".encode()
     task_pub.publish(message)
-    _, task_message = task_q.get(timeout=2)
+    _, _, task_message = task_q.get(timeout=2)
     assert message == task_message
 
     result_pub.publish(task_message)
     _, result_message = result_q.get(timeout=2)
 
-    task_sub.quiesce_event.set()
+    task_sub._stop_event.set()
     result_sub.kill_event.set()
 
     _, expected = (result_pub.queue_info["test_routing_key"], message)


### PR DESCRIPTION
# Description

Pulling tasks from RabbitMQ is now performed via a thread within the main endpoint process, rather than a separate process. This reduces the endpoint's overall memory footprint and fixes sporadic issues in which the formerly forked process would inherit thread locks.

The new `TaskQueueSubscriber` follows the design and functionality of the `CommandQueueSubscriber`. I plan to move common code between these classes to a base queue subscriber class in a subsequent PR.

[sc-34463]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
