### PR TITLE
Test-await the thing under test

### DIFF
--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
@@ -174,7 +174,7 @@ def test_connection_closed_shuts_down(start_task_q_subscriber):
 
 def test_channel_closed_retries_then_shuts_down(start_task_q_subscriber):
     tqs: TaskQueueSubscriber = start_task_q_subscriber()
-    try_assert(lambda: tqs._connection, "Ensure we establish a connection")
+    try_assert(lambda: tqs._channel, "Ensure we establish a connection")
 
     for i in range(1, tqs.channel_close_window_limit):
         tqs._on_channel_closed(tqs._channel, MemoryError())


### PR DESCRIPTION
Copy pasta oversight, I suspect.  In short, the `_channel` is the structure under test, so await its existence before continuing.  Else, it's a race-condition of whether that points to a None, or a test-expected structure.

## Type of change

- Bug fix (non-breaking change that fixes an issue)