### PR TITLE
Adding `GlobusMPIEngine` to support MPI applications

### DIFF
--- a/changelog.d/20240711_190719_yadudoc1729_mpi_engine_2.rst
+++ b/changelog.d/20240711_190719_yadudoc1729_mpi_engine_2.rst
@@ -1,0 +1,37 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Adding `GlobusMPIEngine` with better support for MPI applications.
+  `GlobusMPIEngine` uses Parsl's `MPIExecutor` under the covers to
+  dynamically partition a single batch job to schedule MPI tasks.
+
+  Here's an example endpoint configuration that uses `GlobusMPIEngine`
+
+  .. code-block:: yaml
+
+    display_name: MPIEngine@Expanse.SDSC
+    engine:
+      type: GlobusMPIEngine
+      mpi_launcher: srun
+
+      address:
+        type: address_by_interface
+        ifname: ib0
+
+      provider:
+        type: SlurmProvider
+        partition: compute
+        account: chi150
+
+        launcher:
+          type: SimpleLauncher
+
+        # Command to be run before starting a worker
+        # e.g., "module load anaconda3; source activate gce_env"
+
+        worker_init: "source ~/setup_funcx_test_env.sh"
+        nodes_per_block: 2
+        init_blocks: 0
+        min_blocks: 0
+        max_blocks: 1
+        walltime: 00:05:00

--- a/changelog.d/20240711_190719_yadudoc1729_mpi_engine_2.rst
+++ b/changelog.d/20240711_190719_yadudoc1729_mpi_engine_2.rst
@@ -1,11 +1,11 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
 
-- Adding `GlobusMPIEngine` with better support for MPI applications.
-  `GlobusMPIEngine` uses Parsl's `MPIExecutor` under the covers to
+- Adding ``GlobusMPIEngine`` with better support for MPI applications.
+  ``GlobusMPIEngine`` uses Parsl's `MPIExecutor <https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.MPIExecutor.html>`_ under the hood to
   dynamically partition a single batch job to schedule MPI tasks.
 
-  Here's an example endpoint configuration that uses `GlobusMPIEngine`
+  Here's an example endpoint configuration that uses ``GlobusMPIEngine``
 
   .. code-block:: yaml
 
@@ -14,24 +14,5 @@ New Functionality
       type: GlobusMPIEngine
       mpi_launcher: srun
 
-      address:
-        type: address_by_interface
-        ifname: ib0
-
       provider:
-        type: SlurmProvider
-        partition: compute
-        account: chi150
-
-        launcher:
-          type: SimpleLauncher
-
-        # Command to be run before starting a worker
-        # e.g., "module load anaconda3; source activate gce_env"
-
-        worker_init: "source ~/setup_funcx_test_env.sh"
-        nodes_per_block: 2
-        init_blocks: 0
-        min_blocks: 0
-        max_blocks: 1
-        walltime: 00:05:00
+         ...

--- a/compute_endpoint/globus_compute_endpoint/engines/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/__init__.py
@@ -1,10 +1,12 @@
 from .globus_compute import GlobusComputeEngine
