### PR TITLE
Drop support for Python3.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior, for e.g:
-1. Install globus-compute-sdk==2.0.0 and globus-compute-endpoint==2.0.0 with Python 3.7 on cluster
+1. Install globus-compute-sdk==2.0.0 and globus-compute-endpoint==2.0.0 with Python 3.10 on cluster
 2. Run a test script
 3. Wait 5 mins
 4. See error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Quickstart
 
 Globus Compute is currently available on PyPI.
 
-To install Globus Compute, please ensure you have python3.7+.::
+To install Globus Compute, please ensure you have python3.8+.::
 
    $ python3 --version
 

--- a/changelog.d/20240731_163659_yadudoc1729_update_sdk_to_drop_py3_7.rst
+++ b/changelog.d/20240731_163659_yadudoc1729_update_sdk_to_drop_py3_7.rst
@@ -1,0 +1,7 @@
+Deprecated
+^^^^^^^^^^
+
+- ``globus-compute-sdk`` and ``globus-compute-endpoint`` drop support for Python3.7.
+  Python3.7 reached `end-of-life on 2023-06-27 <https://devguide.python.org/versions/>`_. We discontinue support for
+  Python3.7 since Parsl, an upstream core dependency, has also dropped support for
+  it (in ``parsl==2024.7.1``).

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -74,7 +74,7 @@ setup(
     extras_require={
         "test": TEST_REQUIRES,
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -79,7 +79,7 @@ setup(
         "test": TEST_REQUIRES,
         "docs": DOCS_REQUIRES,
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
# Description

We are well over a year since Python3.7 reached EOL (2023-06-27). Parsl now only supports 3.8+. 
This PR drops support for support for 3.7 and removes 3.7 from test targets in CI.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
