### PR TITLE
Bump parsl dependency to v2024.8.5

### DIFF
--- a/changelog.d/20240807_114300_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20240807_114300_30907815+rjmello_HEAD.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version to 2024.8.5.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -409,11 +409,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
 
     def scale_out(self, blocks: int):
         logger.info(f"Scaling out {blocks} blocks")
-        return self.executor.scale_out(blocks=blocks)
+        return self.executor.scale_out_facade(n=blocks)
 
     def scale_in(self, blocks: int):
         logger.info(f"Scaling in {blocks} blocks")
-        return self.executor.scale_in(blocks=blocks)
+        return self.executor.scale_in_facade(n=blocks)
 
     def _handle_task_exception(
         self,

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -130,6 +130,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 **kwargs,
             )
         self.executor = executor
+        self.executor.interchange_launch_cmd = self._get_compute_ix_launch_cmd()
         self.executor.launch_cmd = self._get_compute_launch_cmd()
 
         self.working_dir = working_dir
@@ -153,6 +154,17 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
     @property
     def encrypted(self):
         return self.executor.encrypted
+
+    def _get_compute_ix_launch_cmd(self) -> t.List[str]:
+        """Returns an endpoint CLI command to launch Parsl's interchange process,
+        rather than rely on Parsl's interchange.py command. This helps to minimize
+        PATH-related issues.
+        """
+        return [
+            "globus-compute-endpoint",
+            "python-exec",
+            "parsl.executors.high_throughput.interchange",
+        ]
 
     def _get_compute_launch_cmd(self) -> str:
         """Modify the launch command so that we launch the worker pool via the

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.6.10",
+    "parsl==2024.8.5",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
# Description

Bumping parsl to version 2024.8.5 required a couple of changes:
- Parsl's `HighThroughputExecutor` now launches its interchange process via the `interchange.py` command. To avoid PATH-related issues, we utilize our `python-exec` endpoint CLI command to launch the interchange, as we do for the process worker pool.
- Updated the `GlobusComputeEngine` to use the `scale_out_facade` and `scale_in_facade` methods from Parsl's `HighThroughputExecutor`, which are now intended for external use.

[sc-34891]

## Type of change

- Code maintenance/cleanup
