### PR TITLE
Move conf debug emission to preexec

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -677,6 +677,7 @@ def _do_start_endpoint(
                 ep_config = load_config_yaml(config_str)
             else:
                 ep_config = get_config(ep_dir)
+            del config_str
 
             if not state.debug and ep_config.debug:
                 setup_logging(
@@ -685,17 +686,6 @@ def _do_start_endpoint(
                     console_enabled=state.log_to_console,
                     no_color=state.no_color,
                 )
-                if config_str is not None:
-                    num_lines = config_str.count("\n") + 1  # +1 == 0-based
-                    _rendered_config = config_str.replace("\n", "\n  | ")
-
-                    log.debug(
-                        f"Begin Compute endpoint configuration ({num_lines:,} lines):"
-                        f"\n  | {_rendered_config}"
-                        f"\nEnd Compute endpoint configuration"
-                    )
-                    del _rendered_config
-            del config_str
 
         except Exception as e:
             if isinstance(e, ClickException):

--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -15,6 +15,7 @@ from datetime import datetime
 
 log = logging.getLogger(__name__)
 
+LOG_TS_FMT = "%Y-%m-%d %H:%M:%S,%f"
 DEFAULT_FORMAT = (
     "%(asctime)s %(levelname)s %(processName)s-%(process)d "
     "%(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s "
@@ -80,7 +81,7 @@ class ComputeConsoleFormatter(logging.Formatter):
     ) -> None:
         super().__init__()
 
-        kwargs.setdefault("datefmt", "%Y-%m-%d %H:%M:%S,%f")
+        kwargs.setdefault("datefmt", LOG_TS_FMT)
 
         self.use_color = debug and not no_color and sys.stderr.isatty()
 
@@ -172,12 +173,12 @@ def _get_file_dict_config(
                 "()": ComputeConsoleFormatter,
                 "debug": debug,
                 "no_color": no_color,
-                "datefmt": "%Y-%m-%d %H:%M:%S,%f",
+                "datefmt": LOG_TS_FMT,
             },
             "filefmt": {
                 "()": DatetimeFormatter,
                 "format": DEFAULT_FORMAT,
-                "datefmt": "%Y-%m-%d %H:%M:%S,%f",
+                "datefmt": LOG_TS_FMT,
             },
         },
         "handlers": {
@@ -213,7 +214,7 @@ def _get_stream_dict_config(debug: bool, no_color: bool) -> dict:
                 "()": ComputeConsoleFormatter,
                 "debug": debug,
                 "no_color": no_color,
-                "datefmt": "%Y-%m-%d %H:%M:%S,%f",
+                "datefmt": LOG_TS_FMT,
             },
         },
         "handlers": {

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -6,7 +6,6 @@ import logging
 import os
 import pathlib
 import random
-import re
 import shlex
 import sys
 import typing as t
@@ -344,30 +343,6 @@ def test_cli_debug_overrides_config(mock_setup_log, run_line, mock_cli_state, ep
     assert mock_ensure.debug is True, "Verify test setup"
     assert "debug" in k
     assert k["debug"] is True, "Expect --debug flag overrides config"
-
-
-def test_debug_emits_ephemeral_config(run_line, mock_cli_state, ep_name, randomstring):
-    mock_ep, mock_ensure = mock_cli_state
-
-    mock_ensure.debug = False
-    ep_dir = mock_ensure.endpoint_config_dir / ep_name
-    ep_dir.mkdir(parents=True)
-    dname = randomstring()
-    config = {
-        "debug": True,
-        "display_name": dname,
-        "engine": {"type": "ThreadPoolEngine"},
-    }
-    data = {"config": yaml.safe_dump(config)}
-
-    with mock.patch(f"{_MOCK_BASE}log.debug") as mock_logd:
-        run_line(f"start {ep_name}", stdin=json.dumps(data))
-
-    a, *_ = mock_logd.call_args
-    # Per documentation, verify sentinels
-    assert a[0].startswith("Begin Compute endpoint"), "Expect start sentinel"
-    assert a[0].endswith("\nEnd Compute endpoint configuration"), "Expect end sentinel"
-    assert re.search(rf"\n +\| display_name: {dname}\n", a[0]), "Expect config emitted"
 
 
 def test_configure_validates_name(mock_command_ensure, run_line):


### PR DESCRIPTION
The pre-exec environment was the initial place for the configuration emission during development, but that proved a problem as it was never stored -- it wasn't very debuggable for regular users!  Thus, moved it to the post-exec environment so it would show up in logs.

However, this poses a problem if *something* happens before logging is setup and the string is written -- debugging the rendered template is not possible then.  Instead, piggy back on the recent std-stream to `endpoint.log` work to move configuration emission to prior to exec, and guarantee that it makes it to the log file.  This also avoids the odd check-if-config-is-a-string to decide whether to write it to the log.  The pre-exec environment has the information that it's ephemeral and can thus just log it.

## Type of change

- Code maintenance/cleanup