### PR TITLE
Remove no-longer-needed dependency

### DIFF
--- a/changelog.d/20240814_122332_kevin_remove_websockets_from_dependency.rst
+++ b/changelog.d/20240814_122332_kevin_remove_websockets_from_dependency.rst
@@ -1,0 +1,5 @@
+Removed
+^^^^^^^
+
+- Remove forgotten ``webockets`` dependency from setup requirements; the SDK
+  does not use the websockets library as of :ref:`v2.3.0 changelog-2.3.0`.

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -9,8 +9,6 @@ REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk>=3.35.0,<4",
     "globus-compute-common==0.4.1",
-    # 'websockets' is used for the client-side websocket listener
-    "websockets==10.3",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy


### PR DESCRIPTION
We removed the last vestigial use of websockets in July 2023:

    commit dacdc8ee6fccbc2f77a3d478860a3231ce77cb58
    Date:   Tue Jul 25 14:22:04 2023 -0500

        Remove deprecated "asynchronous" mode from Client

This was a forgotten dependency removal.

With thanks to @dylanmcreynolds for pointing this out.

Fixes #1624
Closes #1626

## Type of change

- Code maintenance/cleanup