### PR TITLE
Remove remote whitelist commands

### DIFF
--- a/changelog.d/20240811_174452_chris_remove_whitelist.rst
+++ b/changelog.d/20240811_174452_chris_remove_whitelist.rst
@@ -1,0 +1,13 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added ``Client.get_allowed_functions`` for retrieving the list of functions that are
+  allowed to be executed on an endpoint.
+
+Removed
+^^^^^^^
+
+- The ``add_to_whitelist``, ``delete_from_whitelist``, and ``get_whitelist`` functions
+  have been removed from the ``Client``. Use the ``allowed_functions`` endpoint config
+  option instead of the add/remove functions, and ``Client.get_allowed_functions``
+  instead of ``get_whitelist``.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -743,6 +743,20 @@ class Client:
             raise SystemError(message)
 
     @requires_login
+    def get_allowed_functions(self, endpoint_id: UUID_LIKE_T):
+        """List the functions that are allowed to execute on this endpoint
+        Parameters
+        ----------
+        endpoint_id : UUID | str
+            The ID of the endpoint
+        Returns
+        -------
+        json
+            The response of the request
+        """
+        return self.web_client.get_allowed_functions(endpoint_id).data
+
+    @requires_login
     def stop_endpoint(self, endpoint_id: str):
         """Stop an endpoint by dropping it's active connections.
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -743,63 +743,6 @@ class Client:
             raise SystemError(message)
 
     @requires_login
-    def add_to_whitelist(self, endpoint_id, function_ids):
-        """Adds the function to the endpoint's whitelist
-
-        Parameters
-        ----------
-        endpoint_id : str
-            The uuid of the endpoint
-        function_ids : list
-            A list of function id's to be whitelisted
-
-        Returns
-        -------
-        json
-            The response of the request
-        """
-        return self.web_client.whitelist_add(endpoint_id, function_ids)
-
-    @requires_login
-    def get_whitelist(self, endpoint_id):
-        """List the endpoint's whitelist
-
-        Parameters
-        ----------
-        endpoint_id : str
-            The uuid of the endpoint
-
-        Returns
-        -------
-        json
-            The response of the request
-        """
-        return self.web_client.get_whitelist(endpoint_id)
-
-    @requires_login
-    def delete_from_whitelist(self, endpoint_id, function_ids):
-        """List the endpoint's whitelist
-
-        Parameters
-        ----------
-        endpoint_id : str
-            The uuid of the endpoint
-        function_ids : list
-            A list of function id's to be whitelisted
-
-        Returns
-        -------
-        json
-            The response of the request
-        """
-        if not isinstance(function_ids, list):
-            function_ids = [function_ids]
-        res = []
-        for fid in function_ids:
-            res.append(self.web_client.whitelist_remove(endpoint_id, fid))
-        return res
-
-    @requires_login
     def stop_endpoint(self, endpoint_id: str):
         """Stop an endpoint by dropping it's active connections.
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -242,6 +242,11 @@ class WebClient(globus_sdk.BaseClient):
     def get_function(self, function_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
         return self.get(f"/v2/functions/{function_id}")
 
+    def get_allowed_functions(
+        self, endpoint_id: UUID_LIKE_T
+    ) -> globus_sdk.GlobusHTTPResponse:
+        return self.get(f"/v3/endpoints/{endpoint_id}/allowed_functions")
+
     def stop_endpoint(self, endpoint_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
         return self.post(f"/v2/endpoints/{endpoint_id}/lock", data={})
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -242,22 +242,6 @@ class WebClient(globus_sdk.BaseClient):
     def get_function(self, function_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
         return self.get(f"/v2/functions/{function_id}")
 
-    def get_whitelist(self, endpoint_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
-        return self.get(f"/v2/endpoints/{endpoint_id}/whitelist")
-
-    def whitelist_add(
-        self, endpoint_id: UUID_LIKE_T, function_ids: t.Iterable[UUID_LIKE_T]
-    ) -> globus_sdk.GlobusHTTPResponse:
-        if isinstance(function_ids, str):
-            function_ids = [function_ids]
-        data = {"func": [str(f) for f in function_ids]}
-        return self.post(f"/v2/endpoints/{endpoint_id}/whitelist", data=data)
-
-    def whitelist_remove(
-        self, endpoint_id: UUID_LIKE_T, function_id: UUID_LIKE_T
-    ) -> globus_sdk.GlobusHTTPResponse:
-        return self.delete(f"/v2/endpoints/{endpoint_id}/whitelist/{function_id}")
-
     def stop_endpoint(self, endpoint_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
         return self.post(f"/v2/endpoints/{endpoint_id}/lock", data={})
 

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -327,6 +327,15 @@ def test_get_function(gcc):
     gcc.web_client.get_function.assert_called_with(func_uuid_str)
 
 
+def test_get_allowed_functions(gcc):
+    ep_uuid_str = str(uuid.uuid4())
+    gcc.web_client = mock.MagicMock()
+
+    gcc.get_allowed_functions(ep_uuid_str)
+
+    gcc.web_client.get_allowed_functions.assert_called_with(ep_uuid_str)
+
+
 def test_delete_function(gcc):
     func_uuid_str = str(uuid.uuid4())
     gcc.web_client = mock.MagicMock()

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -142,6 +142,20 @@ def test_get_function(client: WebClient, randomstring: t.Callable):
     assert res["some_key"] == expected_response
 
 
+def test_get_allowed_functions(client: WebClient, randomstring: t.Callable):
+    ep_uuid_str = str(uuid.uuid4())
+    expected_response = randomstring()
+    responses.add(
+        responses.GET,
+        f"{_BASE_URL}/v3/endpoints/{ep_uuid_str}/allowed_functions",
+        json={"some_key": expected_response},
+    )
+
+    res = client.get_allowed_functions(ep_uuid_str)
+
+    assert res["some_key"] == expected_response
+
+
 def test_delete_function(client: WebClient, randomstring: t.Callable):
     func_uuid_str = str(uuid.uuid4())
     expected_response = randomstring()


### PR DESCRIPTION
# Description

With the config-based `allowed_functions` feature, managing endpoint allow-lists via `add_to_whitelist` and `delete_from_whitelist` does not work as expected. Since `allowed_functions` is the recommended route, this simply removes those broken features.

[[sc-34835]](https://app.shortcut.com/globus/story/34835/remove-remote-whitelist-commands-from-sdk-and-api)

## Type of change

- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintenance/cleanup
