### PR TITLE
Allow `GLOBUS_COMPUTE_CLIENT_ID` env var alone

### DIFF
--- a/changelog.d/20240905_180131_30907815+rjmello_allow_client_id_alone.rst
+++ b/changelog.d/20240905_180131_30907815+rjmello_allow_client_id_alone.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- We no longer raise an exception if a user defines the ``GLOBUS_COMPUTE_CLIENT_ID``
+  environment variable without defining ``GLOBUS_COMPUTE_SECRET_KEY``. The reverse,
+  however, will still raise an exception.

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -967,12 +967,9 @@ def test_endpoint_login(mocker, caplog, force, is_client, logged_in):
         assert "Already logged in" in caplog.text
 
 
-@pytest.mark.parametrize(
-    "env_var", ["GLOBUS_COMPUTE_CLIENT_ID", "GLOBUS_COMPUTE_CLIENT_SECRET"]
-)
 @pytest.mark.parametrize("force", [True, False], ids=["forced", "unforced"])
-def test_endpoint_login_handles_partial_client_login_state(monkeypatch, env_var, force):
-    monkeypatch.setenv(env_var, "some_uuid")
+def test_endpoint_login_handles_partial_client_login_state(monkeypatch, force):
+    monkeypatch.setenv("GLOBUS_COMPUTE_CLIENT_SECRET", "some_uuid")
     with pytest.raises(ClickException) as e:
         _do_login(force)
     assert "both environment variables" in str(e)

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/client_login.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/client_login.py
@@ -34,7 +34,7 @@ def is_client_login() -> bool:
     """
     client_id, client_secret = _get_client_creds_from_env()
 
-    if bool(client_id) ^ bool(client_secret):
+    if client_secret and not client_id:
         raise ValueError(
             "Both GLOBUS_COMPUTE_CLIENT_ID and GLOBUS_COMPUTE_CLIENT_SECRET must "
             "be set to use a client identity. Either set both environment "

--- a/compute_sdk/tests/unit/test_login_manager.py
+++ b/compute_sdk/tests/unit/test_login_manager.py
@@ -170,7 +170,13 @@ def test_is_client_login():
     with mock.patch.dict(os.environ, env):
         assert is_client_login()
 
-    for cid, csc in (("", ""), ("", None), (None, ""), (None, None)):
+    for cid, csc in (
+        ("some_id", ""),
+        ("some_id", None),
+        ("", None),
+        (None, ""),
+        (None, None),
+    ):
         env = {}
         if cid is not None:
             env[CID_KEY] = cid
@@ -180,8 +186,6 @@ def test_is_client_login():
             assert not is_client_login()
 
     for cid, csc in (
-        ("some_id", ""),
-        ("some_id", None),
         ("", "some_secret"),
         (None, "some_secret"),
     ):


### PR DESCRIPTION
# Description

Defining the `GLOBUS_COMPUTE_CLIENT_ID` environment variable without defining `GLOBUS_COMPUTE_SECRET_KEY` is a valid use case. The reverse, however, is not and will still raise an exception.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
