### PR TITLE
Reformat env difference warning again and link to readthedocs

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -189,7 +189,7 @@ class Client:
 
         check_result = check_version(worker_details)
         if check_result is not None:
-            logger.warning(check_result)
+            warnings.warn(check_result, UserWarning)
             self._version_mismatch_already_warned_eps.add(worker_ep_id)
 
     def _update_task_table(

--- a/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
@@ -61,9 +61,7 @@ def check_version(task_details: dict | None, check_py_micro: bool = True) -> str
     if task_details:
         worker_py = task_details.get("python_version", "UnknownPy")
         worker_dill = task_details.get("dill_version", "UnknownDill")
-        worker_os = task_details.get("os", "UnknownOS")
         worker_epid = task_details.get("endpoint_id", "<unknown>")
-        worker_sdk = task_details.get("globus_compute_sdk_version", "UnknownSDK")
         client_details = get_env_details()
 
         sdk_py = client_details["python_version"]
@@ -85,14 +83,13 @@ def check_version(task_details: dict | None, check_py_micro: bool = True) -> str
         sdk_dill = client_details["dill_version"]
         if python_mismatch or sdk_dill != worker_dill:
             return (
-                "Local SDK and remote worker execution environment differences "
-                f"detected for endpoint {worker_epid} -\n"
-                f"  SDK uses Python {sdk_py}/Dill {sdk_dill} "
-                f"but worker used {worker_py}/{worker_dill}\n"
-                f"  (worker SDK version: {worker_sdk}; worker OS: {worker_os})\n"
-                "Dill and Python version mismatches can cause issues during "
-                "function/argument (de)serialization. Globus Compute recommends "
-                "keeping them in sync."
+                "\nEnvironment differences detected between local SDK and "
+                f"endpoint {worker_epid} workers:\n"
+                f"\t    SDK: Python {sdk_py}/Dill {sdk_dill}\n"
+                f"\tWorkers: Python {worker_py}/Dill {worker_dill}\n"
+                f"This may cause serialization issues.  See "
+                "https://globus-compute.readthedocs.io/en/latest/sdk.html#avoiding-serialization-errors "  # noqa"
+                "for more information."
             )
     return None
 

--- a/compute_sdk/tests/unit/test_util.py
+++ b/compute_sdk/tests/unit/test_util.py
@@ -36,6 +36,6 @@ def test_check_py_version(mocker, sdk_py, worker_py, check_micro, should_warn):
 
     result = check_version(task_details, check_py_micro=check_micro)
     if should_warn:
-        assert result and "environment differences detected" in result
+        assert result and "Environment differences detected" in result
     else:
         assert result is None

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -327,5 +327,39 @@ the other alternatives that we currently support are ``DillTextInspect`` and
 strategies and will use the first one that deserializes successfully at
 execution time.
 
+
+Avoiding Serialization Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We strongly recommend that you use the same python version as the target
+Endpoint when using the SDK to submit new functions.
+
+The serialization/deserialization mechanics in python and the pickle/dill
+libraries are implemented at the bytecode level and have evolved extensively
+over time.  There is no backward/forward compatability guarantee between
+versions.  Thus a function serialized in an older version of python or dill
+may not deserialize correctly in later versions, and the opposite is even more
+problematic.
+
+Even a single number difference in python minor versions, ie from 3.10 --> 3.11,
+can generate issues.  Micro version differences, ie from 3.11.8 to 3.11.9,
+are mostly safe, though not universally.
+
+Errors may surface as serialization/deserialization Exceptions, Globus
+Compute task workers lost due to SEGFAULT, or even incorrect results.
+
+Note that the |Client|_ class's ``register_function()`` method can be used
+to pre-serialize a function using the registering SDK's environment and
+return a UUID identifier.   The resulting bytecode will then be deserialized
+at run time by an Endpoint whenever a task that specifies this function UUID
+is submitted (possibly from a different SDK environment) using the Client's
+``.run()`` or the Executor's ``.submit_to_registered_function()`` methods.
+On the other hand, the |Executor|_ 's ``.submit()`` takes a function argument
+and serializes a fresh copy each time it is invoked.
+
+.. |Client| replace:: ``Client``
+.. _Client: reference/client.html
+.. |Executor| replace:: ``Executor``
+.. _Executor: reference/executor.html
 .. |dill| replace:: ``dill``
 .. _dill: https://dill.readthedocs.io/en/latest/#basic-usage


### PR DESCRIPTION
# Description

As referred to in scrum, this PR shortens the previous env difference message slightly and links to a new readthedocs.io section with more details on its implication.  Feel free to comment on the wording.

Also, this changes the above's output from logger.warning() to warnings.warn() to let the user manage warnings more easily.

Example new output:
```
>>> with Executor(endpoint_id='4b116d3c-1703-4f8f-9f6f-39921e5864df') as gce:
...     fut = gce.submit(abs, -1234)
...     print(fut.result())
...
/Users/lei/glob/funcX/compute_sdk/globus_compute_sdk/sdk/client.py:192: UserWarning:
Environment differences detected between local SDK and endpoint ab77c7ab-265b-d1db-870d-9d3715242fa1 workers:
	    SDK: Python 3.10.4/Dill 0.3.5.1
	Workers: Python 3.11.8/Dill 0.3.6
This may cause serialization issues.  See https://globus-compute.readthedocs.io/en/latest/sdk.html#avoiding-serialization-errors for more information.
  warnings.warn(check_result, UserWarning)
1234
```

## Type of change

- Documentation update
- Code maintenance/cleanup
