### PR TITLE
Refactor selected tests to use fixtures

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -8,10 +8,9 @@ from unittest import mock
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import GlobusComputeEngine
-from globus_compute_sdk.serialize import ComputeSerializer
 from parsl.executors.high_throughput.interchange import ManagerLost
 from parsl.providers import LocalProvider
-from tests.utils import ez_pack_function, slow_double
+from tests.utils import slow_double
 
 
 class MockHTEX:
@@ -54,59 +53,41 @@ def mock_gce(tmp_path):
         yield engine
 
 
-def test_success_after_1_fail(mock_gce, tmp_path):
+def test_success_after_1_fail(mock_gce, serde, ez_pack_task):
     engine = mock_gce
     engine.max_retries_on_system_failure = 2
-    queue = engine.results_passthrough
+    q = engine.results_passthrough
     task_id = uuid.uuid1()
-    serializer = ComputeSerializer()
     num = random.randint(1, 10000)
+    task_bytes = ez_pack_task(slow_double, num, 0.2)
 
     # Set the failure count on the mock executor to force failure
     engine.executor.fail_count = 1
+    engine.submit(task_id, task_bytes, resource_specification={})
 
-    task_body = ez_pack_function(
-        serializer,
-        slow_double,
-        (
-            num,
-            0.2,
-        ),
-        {},
-    )
-    task_message = messagepack.pack(
-        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
-    )
-
-    engine.submit(task_id, task_message, resource_specification={})
-
-    packed_result = queue.get()
+    packed_result = q.get()
     assert isinstance(packed_result, dict)
     result = messagepack.unpack(packed_result["message"])
 
     assert result.task_id == task_id
-    assert serializer.deserialize(result.data) == 2 * num
+    assert serde.deserialize(result.data) == 2 * num
 
 
-def test_repeated_fail(mock_gce, tmp_path):
+def test_repeated_fail(mock_gce, ez_pack_task):
     fail_count = 2
     engine = mock_gce
     engine.max_retries_on_system_failure = fail_count
-    queue = engine.results_passthrough
+    q = engine.results_passthrough
     task_id = uuid.uuid1()
-    serializer = ComputeSerializer()
 
     # Set executor to continue failures beyond retry limit
     engine.executor.fail_count = fail_count + 1
 
-    task_body = ez_pack_function(serializer, slow_double, (5,), {})
-    task_message = messagepack.pack(
-        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
-    )
+    task_bytes = ez_pack_task(slow_double, 5)
 
-    engine.submit(task_id, task_message, resource_specification={})
+    engine.submit(task_id, task_bytes, resource_specification={})
 
-    packed_result_q = queue.get(10)
+    packed_result_q = q.get()
     result = messagepack.unpack(packed_result_q["message"])
     assert isinstance(result, messagepack.message_types.Result)
     assert result.task_id == task_id

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -6,9 +6,7 @@ import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
 from globus_compute_endpoint.engines.helper import execute_task
-from globus_compute_sdk.serialize import ComputeSerializer
 from parsl.executors import HighThroughputExecutor
-from tests.utils import ez_pack_function
 
 
 @pytest.fixture()
@@ -59,7 +57,7 @@ def test_absolute_working_dir(tmp_path):
     assert gce.working_dir == "/absolute/path"
 
 
