### PR TITLE
Make python-exec replace the existing process

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -5,10 +5,10 @@ import difflib
 import gzip
 import json
 import logging
+import os
 import pathlib
 import re
 import shutil
-import subprocess
 import sys
 import textwrap
 import uuid
@@ -924,7 +924,7 @@ def run_python_executable(ctx: click.Context, module: str):
 
     E.g., globus-compute-endpoint python-exec path.to.module --ahoy matey
     """
-    subprocess.run([sys.executable, "-m", module] + ctx.args)
+    os.execvpe(sys.executable, [sys.executable, "-m", module] + ctx.args, os.environ)
 
 
 def create_or_choose_auth_project(ac: AuthClient) -> str:

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -808,10 +808,12 @@ _test_name_or_uuid_decorator__data = [
 
 
 def test_python_exec(mocker: MockFixture, run_line: t.Callable):
-    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_execvpe = mocker.patch("os.execvpe")
     run_line("python-exec path.to.module arg --option val")
-    mock_subprocess_run.assert_called_with(
-        [sys.executable, "-m", "path.to.module", "arg", "--option", "val"]
+    mock_execvpe.assert_called_with(
+        sys.executable,
+        [sys.executable, "-m", "path.to.module", "arg", "--option", "val"],
+        os.environ,
     )
 
 


### PR DESCRIPTION
# Description

The `python-exec` CLI command now uses `execvpe` to replace the existing process rather than launch an additional subprocess. This reduces some process complexity and ensures that signals make it to their intended destination.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