+from .globus_mpi import GlobusMPIEngine
 from .high_throughput.engine import HighThroughputEngine
 from .process_pool import ProcessPoolEngine
 from .thread_pool import ThreadPoolEngine
 
 __all__ = (
     "GlobusComputeEngine",
+    "GlobusMPIEngine",
     "ProcessPoolEngine",
     "ThreadPoolEngine",
     "HighThroughputEngine",

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
@@ -1,0 +1,103 @@
+import os
+import typing as t
+
+from globus_compute_endpoint.engines.globus_compute import (
+    VALID_CONTAINER_TYPES,
+    GlobusComputeEngine,
+    JobStatusPollerKwargs,
+)
+from parsl.executors import MPIExecutor
+
+
+class GlobusMPIEngine(GlobusComputeEngine):
+
+    def __init__(
+        self,
+        *args,
+        label: str = "GlobusMPIEngine",
+        max_retries_on_system_failure: int = 0,
+        executor: t.Optional[MPIExecutor] = None,
+        container_type: t.Literal[VALID_CONTAINER_TYPES] = None,  # type: ignore
+        container_uri: t.Optional[str] = None,
+        container_cmd_options: t.Optional[str] = None,
+        encrypted: bool = True,
+        strategy: t.Optional[str] = None,
+        job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
+        working_dir: t.Union[str, os.PathLike] = "tasks_working_dir",
+        run_in_sandbox: bool = False,
+        **kwargs,
+    ):
+        """``GlobusMPIEngine`` is a shim over `Parsl's MPIExecutor
+        <parslmpiex_>`_, almost all of arguments are passed along, unfettered.
+        Consequently, please reference `Parsl's MPIExecutor <parslmpiex_>`_
+        documentation for a complete list of arguments; we list below only the
+        arguments specific to the ``GlobusMPIEngine``.
+
+        .. _parslmpiex: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.MPIExecutor.html
+        .. _parslstrategy: https://parsl.readthedocs.io/en/stable/stubs/parsl.jobs.strategy.Strategy.html
+        .. _parsljobstatuspoller: https://parsl.readthedocs.io/en/stable/stubs/parsl.jobs.job_status_poller.JobStatusPoller.html
+
+        Parameters
+        ----------
+
+        label: str
+           Label used to name engine log directories and batch jobs
+           default: "GlobusComputeEngine"
+
+        max_retries_on_system_failure: int
+           Set the number of retries for functions that fail due to
+           system failures such as node failure/loss. Since functions
+           can fail after partial runs, consider additional cleanup
+           logic before enabling this functionality
+           default: 0
+
+        strategy: str | None
+            Specify which scaling strategy to use; this is eventually given to
+            `Parsl's Strategy <parslstrategy_>`_.  [Deprecated; use
+            ``job_status_kwargs``]
+
+        job_status_kwargs: dict | None
+            Keyword arguments to be passed through to `Parsl's JobStatusPoller
+            <parsljobstatuspoller_>`_ class that drives strategy to do auto-scaling.
+
+        encrypted: bool
+            Flag to enable/disable encryption (CurveZMQ). Default is True.
+
+        working_dir: str | os.PathLike
+            Directory within which functions should execute, defaults to
+            (~/.globus_compute/<endpoint_name>/tasks_working_dir)
+            If a relative path is supplied, the working dir is set relative
+            to the endpoint.run_dir. If an absolute path is supplied, it is
+            used as is.
+
+        run_in_sandbox: bool
+            Functions will run in a sandbox directory under the working_dir
+            if this option is enabled. Default: False
+
+        """  # noqa: E501
+
+        if executor is None:
+            executor = MPIExecutor(  # type: ignore
+                *args,
+                label=label,
+                encrypted=encrypted,
+                **kwargs,
+            )
+        elif not isinstance(executor, MPIExecutor):
+            raise TypeError(
+                "The executor must be an instance of parsl.executors.MPIExecutor"
+            )
+
+        super().__init__(
+            label=label,
+            max_retries_on_system_failure=max_retries_on_system_failure,
+            executor=executor,
+            container_type=container_type,
+            container_uri=container_uri,
+            container_cmd_options=container_cmd_options,
+            encrypted=encrypted,
+            strategy=strategy,
+            job_status_kwargs=job_status_kwargs,
+            working_dir=working_dir,
+            run_in_sandbox=run_in_sandbox,
+        )

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
@@ -24,11 +24,11 @@ class GlobusMPIEngine(GlobusComputeEngine):
         strategy: t.Optional[str] = None,
         job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
         working_dir: t.Union[str, os.PathLike] = "tasks_working_dir",
-        run_in_sandbox: bool = False,
+        run_in_sandbox: bool = True,
         **kwargs,
     ):
         """``GlobusMPIEngine`` is a shim over `Parsl's MPIExecutor
-        <parslmpiex_>`_, almost all of arguments are passed along, unfettered.
+        <parslmpiex_>`_, and as such, all of arguments are passed along, unfettered.
         Consequently, please reference `Parsl's MPIExecutor <parslmpiex_>`_
         documentation for a complete list of arguments; we list below only the
         arguments specific to the ``GlobusMPIEngine``.
@@ -53,8 +53,7 @@ class GlobusMPIEngine(GlobusComputeEngine):
 
         strategy: str | None
             Specify which scaling strategy to use; this is eventually given to
-            `Parsl's Strategy <parslstrategy_>`_.  [Deprecated; use
-            ``job_status_kwargs``]
+            `Parsl's Strategy <parslstrategy_>`_.
 
         job_status_kwargs: dict | None
             Keyword arguments to be passed through to `Parsl's JobStatusPoller
@@ -65,14 +64,14 @@ class GlobusMPIEngine(GlobusComputeEngine):
 
         working_dir: str | os.PathLike
             Directory within which functions should execute, defaults to
-            (~/.globus_compute/<endpoint_name>/tasks_working_dir)
+            ``~/.globus_compute/<endpoint_name>/tasks_working_dir``.
             If a relative path is supplied, the working dir is set relative
-            to the endpoint.run_dir. If an absolute path is supplied, it is
+            to the ``endpoint.run_dir``. If an absolute path is supplied, it is
             used as is.
 
         run_in_sandbox: bool
-            Functions will run in a sandbox directory under the working_dir
-            if this option is enabled. Default: False
+            Functions will run in a sandbox directory under the ``working_dir``
+            if this option is enabled. Default: True
 
         """  # noqa: E501
 

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -1,13 +1,10 @@
 import random
 import uuid
