### PR TITLE
Hotfix(v2.27.1): Set upper bound for `pyzmq` to avoid bug

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.27.0"
+__version__ = "2.27.1"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.27.0",
+    "globus-compute-sdk==2.27.1",
     "globus-compute-common==0.4.1",
     "globus-identity-mapping==0.3.0",
     # table printing used in list-endpoints
@@ -31,7 +31,7 @@ REQUIRES = [
     # building from source, which may mean there's an issue in the packaged library
     # further investigation may be needed if the issue persists in the next pyzmq
     # release
-    "pyzmq>=22.0.0,!=22.3.0,<27.0.0",
+    "pyzmq>=22.0.0,!=22.3.0,<=26.1.0",
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.27.0"
+__version__ = "2.27.1"
 
 
 def compare_versions(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,16 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-2.27.1:
+
+globus-compute-sdk & globus-compute-endpoint v2.27.1
+----------------------------------------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Set upper bound for ``pyzmq`` dependency to ``v26.1.0`` to avoid bug with ``libzmq`` installation.
+
 .. _changelog-2.27.0:
 
 globus-compute-sdk & globus-compute-endpoint v2.27.0


### PR DESCRIPTION
# Description

Version 26.1.1 of `pyzmq` manually sets the LDFLAGS environment variable during the `libzmq` installation process, causing installation failures on some systems. To prevent these issues, we set the upper bound for `pyzmq` to 26.1.0 until `pyzmq` developers resolve the bug.

Ref: https://github.com/zeromq/pyzmq/pull/2014

## Type of change

- Bug fix (non-breaking change that fixes an issue)
