### PR TITLE
un-pin websockets dependency

### DIFF
--- a/changelog.d/20240814_085854_dmcreynolds_websockets_dep.rst
+++ b/changelog.d/20240814_085854_dmcreynolds_websockets_dep.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Loosened globus_comput_sdk websockets dependency from ==10.3 to >=10.3

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     "globus-sdk>=3.35.0,<4",
     "globus-compute-common==0.4.1",
     # 'websockets' is used for the client-side websocket listener
-    "websockets==10.3",
+    "websockets>=10.3",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy


### PR DESCRIPTION
# Description
The pinning of websocksets in the `compute-sdk` package is to an exact version, which is now a few years old. We are using the globus-compute-sdk package within a project that uses another package which itself uses websocksets, and [requires >=10.4](https://github.com/PrefectHQ/prefect/blob/bc2796eb6193d29c230b7c5599a57a4c2dfa9c3d/requirements-client.txt#L38)


Fixes # (issue)
Fixes #1624 
## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