-from queue import Queue
 
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import GlobusMPIEngine
 from globus_compute_sdk.serialize import ComputeSerializer
-from parsl.launchers import SimpleLauncher
-from parsl.providers import LocalProvider
 from tests.utils import ez_pack_function, get_env_vars
 
 temporary_skip = False
@@ -18,49 +15,10 @@ except ImportError:
     temporary_skip = True
 
 
-@pytest.fixture
-def nodeslist(num=100):
-    limit = random.randint(1, num)
-    yield [f"NODE{node_i}" for node_i in range(1, limit)]
-
-
-@pytest.fixture
-def mpi_engine(tmp_path, nodeslist):
-    ep_id = uuid.uuid4()
-
-    nodefile_path = tmp_path / "pbs_nodefile"
-    nodes_string = "\n".join(nodeslist)
-    worker_init = f"""
-    echo -e "{nodes_string}" > {nodefile_path} ;
-    export PBS_NODEFILE={nodefile_path}
-    """
-
-    engine = GlobusMPIEngine(
-        address="127.0.0.1",
-        heartbeat_period=1,
-        heartbeat_threshold=1,
-        max_retries_on_system_failure=0,
-        mpi_launcher="mpiexec",
-        provider=LocalProvider(
-            init_blocks=1,
-            min_blocks=1,
-            max_blocks=1,
-            worker_init=worker_init,
-            launcher=SimpleLauncher(),
-        ),
-    )
-    engine._status_report_thread.reporting_period = 1
-    queue = Queue()
-    engine.start(endpoint_id=ep_id, run_dir=tmp_path, results_passthrough=queue)
-    yield engine, nodeslist
-    engine.shutdown()
-
-
 @pytest.mark.skipif(temporary_skip, reason="Skip test until MPIFunctions are merged")
-def test_mpi_function(mpi_engine, tmp_path):
+def test_mpi_function(engine_runner, nodeslist, tmp_path):
     """Test for the right cmd being generated"""
-    engine, nodeslist = mpi_engine
-    queue = engine.results_passthrough
+    engine = engine_runner(GlobusMPIEngine)
     task_id = uuid.uuid1()
     serializer = ComputeSerializer()
 
