### PR TITLE
Update Midway config examples

### DIFF
--- a/docs/endpoints/configs/midway.yaml
+++ b/docs/endpoints/configs/midway.yaml
@@ -1,9 +1,7 @@
-label: Midway@RCC.UChicago
-
 engine:
     type: GlobusComputeEngine
+    label: Midway@RCC.UChicago
     max_workers_per_node: 2
-    worker_debug: False
 
     address:
         type: address_by_interface
@@ -11,20 +9,23 @@ engine:
 
     provider:
         type: SlurmProvider
-        partition: caslake
-
-        account: {{ ACCOUNT }}
 
         launcher:
             type: SrunLauncher
 
+        # e.g., pi-compute
+        account: {{ ACCOUNT }}
+
+        # e.g., caslake
+        partition: {{ PARTITION }}
+
         # string to prepend to #SBATCH blocks in the submit
         # script to the scheduler
-        # e.g., "#SBATCH --constraint=knl,quad,cache"
+        # e.g., "#SBATCH --gres=gpu:4"
         scheduler_options: {{ OPTIONS }}
 
         # Command to be run before starting a worker
-        # e.g., module load Anaconda; source activate parsl_env
+        # e.g., "module load Anaconda; source activate compute-env"
         worker_init: {{ COMMAND }}
 
         # Scale between 0-1 blocks with 2 nodes per block

--- a/docs/endpoints/configs/midway_apptainer.yaml
+++ b/docs/endpoints/configs/midway_apptainer.yaml
@@ -1,30 +1,35 @@
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
+    label: Midway@RCC.UChicago
     max_workers_per_node: 10
 
     address:
         type: address_by_interface
         ifname: bond0
 
-    scheduler_mode: soft
-    worker_mode: singularity_reuse
-    container_type: singularity
+    container_type: apptainer
     container_cmd_options: -H /home/$USER
+    container_uri: {{ CONTAINER_URI }}
 
     provider:
         type: SlurmProvider
-        partition: broadwl
 
         launcher:
             type: SrunLauncher
 
+        # e.g., pi-compute
+        account: {{ ACCOUNT }}
+
+        # e.g., caslake
+        partition: {{ PARTITION }}
+
         # string to prepend to #SBATCH blocks in the submit
         # script to the scheduler
-        # eg: "#SBATCH --constraint=knl,quad,cache"
+        # e.g., "#SBATCH --gres=gpu:4"
         scheduler_options: {{ OPTIONS }}
 
         # Command to be run before starting a worker
-        # e.g., "module load Anaconda; source activate parsl_env"
+        # e.g., "module load Anaconda; source activate compute-env"
         worker_init: {{ COMMAND }}
 
         # Scale between 0-1 blocks with 2 nodes per block

--- a/docs/endpoints/endpoint_examples.rst
+++ b/docs/endpoints/endpoint_examples.rst
@@ -164,9 +164,10 @@ uses the ``SlurmProvider`` to interface with the scheduler, and uses the
 .. literalinclude:: configs/midway.yaml
    :language: yaml
 
-The following configuration is an example to use singularity container on Midway.
+The following configuration example uses an Apptainer (formerly Singularity) container
+on Midway.
 
-.. literalinclude:: configs/midway_singularity.yaml
+.. literalinclude:: configs/midway_apptainer.yaml
    :language: yaml
 
 


### PR DESCRIPTION
# Description

This PR makes a number of updates to the Midway container configuration examples. Notably, it updates the container example to use `GlobusComputeEngine` instead of `HighThroughputEngine` and sets the container type to Apptainer, reflecting Singularity's renaming in 2021.

## Type of change

- Documentation update
