### PR TITLE
Write std streams to log; don't ignore

### DIFF
--- a/changelog.d/20240822_230438_kevin_redirect_stdstreams_to_eplog.rst
+++ b/changelog.d/20240822_230438_kevin_redirect_stdstreams_to_eplog.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The multi-user endpoint now saves user-endpoint standard file streams (aka
+  ``stdout`` and ``stderr``) to the UEP's ``endpoint.log``.  This makes it much
+  easier to identity implementation missteps that affect the early UEP boot
+  process, before the UEP's logging is bootstrapped.


### PR DESCRIPTION
Update MEP logic to direct UEP `stdout` and `stderr` to the `endpoint.log` file rather than the dev null.  This will aid (has already aided) in bootstrap debugging the MEP/UEP deployment experience.

[sc-35380]

## Type of change

- New feature (non-breaking change that adds functionality)