@@ -74,30 +32,21 @@ def test_mpi_function(mpi_engine, tmp_path):
     task_message = messagepack.pack(
         messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
     )
-    engine.submit(task_id, task_message, resource_specification=resource_spec)
-    flag = False
-    for _i in range(20):
-        q_msg = queue.get(timeout=10)
-        assert isinstance(q_msg, dict)
+    future = engine.submit(task_id, task_message, resource_specification=resource_spec)
 
-        packed_result_q = q_msg["message"]
-        result = messagepack.unpack(packed_result_q)
-        if isinstance(result, messagepack.message_types.Result):
-            assert result.task_id == task_id
-            assert result.error_details is None
-            result = serializer.deserialize(result.data)
+    packed_result = future.result(timeout=10)
+    result = messagepack.unpack(packed_result)
+    assert isinstance(result, messagepack.message_types.Result)
+    assert result.task_id == task_id
+    assert result.error_details is None
+    result = serializer.deserialize(result.data)
 
-            assert isinstance(result, BashResult)
-            assert result.cmd == "$PARSL_MPI_PREFIX pwd"
-            flag = True
-            break
-
-    assert flag, "Expected result packet, but none received"
+    assert isinstance(result, BashResult)
+    assert result.cmd == "$PARSL_MPI_PREFIX pwd"
 
 
-def test_env_vars(mpi_engine, tmp_path):
-    engine, nodeslist = mpi_engine
-    queue = engine.results_passthrough
+def test_env_vars(engine_runner, nodeslist, tmp_path):
+    engine = engine_runner(GlobusMPIEngine)
     task_id = uuid.uuid1()
     serializer = ComputeSerializer()
     task_body = ez_pack_function(serializer, get_env_vars, (), {})
@@ -106,26 +55,18 @@ def test_env_vars(mpi_engine, tmp_path):
         messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
     )
     num_nodes = random.randint(1, len(nodeslist))
