### PR TITLE
Update CI job timing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
What was once plenty/an overkill amount of time is apparently biting us on "slow network days."  So, bump this value just a smidgen.

## Type of change

- Code maintenance/cleanup