-def test_submit_pass(tmp_path):
+def test_submit_pass(tmp_path, task_uuid):
     """Test absolute path for working_dir"""
     gce = GlobusComputeEngine(
         address="127.0.0.1",
@@ -69,7 +67,7 @@ def test_submit_pass(tmp_path):
     gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
 
     gce.submit(
-        task_id=uuid.uuid4(),
+        task_id=task_uuid,
         packed_task=b"PACKED_TASK",
         resource_specification={},
     )
@@ -84,92 +82,65 @@ def test_submit_pass(tmp_path):
     assert flag, "Call args parsing failed, did not find run_dir"
 
 
-def test_execute_task_working_dir(tmp_path, reset_cwd):
-
-    task_id = uuid.uuid4()
-    serializer = ComputeSerializer()
-    task_body = ez_pack_function(serializer, get_cwd, (), {})
-    task_message = messagepack.pack(
-        messagepack.message_types.Task(
-            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
-        )
-    )
-
-    assert os.getcwd() != tmp_path.name
-
-    packed_result = execute_task(
-        task_id,
-        task_message,
-        uuid.uuid4(),
-        run_dir=tmp_path,
-    )
+def test_execute_task_working_dir(
+    tmp_path, reset_cwd, serde, endpoint_uuid, task_uuid, ez_pack_task
+):
+    assert os.getcwd() != str(tmp_path)
+    task_bytes = ez_pack_task(get_cwd)
+    packed_result = execute_task(task_uuid, task_bytes, endpoint_uuid, run_dir=tmp_path)
 
     message = messagepack.unpack(packed_result)
-    assert message.task_id == task_id
+    assert message.task_id == task_uuid
     assert message.data
-    result = serializer.deserialize(message.data)
-    assert result == tmp_path.__fspath__()
-    assert os.getcwd() == tmp_path.__fspath__()
+
+    result = serde.deserialize(message.data)
+    assert result == os.fspath(tmp_path)
+    assert os.getcwd() == os.fspath(tmp_path)
 
 
-def test_non_existent_relative_working_dir(tmp_path, reset_cwd):
+def test_non_existent_relative_working_dir(
+    tmp_path, reset_cwd, serde, endpoint_uuid, task_uuid, ez_pack_task
+):
     """This tests for execute_task creating a non-existent working dir
     when a relative path is specified to the CWD"""
 
-    task_id = uuid.uuid4()
     os.chdir(tmp_path)
     target_dir = f"{uuid.uuid4()}"
-    abs_target_dir = os.path.abspath(target_dir)
-    serializer = ComputeSerializer()
-    task_body = ez_pack_function(serializer, get_cwd, (), {})
-    task_message = messagepack.pack(
-        messagepack.message_types.Task(
-            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
-        )
-    )
-
     assert os.getcwd() != target_dir
 
+    abs_target_dir = os.path.abspath(target_dir)
+
+    task_bytes = ez_pack_task(get_cwd)
     packed_result = execute_task(
-        task_id,
-        task_message,
-        uuid.uuid4(),
+        task_uuid,
+        task_bytes,
+        endpoint_uuid,
         run_dir=target_dir,
     )
 
     message = messagepack.unpack(packed_result)
-    assert message.task_id == task_id
+    assert message.task_id == task_uuid
     assert message.data
-    result = serializer.deserialize(message.data)
+    result = serde.deserialize(message.data)
 
     assert result == abs_target_dir
 
 
-def test_sandbox(tmp_path, reset_cwd):
-
-    task_id = uuid.uuid4()
+def test_sandbox(tmp_path, reset_cwd, serde, endpoint_uuid, task_uuid, ez_pack_task):
     os.chdir(tmp_path)
-    serializer = ComputeSerializer()
-    task_body = ez_pack_function(serializer, get_cwd, (), {})
-    task_message = messagepack.pack(
-        messagepack.message_types.Task(
-            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
-        )
-    )
 
-    assert os.getcwd() != tmp_path
-
+    task_bytes = ez_pack_task(get_cwd)
     packed_result = execute_task(
-        task_id,
-        task_message,
-        uuid.uuid4(),
+        task_uuid,
+        task_bytes,
+        endpoint_uuid,
         run_dir=tmp_path,
         run_in_sandbox=True,
     )
 
     message = messagepack.unpack(packed_result)
-    assert message.task_id == task_id
+    assert message.task_id == task_uuid
     assert message.data
-    result = serializer.deserialize(message.data)
+    result = serde.deserialize(message.data)
 
-    assert result == os.path.join(tmp_path, str(task_id))
+    assert result == os.path.join(tmp_path, str(task_uuid))


### PR DESCRIPTION
We have the fixtures, let's use them.  Take a more global look at some of the tests; move a helpful fixture (`ez_pack_task`) to the top-level `conftest.py`, then reference it where appropriate.

Dedup the lines by over half.

## Type of change

- Code maintenance/cleanup