-    engine.submit(
+    future = engine.submit(
         task_id,
         task_message,
         resource_specification={"num_nodes": num_nodes, "num_ranks": 2},
     )
 
-    flag = False
-    for _i in range(20):
-        q_msg = queue.get(timeout=10)
-        assert isinstance(q_msg, dict)
+    packed_result = future.result(timeout=10)
+    result = messagepack.unpack(packed_result)
+    assert isinstance(result, messagepack.message_types.Result)
+    assert result.task_id == task_id
+    assert result.error_details is None
+    inner_result = serializer.deserialize(result.data)
 
-        packed_result_q = q_msg["message"]
-        result = messagepack.unpack(packed_result_q)
-        if isinstance(result, messagepack.message_types.Result):
-            assert result.task_id == task_id
-            assert result.error_details is None
-            result = serializer.deserialize(result.data)
-            assert result["PARSL_NUM_NODES"] == str(num_nodes)
-            assert result["PARSL_MPI_PREFIX"].startswith("mpiexec")
-            flag = True
-            break
-
-    assert flag, "Expected result packet, but none received"
+    assert inner_result["PARSL_NUM_NODES"] == str(num_nodes)
+    assert inner_result["PARSL_MPI_PREFIX"].startswith("mpiexec")

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -1,0 +1,125 @@
+import random
+import uuid
+from queue import Queue
+
+import pytest
+from globus_compute_common import messagepack
+from globus_compute_endpoint.engines import GlobusMPIEngine
+from globus_compute_sdk.sdk.bash_function import BashResult
+from globus_compute_sdk.sdk.mpi_function import MPIFunction
+from globus_compute_sdk.serialize import ComputeSerializer
+from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
+from tests.utils import ez_pack_function, get_env_vars
+
+
+@pytest.fixture
+def nodeslist(num=100):
+    limit = random.randint(1, num)
+    yield [f"NODE{node_i}" for node_i in range(1, limit)]
+
+
+@pytest.fixture
+def mpi_engine(tmp_path, nodeslist):
+    ep_id = uuid.uuid4()
+
+    nodefile_path = tmp_path / "pbs_nodefile"
+    nodes_string = "\n".join(nodeslist)
+    worker_init = f"""
+    echo -e "{nodes_string}" > {nodefile_path} ;
+    export PBS_NODEFILE={nodefile_path}
+    """
+
+    engine = GlobusMPIEngine(
+        address="127.0.0.1",
+        heartbeat_period=1,
+        heartbeat_threshold=1,
+        max_retries_on_system_failure=0,
+        mpi_launcher="mpiexec",
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=1,
+            max_blocks=1,
+            worker_init=worker_init,
+            launcher=SimpleLauncher(),
+        ),
+    )
+    engine._status_report_thread.reporting_period = 1
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=tmp_path, results_passthrough=queue)
+    yield engine, nodeslist
+    engine.shutdown()
+
+
+def test_mpi_function(mpi_engine, tmp_path):
+    """Test for the right cmd being generated"""
+    engine, nodeslist = mpi_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+
+    num_nodes = random.randint(1, len(nodeslist))
+    resource_spec = {"num_nodes": num_nodes, "num_ranks": random.randint(1, 4)}
+
+    mpi_func = MPIFunction("pwd", resource_specification=resource_spec)
+    task_body = ez_pack_function(
+        serializer, mpi_func, (), {"resource_specification": resource_spec}
+    )
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message, resource_specification=resource_spec)
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            result = serializer.deserialize(result.data)
+
+            assert isinstance(result, BashResult)
+            assert result.cmd == "$PARSL_MPI_PREFIX pwd"
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"
+
+
+def test_env_vars(mpi_engine, tmp_path):
+    engine, nodeslist = mpi_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(serializer, get_env_vars, (), {})
+
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    num_nodes = random.randint(1, len(nodeslist))
+    engine.submit(
+        task_id,
+        task_message,
+        resource_specification={"num_nodes": num_nodes, "num_ranks": 2},
+    )
+
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            result = serializer.deserialize(result.data)
+            assert result["PARSL_NUM_NODES"] == str(num_nodes)
+            assert result["PARSL_MPI_PREFIX"].startswith("mpiexec")
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -5,12 +5,17 @@ from queue import Queue
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import GlobusMPIEngine
-from globus_compute_sdk.sdk.bash_function import BashResult
-from globus_compute_sdk.sdk.mpi_function import MPIFunction
 from globus_compute_sdk.serialize import ComputeSerializer
 from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
 from tests.utils import ez_pack_function, get_env_vars
+
+temporary_skip = False
+try:
+    from globus_compute_sdk.sdk.bash_function import BashResult
+    from globus_compute_sdk.sdk.mpi_function import MPIFunction
+except ImportError:
+    temporary_skip = True
 
 
 @pytest.fixture
@@ -51,6 +56,7 @@ def mpi_engine(tmp_path, nodeslist):
     engine.shutdown()
 
 
+@pytest.mark.skipif(temporary_skip, reason="Skip test until MPIFunctions are merged")
 def test_mpi_function(mpi_engine, tmp_path):
     """Test for the right cmd being generated"""
     engine, nodeslist = mpi_engine

--- a/docs/endpoints/configs/expanse_mpi.yaml
+++ b/docs/endpoints/configs/expanse_mpi.yaml
@@ -1,9 +1,8 @@
-display_name: Expanse@SDSC
+display_name: ExpanseMPI@SDSC
 
 engine:
-    type: GlobusComputeEngine
-    max_workers_per_node: 2
-    worker_debug: False
+    type: GlobusMPIEngine
+    mpi_launcher: srun
 
     address:
         type: address_by_interface
@@ -15,7 +14,7 @@ engine:
         account: {{ ACCOUNT }}
 
         launcher:
-            type: SrunLauncher
+            type: SimpleLauncher
 
         # string to prepend to #SBATCH blocks in the submit
         # script to the scheduler
