### PR TITLE
Remove redundant GlobusMPIEngine arguments

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
@@ -1,106 +1,32 @@
-import os
+from __future__ import annotations
+
 import typing as t
 from concurrent.futures import Future
 
-from globus_compute_endpoint.engines.globus_compute import (
-    VALID_CONTAINER_TYPES,
-    GlobusComputeEngine,
-    JobStatusPollerKwargs,
-)
-from parsl.executors import MPIExecutor
+import parsl.executors
+from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
 
 
 class GlobusMPIEngine(GlobusComputeEngine):
+    # There's no programmatic need for this interstitial __init__; it's here merely to
+    # hold the documentation (for Sphinx and the build process).  A naive attempt
+    # to place the documentation on the class also pulled in the parent class
+    # documentation.
 
-    def __init__(
-        self,
-        *args,
-        label: str = "GlobusMPIEngine",
-        max_retries_on_system_failure: int = 0,
-        executor: t.Optional[MPIExecutor] = None,
-        container_type: t.Literal[VALID_CONTAINER_TYPES] = None,  # type: ignore
-        container_uri: t.Optional[str] = None,
-        container_cmd_options: t.Optional[str] = None,
-        encrypted: bool = True,
-        strategy: t.Optional[str] = None,
-        job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
-        working_dir: t.Union[str, os.PathLike] = "tasks_working_dir",
-        run_in_sandbox: bool = True,
-        **kwargs,
-    ):
-        """``GlobusMPIEngine`` is a shim over `Parsl's MPIExecutor
-        <parslmpiex_>`_, and as such, all of arguments are passed along, unfettered.
-        Consequently, please reference `Parsl's MPIExecutor <parslmpiex_>`_
-        documentation for a complete list of arguments; we list below only the
-        arguments specific to the ``GlobusMPIEngine``.
+    _ExecutorClass = parsl.executors.MPIExecutor
 
-        .. _parslmpiex: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.MPIExecutor.html
-        .. _parslstrategy: https://parsl.readthedocs.io/en/stable/stubs/parsl.jobs.strategy.Strategy.html
-        .. _parsljobstatuspoller: https://parsl.readthedocs.io/en/stable/stubs/parsl.jobs.job_status_poller.JobStatusPoller.html
+    def __init__(self, *args, **kwargs):
+        """``GlobusMPIEngine`` extends |GCE|_ and is a shim over Parsl's |MPIExecutor|_.
+        For a complete list of available arguments, please reference the documentation
+        for those classes.
 
-        Parameters
-        ----------
-
-        label: str
-           Label used to name engine log directories and batch jobs
-           default: "GlobusComputeEngine"
-
-        max_retries_on_system_failure: int
-           Set the number of retries for functions that fail due to
-           system failures such as node failure/loss. Since functions
-           can fail after partial runs, consider additional cleanup
-           logic before enabling this functionality
-           default: 0
-
-        strategy: str | None
-            Specify which scaling strategy to use; this is eventually given to
-            `Parsl's Strategy <parslstrategy_>`_.
-
-        job_status_kwargs: dict | None
-            Keyword arguments to be passed through to `Parsl's JobStatusPoller
-            <parsljobstatuspoller_>`_ class that drives strategy to do auto-scaling.
-
-        encrypted: bool
-            Flag to enable/disable encryption (CurveZMQ). Default is True.
-
-        working_dir: str | os.PathLike
-            Directory within which functions should execute, defaults to
-            ``~/.globus_compute/<endpoint_name>/tasks_working_dir``.
-            If a relative path is supplied, the working dir is set relative
-            to the ``endpoint.run_dir``. If an absolute path is supplied, it is
-            used as is.
-
-        run_in_sandbox: bool
-            Functions will run in a sandbox directory under the ``working_dir``
-            if this option is enabled. Default: True
-
+        .. |GCE| replace:: ``GlobusComputeEngine``
+        .. _GCE: engine.html
+        .. |MPIExecutor| replace:: ``MPIExecutor``
+        .. _MPIExecutor: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.MPIExecutor.html
         """  # noqa: E501
 
-        if executor is None:
-            executor = MPIExecutor(  # type: ignore
-                *args,
-                label=label,
-                encrypted=encrypted,
-                **kwargs,
-            )
-        elif not isinstance(executor, MPIExecutor):
-            raise TypeError(
-                "The executor must be an instance of parsl.executors.MPIExecutor"
-            )
-
-        super().__init__(
-            label=label,
-            max_retries_on_system_failure=max_retries_on_system_failure,
-            executor=executor,
-            container_type=container_type,
-            container_uri=container_uri,
-            container_cmd_options=container_cmd_options,
-            encrypted=encrypted,
-            strategy=strategy,
-            job_status_kwargs=job_status_kwargs,
-            working_dir=working_dir,
-            run_in_sandbox=run_in_sandbox,
-        )
+        super().__init__(*args, **kwargs)
 
     def _submit(
         self,

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -3,6 +3,7 @@ import queue
 import random
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
 
 import pytest
 from globus_compute_common import messagepack
@@ -42,13 +43,15 @@ def mock_gce(tmp_path):
 
     executor.launch_cmd = ""
     scripts_dir = str(tmp_path / "submit_scripts")
-    engine = GlobusComputeEngine(
-        executor=executor,
-        working_dir=scripts_dir,
-        provider=LocalProvider(min_blocks=0, max_blocks=0, init_blocks=0),
-    )
-    engine.results_passthrough = queue.Queue()
-    yield engine
+    with mock.patch.object(GlobusComputeEngine, "_ExecutorClass", MockHTEX) as mock_Ex:
+        mock_Ex.__name__ = MockHTEX.__name__
+        engine = GlobusComputeEngine(
+            executor=executor,
+            working_dir=scripts_dir,
+            provider=LocalProvider(min_blocks=0, max_blocks=0, init_blocks=0),
+        )
+        engine.results_passthrough = queue.Queue()
+        yield engine
 
 
 def test_success_after_1_fail(mock_gce, tmp_path):

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -14,7 +14,7 @@ from parsl.executors.high_throughput.mpi_prefix_composer import (
 from tests.utils import ez_pack_function, get_env_vars
 
 
-def test_mpi_function(engine_runner, nodeslist, tmp_path):
+def test_mpi_function(engine_runner, nodeslist):
     """Test for the right cmd being generated"""
     engine = engine_runner(GlobusMPIEngine)
     task_id = uuid.uuid1()

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -373,13 +373,15 @@ def test_gcmpiengine_default_executor(randomstring):
     assert k["encrypted"] is True, "Expect encrypted by default"
 
 
-def test_gcmpiengine_accepts_resource_specification(task_uuid):
+def test_gcmpiengine_accepts_resource_specification(task_uuid, randomstring):
+    spec = {"some": "conf", "sentinel": randomstring()}
     with mock.patch.object(GlobusMPIEngine, "_ExecutorClass") as mock_ex:
         mock_ex.__name__ = "ClassName"
         mock_ex.return_value = mock.Mock(launch_cmd="")
         engine = GlobusMPIEngine()
-        engine.submit(
-            str(task_uuid), b"some task", resource_specification={"some": "conf"}
-        )
+        engine.submit(str(task_uuid), b"some task", resource_specification=spec)
 
     assert engine.executor.submit.called, "Verify test: correct internal method invoked"
+
+    a, _k = engine.executor.submit.call_args
+    assert spec in a


### PR DESCRIPTION
There is no sense in duplicating the arguments.  Update related `GlobusMPIEngine` docstring and tests.

## Type of change

- Code maintenance/cleanup