### PR TITLE
Fix broken MPI test

### DIFF
--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -112,7 +112,7 @@ def engine_heartbeat() -> int:
 
 @pytest.fixture
 def nodeslist(num=100):
-    limit = random.randint(1, num)
+    limit = random.randint(2, num)
     yield [f"NODE{node_i}" for node_i in range(1, limit)]
 
 


### PR DESCRIPTION
As evidenced by a recent CI failure, the tests expecta `nodeslist` to be a list of least 1 item in length.  As written, there's 1 in 99 change that it doesn't:

```python
limit = random.randint(1, 100)  # but say limit yields 1, then:
yield [f"NODE{node_i}" for node_i in range(1, limit)]  # is an empty list.  DOH!
```

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup