### PR TITLE
Include config file content in EP registration

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -229,3 +229,6 @@ class Config(RepresentationMixin):
 
         # Misc info
         self.display_name = display_name
+
+        # Used to store the raw content of the YAML or Python config file
+        self.source_content: str | None = None

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -870,6 +870,7 @@ class Endpoint:
             "hostname": socket.getfqdn(),
             # should be more accurate than `getpass.getuser()` in non-login situations
             "local_user": pwd.getpwuid(os.getuid()).pw_name,
+            "endpoint_config": config.source_content,
         }
 
         try:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -307,6 +307,7 @@ class EndpointManager:
             "hostname": socket.getfqdn(),
             "local_user": pwd.getpwuid(os.getuid()).pw_name,
             "config": serialize_config(config),
+            "endpoint_config": config.source_content,
             "user_config_template": user_config_template,
             "user_config_schema": user_config_schema,
         }

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -234,10 +234,11 @@ def test_start_ep_reads_stdin(
 ):
     data_is_valid, data = stdin_data
 
+    conf = Config()
     mock_load_conf = mocker.patch(f"{_MOCK_BASE}load_config_yaml")
-    mock_load_conf.return_value = Config()
+    mock_load_conf.return_value = conf
     mock_get_config = mocker.patch(f"{_MOCK_BASE}get_config")
-    mock_get_config.return_value = Config()
+    mock_get_config.return_value = conf
 
     mock_log = mocker.patch(f"{_MOCK_BASE}log")
     mock_sys = mocker.patch(f"{_MOCK_BASE}sys")
@@ -495,9 +496,9 @@ def test_start_ep_incorrect_config_py(
     assert "modified incorrectly?" in res.stderr
 
 
-@mock.patch("globus_compute_endpoint.endpoint.config.utils._read_config_yaml")
+@mock.patch("globus_compute_endpoint.endpoint.config.utils.load_config_yaml")
 def test_start_ep_config_py_takes_precedence(
-    read_config, run_line, mock_cli_state, make_endpoint_dir, ep_name
+    load_config_yaml, run_line, mock_cli_state, make_endpoint_dir, ep_name
 ):
     ep_dir = make_endpoint_dir()
     conf_py = ep_dir / "config.py"
@@ -509,7 +510,7 @@ def test_start_ep_config_py_takes_precedence(
 
     run_line(f"start {ep_name}")
     assert mock_ep.start_endpoint.called
-    assert not read_config.called, "Key outcome: config.py takes precendence"
+    assert not load_config_yaml.called, "Key outcome: config.py takes precedence"
 
 
 def test_single_user_requires_engine_configured(mock_command_ensure, ep_name, run_line):

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -17,9 +17,6 @@ import pytest
 import responses
 from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import Config
-from globus_compute_endpoint.endpoint.config.default_config import (
-    config as default_config,
-)
 from globus_compute_endpoint.endpoint.config.utils import (
     get_config,
     load_user_config_template,
@@ -512,11 +509,14 @@ def test_endpoint_get_metadata(mocker):
     mock_pwuid = mocker.patch("globus_compute_endpoint.endpoint.endpoint.pwd.getpwuid")
     mock_pwuid.return_value = SimpleNamespace(pw_name=mock_data["local_user"])
 
-    meta = Endpoint.get_metadata(default_config)
+    test_config = Config()
+    test_config.source_content = "foo: bar"
+    meta = Endpoint.get_metadata(test_config)
 
     for k, v in mock_data.items():
         assert meta[k] == v
 
+    assert meta["endpoint_config"] == test_config.source_content
     config = meta["config"]
     assert len(config["executors"]) == 1
     assert config["executors"][0]["type"] == "GlobusComputeEngine"

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -430,6 +430,7 @@ def test_sends_data_during_registration(
     ep_uuid, mock_gcc = mock_client
     mock_conf.multi_user = True
     mock_conf.public = public
+    mock_conf.source_content = "foo: bar"
     EndpointManager(conf_dir, ep_uuid, mock_conf)
 
     assert mock_gcc.register_endpoint.called
@@ -452,6 +453,7 @@ def test_sends_data_during_registration(
         "hostname",
         "local_user",
         "config",
+        "endpoint_config",
         "user_config_template",
         "user_config_schema",
     }
@@ -469,6 +471,7 @@ def test_sends_data_during_registration(
     assert k["public"] is mock_conf.public
     assert k["multi_user"] is True
     assert k["metadata"]["config"]["multi_user"] is True
+    assert k["metadata"]["endpoint_config"] == mock_conf.source_content
 
 
 def test_handles_network_error_scriptably(


### PR DESCRIPTION
# Description

The endpoint registration API route now accepts the endpoint's raw configuration file content as a string for UI display purposes. We will keep the JSON object config field in place until the web app team has started using the new field.

[sc-33036]

## Type of change

- New feature (non-breaking change that adds functionality)
