### PR TITLE
update parsl to latest to avoid cryptography version warning

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.8.5",
+    "parsl==2024.8.12",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
The latest globus-compute-endpoint, which upgraded to a more recent version of parsl, started generating this error message on endpoint CLI commands:

```
/opt/globus-compute-agent/venv-py39/lib/python3.9/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES a
nd will be removed from this module in 48.0.0.                                                                                                                                                               
  "cipher": algorithms.TripleDES,                                                                                                                                                                            
/opt/globus-compute-agent/venv-py39/lib/python3.9/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.Triple
DES and will be removed from this module in 48.0.0.                                                                                                                                                          
  "class": algorithms.TripleDES,                                                                                                                                                                             
Created multi-user profile for endpoint named <some-endpoint-name>  
```

This was observed with 3.9, 3.12, and some environments of 3.10.

See slack thread with more context: https://funcx.slack.com/archives/C016JMYST9C/p1723232785192439

The temporary solution was to pin cryptography to a lower version until the [parsl issue](https://github.com/Parsl/parsl/issues/3515) with PR  [parsl #3569](https://github.com/Parsl/parsl/pull/3569) is deployed and Compute updates our parsl version to it. 

***Update***
42.0.0 triggered a pip-audit security warning, so instead of pinning cryptography, updated to parsl 2024.8.12 that no longer depends on it.