@@ -26,6 +25,7 @@ engine:
         # e.g., "module load anaconda3; source activate gce_env"
         worker_init: {{ COMMAND }}
 
+        nodes_per_block: 4
         init_blocks: 0
         min_blocks: 0
         max_blocks: 1

--- a/docs/endpoints/endpoint_examples.rst
+++ b/docs/endpoints/endpoint_examples.rst
@@ -121,6 +121,14 @@ scheduler, and uses the ``SrunLauncher`` to launch workers.
 .. literalinclude:: configs/expanse.yaml
    :language: yaml
 
+The |GlobusMPIEngine|_ adds support for running MPI applications. The following snippet
+shows an example configure for Expanse that uses the ``SlurmProvider`` to provision
+batch jobs each with 4 nodes, which can be dynamically partitioned to launch
+MPI functions with ``srun``.
+
+.. literalinclude:: configs/expanse_mpi.yaml
+   :language: yaml
+
 
 UChicago AI Cluster
 ^^^^^^^^^^^^^^^^^^^
@@ -287,3 +295,5 @@ specific identity assigned: ``CUDA_VISIBLE_DEVICES``, ``ROCR_VISIBLE_DEVICES``,
 
 .. |Providers| replace:: ``Providers``
 .. _Providers: https://parsl.readthedocs.io/en/stable/reference.html#providers
+.. |GlobusMPIEngine| replace:: ``GlobusMPIEngine``
+.. _GlobusMPIEngine: reference/mpi_engine.html

--- a/docs/endpoints/endpoint_examples.rst
+++ b/docs/endpoints/endpoint_examples.rst
@@ -122,7 +122,7 @@ scheduler, and uses the ``SrunLauncher`` to launch workers.
    :language: yaml
 
 The |GlobusMPIEngine|_ adds support for running MPI applications. The following snippet
-shows an example configure for Expanse that uses the ``SlurmProvider`` to provision
+shows an example configuration for Expanse that uses the ``SlurmProvider`` to provision
 batch jobs each with 4 nodes, which can be dynamically partitioned to launch
 MPI functions with ``srun``.
 

--- a/docs/reference/engine.rst
+++ b/docs/reference/engine.rst
@@ -4,4 +4,3 @@ The Globus Compute Engine
 .. autoclass:: globus_compute_endpoint.engines.GlobusComputeEngine
     :members:
     :member-order: bysource
-

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,3 +9,4 @@ Globus Compute SDK
     executor
     client
     engine
+    mpi_engine

--- a/docs/reference/mpi_engine.rst
+++ b/docs/reference/mpi_engine.rst
@@ -1,0 +1,6 @@
+The Globus MPI Engine
+===========================
+
+.. autoclass:: globus_compute_endpoint.engines.GlobusMPIEngine
+    :members:
+    :member-order: bysource


### PR DESCRIPTION
# Description

This PR adds support for `GlobusMPIEngine` with better support for MPI applications.
`GlobusMPIEngine` uses Parsl's `MPIExecutor` under the covers to dynamically partition a single batch job to schedule MPI tasks. I'm not adding integration tests that confirm proper MPI launches since those exist in Parsl, and tend to be really slow.

Here's an example endpoint configuration that uses `GlobusMPIEngine`

``` yaml
    display_name: MPIEngine@Expanse.SDSC
    engine:
      type: GlobusMPIEngine
      mpi_launcher: srun

      address:
        type: address_by_interface
        ifname: ib0

      provider:
        type: SlurmProvider
        partition: compute
        account: chi150

        launcher:
          type: SimpleLauncher

        # Command to be run before starting a worker
        # e.g., "module load anaconda3; source activate gce_env"
        worker_init: "source ~/setup_funcx_test_env.sh"
        nodes_per_block: 2
        init_blocks: 0
        min_blocks: 0
        max_blocks: 1
        walltime: 00:05:00
```

Fixes # (issue)
[sc-32391]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
