### PR TITLE
Add GlobusApp support

### DIFF
--- a/changelog.d/20240906_104313_rjmello_support_globus_apps.rst
+++ b/changelog.d/20240906_104313_rjmello_support_globus_apps.rst
@@ -1,0 +1,28 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The SDK ``Client`` and ``WebClient`` now support using a ``GlobusApp`` for authentication.
+  For standard interactive login flows, users can leave the ``app`` argument blank when
+  initializing the ``Client``, or pass in a custom ``UserApp``. For client authentication,
+  users can leave the ``app`` argument blank and set the ``GLOBUS_COMPUTE_CLIENT_ID`` and
+  ``GLOBUS_COMPUTE_CLIENT_SECRET`` environment variables, or pass in a custom ``ClientApp``.
+
+  For more information on how to use a ``GlobusApp``, see the `Globus SDK documentation
+  <https://globus-sdk-python.readthedocs.io/en/stable/experimental/examples/oauth2/globus_app.html>`_.
+
+  Users can still pass in a custom ``LoginManager`` to the ``login_manager`` argument, but
+  this is mutually exclusive with the ``app`` argument.
+
+  E.g.,
+
+  .. code-block:: python
+
+     from globus_compute_sdk import Client
+     from globus_sdk.experimental.globus_app import UserApp
+
+     gcc = Client()
+
+     # or
+
+     my_app = UserApp("my-app", client_id="...")
+     gcc = Client(app=my_app)

--- a/changelog.d/20240906_152758_30907815_rjmello_deprecate_user_app_name.rst
+++ b/changelog.d/20240906_152758_30907815_rjmello_deprecate_user_app_name.rst
@@ -1,0 +1,6 @@
+Deprecated
+^^^^^^^^^^
+
+- The ``WebClient.user_app_name`` attribute has been marked for deprecation and
+  will be removed in a future release. Please directly use ``WebClient.app_name``
+  instead.

--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -6,7 +6,7 @@ import textwrap
 from click import ClickException
 from globus_compute_endpoint.endpoint.config.utils import get_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_compute_sdk.sdk.login_manager import LoginManager
+from globus_sdk.experimental.globus_app import GlobusApp
 
 _SYSTEMD_UNIT_DIR = pathlib.Path("/etc/systemd/system")
 
@@ -39,7 +39,7 @@ def _systemd_available() -> bool:
     return _SYSTEMD_UNIT_DIR.exists()
 
 
-def enable_on_boot(ep_dir: pathlib.Path):
+def enable_on_boot(ep_dir: pathlib.Path, app: GlobusApp):
     if not _systemd_available():
         raise ClickException(
             "Systemd not found. On-boot persistence is currently only implemented for"
@@ -75,7 +75,7 @@ def enable_on_boot(ep_dir: pathlib.Path):
 
     # ensure that credentials exist when systemd tries to start endpoint, so that
     # auth login flow doesn't run under systemd
-    LoginManager().ensure_logged_in()
+    app.login()
 
     service_name = _systemd_service_name(ep_name)
     unit_file_path = _SYSTEMD_UNIT_DIR / f"{service_name}.service"

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -28,9 +28,9 @@ from globus_compute_endpoint.endpoint.utils import (
 from globus_compute_endpoint.exception_handling import handle_auth_errors
 from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_endpoint.self_diagnostic import run_self_diagnostic
+from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
 from globus_compute_sdk.sdk.login_manager import LoginManager
 from globus_compute_sdk.sdk.login_manager.client_login import is_client_login
-from globus_compute_sdk.sdk.login_manager.tokenstore import ensure_compute_dir
 from globus_compute_sdk.sdk.login_manager.whoami import print_whoami_info
 from globus_sdk import MISSING, AuthClient, GlobusAPIError, MissingType
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -971,7 +971,7 @@ class EndpointManager:
             startup_proc_title = f"Endpoint starting up for {uname} [{args_title}]"
             setproctitle.setproctitle(startup_proc_title)
 
-            gc_dir: pathlib.Path = GC.sdk.login_manager.tokenstore.ensure_compute_dir()
+            gc_dir: pathlib.Path = GC.sdk.compute_dir.ensure_compute_dir()
             ep_dir = gc_dir / ep_name
             ep_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
             ep_log = ep_dir / "endpoint.log"

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -503,7 +503,7 @@ class EndpointManager:
 
             gcc = GC.Client(**client_options)
             try:
-                userinfo = gcc.login_manager.get_auth_client().userinfo()
+                userinfo = gcc.auth_client.userinfo()
                 ids = userinfo["identity_set"]
                 parent_identities.update(ident["sub"] for ident in ids)
                 log.debug(

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -12,7 +12,6 @@ import responses
 from click import ClickException
 from click.testing import CliRunner
 from globus_compute_endpoint.cli import (
-    _do_logout_endpoints,
     _do_stop_endpoint,
     _upgrade_funcx_imports_in_config,
     app,
@@ -109,47 +108,6 @@ def test_start_endpoint_data_passthrough(fs):
     assert req_json["authentication_policy"] == ep_conf.authentication_policy
     assert req_json["subscription_uuid"] == ep_conf.subscription_id
     assert req_json["public"] is ep_conf.public
-
-
-def test_endpoint_logout(monkeypatch):
-    # not forced, and no running endpoints
-    logout_true = mock.Mock(return_value=True)
-    logout_false = mock.Mock(return_value=False)
-    monkeypatch.setattr(
-        globus_compute_sdk.sdk.login_manager.LoginManager, "logout", logout_true
-    )
-    success, msg = _do_logout_endpoints(False, running_endpoints={})
-    logout_true.assert_called_once()
-    assert success
-
-    logout_true.reset_mock()
-
-    # forced, and no running endpoints
-    success, msg = _do_logout_endpoints(True, running_endpoints={})
-    logout_true.assert_called_once()
-    assert success
-
-    one_running = {
-        "default": {"status": "Running", "id": "123abcde-a393-4456-8de5-123456789abc"}
-    }
-
-    monkeypatch.setattr(
-        globus_compute_sdk.sdk.login_manager.LoginManager, "logout", logout_false
-    )
-    # not forced, with running endpoint
-    success, msg = _do_logout_endpoints(False, running_endpoints=one_running)
-    logout_false.assert_not_called()
-    assert not success
-
-    logout_true.reset_mock()
-
-    monkeypatch.setattr(
-        globus_compute_sdk.sdk.login_manager.LoginManager, "logout", logout_true
-    )
-    # forced, with running endpoint
-    success, msg = _do_logout_endpoints(True, running_endpoints=one_running)
-    logout_true.assert_called_once()
-    assert success
 
 
 @mock.patch(f"{_MOCK_BASE}Endpoint.get_endpoint_id", return_value="abc-uuid")

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -28,7 +28,7 @@ from globus_compute_endpoint.cli import (
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_compute_sdk.sdk.login_manager.tokenstore import ensure_compute_dir
+from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
 from globus_compute_sdk.sdk.web_client import WebClient
 from globus_sdk import MISSING, AuthClient
 from pyfakefs import fake_filesystem as fakefs

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -193,9 +193,7 @@ def mock_unprivileged_epmanager(mocker, conf_dir, mock_client, mock_conf):
 
     ep_uuid, mock_gcc = mock_client
     ident = "some_identity_uuid"
-    mock_gcc.login_manager.get_auth_client.return_value.userinfo.return_value = {
-        "identity_set": [{"sub": ident}]
-    }
+    mock_gcc.auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
     mock_conf.identity_mapping_config_path = None
     em = EndpointManager(conf_dir, ep_uuid, mock_conf)
@@ -234,7 +232,7 @@ def epmanager_as_root(mocker, conf_dir, mock_conf, mock_client, mock_pim):
 
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=True)
     mocker.patch(
-        f"{_MOCK_BASE}GC.sdk.login_manager.tokenstore.ensure_compute_dir",
+        f"{_MOCK_BASE}GC.sdk.compute_dir.ensure_compute_dir",
         side_effect=mock_ensure_compute_dir,
     )
 
@@ -245,9 +243,7 @@ def epmanager_as_root(mocker, conf_dir, mock_conf, mock_client, mock_pim):
     mock_pim.map_identity.return_value = "an_account_that_doesnt_exist_abc123"
 
     ident = "epmanager_some_identity"
-    mock_gcc.login_manager.get_auth_client.return_value.userinfo.return_value = {
-        "identity_set": [{"sub": ident}]
-    }
+    mock_gcc.auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
     em = EndpointManager(conf_dir, ep_uuid, mock_conf)
     em._command = mocker.Mock(spec=CommandQueueSubscriber)
@@ -282,9 +278,8 @@ def successful_exec_from_mocked_root(
     conf_dir, mock_conf, mock_client, mock_os, mock_pwd, em = epmanager_as_root
 
     _, mock_gcc = mock_client
-    mock_gcc.login_manager.get_auth_client.return_value.userinfo.return_value = {
-        "identity_set": [{"sub": ident}]
-    }
+
+    mock_gcc.auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
     queue_item = (1, mock_props, json.dumps(command_payload).encode())
 
@@ -862,9 +857,7 @@ def test_quits_if_not_privileged_and_no_identity_set(
     ep_uuid, mock_gcc = mock_client
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=False)
     mock_log = mocker.patch(f"{_MOCK_BASE}log")
-    mock_gcc.login_manager.get_auth_client.return_value.userinfo.return_value = {
-        "identity_set": []
-    }
+    mock_gcc.auth_client.userinfo.return_value = {"identity_set": []}
     assert em._time_to_stop is False, "Verify test setup"
     em._event_loop()
 
@@ -881,9 +874,7 @@ def test_clean_exit_on_identity_collection_error(
     ep_uuid, mock_gcc = mock_client
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=False)
     mock_log = mocker.patch(f"{_MOCK_BASE}log")
-    mock_gcc.login_manager.get_auth_client.return_value.userinfo.return_value = {
-        "not_identity_set": None
-    }
+    mock_gcc.auth_client.userinfo.return_value = {"not_identity_set": None}
     assert em._time_to_stop is False, "Verify test setup"
     em._event_loop()
 
@@ -1328,7 +1319,7 @@ def test_unprivileged_happy_path(
 ):
     *_, mock_client, mock_os, _, em = mock_unprivileged_epmanager
     _, mock_gcc = mock_client
-    ident_rv = mock_gcc.login_manager.get_auth_client.return_value.userinfo.return_value
+    ident_rv = mock_gcc.auth_client.userinfo.return_value
 
     mocker.patch(f"{_MOCK_BASE}log")
     cmd_payload = {

--- a/compute_sdk/globus_compute_sdk/sdk/auth/auth_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/auth_client.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from globus_sdk import AuthClient
+from globus_sdk.scopes import AuthScopes, Scope
+
+
+class ComputeAuthClient(AuthClient):
+    default_scope_requirements = [
+        Scope(AuthScopes.openid),
+        Scope(AuthScopes.manage_projects),
+    ]

--- a/compute_sdk/globus_compute_sdk/sdk/auth/client_login.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/client_login.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ..utils import get_env_var_with_deprecation
+
+
+def get_client_creds() -> tuple[str | None, str | None]:
+    client_id = get_env_var_with_deprecation(
+        "GLOBUS_COMPUTE_CLIENT_ID", "FUNCX_SDK_CLIENT_ID"
+    )
+    client_secret = get_env_var_with_deprecation(
+        "GLOBUS_COMPUTE_CLIENT_SECRET", "FUNCX_SDK_CLIENT_SECRET"
+    )
+    return client_id, client_secret

--- a/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import platform
+import sys
+
+from globus_sdk.experimental.globus_app import ClientApp, GlobusAppConfig, UserApp
+
+from .client_login import get_client_creds
+from .token_storage import get_token_storage
+
+DEFAULT_CLIENT_ID = "4cf29807-cf21-49ec-9443-ff9a3fb9f81c"
+
+
+def _is_jupyter():
+    # Simplest way to find out if we are in Jupyter without having to
+    # check imports
+    return "jupyter_core" in sys.modules
+
+
+def get_globus_app(environment: str | None = None):
+    app_name = platform.node()
+    client_id, client_secret = get_client_creds()
+    config = GlobusAppConfig(token_storage=get_token_storage(environment=environment))
+
+    if client_id and client_secret:
+        return ClientApp(
+            app_name=app_name,
+            client_id=client_id,
+            client_secret=client_secret,
+            config=config,
+        )
+
+    elif client_secret:
+        raise ValueError(
+            "Both GLOBUS_COMPUTE_CLIENT_ID and GLOBUS_COMPUTE_CLIENT_SECRET must "
+            "be set to use a client identity. Either set both environment "
+            "variables, or unset them to use a normal login."
+        )
+
+    # The authorization-via-web-link flow requires stdin; the user must visit
+    # the web link and enter generated code.
+    elif not sys.stdin.isatty() or sys.stdin.closed and not _is_jupyter():
+        # Not technically necessary; the login flow would just die with an EOF
+        # during input(), but adding this message here is much more direct --
+        # handle the non-happy path by letting the user know precisely the issue
+        raise RuntimeError(
+            "Unable to run native app login flow: stdin is closed or is not a TTY."
+        )
+
+    else:
+        client_id = client_id or DEFAULT_CLIENT_ID
+        return UserApp(app_name=app_name, client_id=client_id, config=config)

--- a/compute_sdk/globus_compute_sdk/sdk/auth/scopes.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/scopes.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from globus_sdk.scopes import ScopeBuilder
+
+from ..utils import get_env_var_with_deprecation
+
+DEFAULT_SCOPE = (
+    "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all"
+)
+
+
+class ComputeScopeBuilder(ScopeBuilder):
+    # A ScopeBuilder in the style of globus_sdk.scopes for the Globus Compute service
+    # that supports one scope named 'all', as in ``ComputeScopes.all``
+    def __init__(self):
+        # FIXME:
+        # For some reason, the Compute resource server name on the production scope is
+        # "funcx_service" even though this doesn't match the resource server ID and the
+        # scope is in URL format
+        # At some point, we ought to work out how to normalize this so that it conforms
+        # to one of the known, pre-existing modes for scopes
+        super().__init__(resource_server="funcx_service")
+        self.all = get_env_var_with_deprecation(
+            "GLOBUS_COMPUTE_SCOPE",
+            "FUNCX_SCOPE",
+            DEFAULT_SCOPE,
+        )
+
+
+ComputeScopes = ComputeScopeBuilder()

--- a/compute_sdk/globus_compute_sdk/sdk/auth/token_storage.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/token_storage.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+
+from globus_sdk.experimental.tokenstorage import SQLiteTokenStorage
+
+from .._environments import _get_envname
+from ..compute_dir import ensure_compute_dir
+from .client_login import get_client_creds
+
+
+def _get_storage_filepath():
+    compute_dir = ensure_compute_dir()
+    return os.path.join(compute_dir, "storage.db")
+
+
+def _resolve_namespace(environment: str | None = None) -> str:
+    """Return the namespace used to save tokens. This will check if a
+    client login is being used and return either `user/<envname>` or
+    `clientprofile/<envname>/<clientid>`.
+    """
+    env = environment if environment is not None else _get_envname()
+
+    client_id, client_secret = get_client_creds()
+    if client_id and client_secret:
+        return f"clientprofile/{env}/{client_id}"
+
+    return f"user/{env}"
+
+
+def get_token_storage(environment: str | None = None) -> SQLiteTokenStorage:
+    return SQLiteTokenStorage(
+        filepath=_get_storage_filepath(),
+        namespace=_resolve_namespace(environment),
+        connect_params={"check_same_thread": False},
+    )

--- a/compute_sdk/globus_compute_sdk/sdk/auth/whoami.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/whoami.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 import logging
 
-from globus_compute_sdk.sdk.login_manager import LoginManager
+from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.utils.printing import print_table
 from globus_sdk import AuthAPIError
+from globus_sdk.experimental.globus_app import GlobusApp
 
 NOT_LOGGED_IN_MSG = "Unable to retrieve user information. Please log in again."
 
 logger = logging.getLogger(__name__)
 
 
-def get_user_info(auth_client, user_id):
+def get_user_info(auth_client: ComputeAuthClient, user_id: str) -> list[str]:
     """
     Parse username, name, email from auth response and return a list of info
     """
@@ -22,17 +25,15 @@ def get_user_info(auth_client, user_id):
     ]
 
 
-def print_whoami_info(linked_identities: bool = False) -> None:
+def print_whoami_info(app: GlobusApp, linked_identities: bool = False) -> None:
     """
     Display information for the currently logged-in user.
     """
-
-    try:
-        auth_client = LoginManager().get_auth_client()
-    except LookupError:
+    if app.login_required():
         logger.debug(NOT_LOGGED_IN_MSG, exc_info=True)
         raise ValueError(NOT_LOGGED_IN_MSG)
 
+    auth_client = ComputeAuthClient(app=app)
     whoami_headers = ["Username", "Name", "ID", "Email"]
 
     # get userinfo from auth.

--- a/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
+++ b/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def ensure_compute_dir() -> pathlib.Path:
+    dirname = pathlib.Path.home() / ".globus_compute"
+
+    user_dir = os.getenv("GLOBUS_COMPUTE_USER_DIR")
+    if user_dir:
+        dirname = pathlib.Path(user_dir)
+
+    if dirname.is_dir():
+        pass
+    elif dirname.is_file():
+        raise FileExistsError(
+            f"Error creating directory {dirname}, "
+            "please remove or rename the conflicting file"
+        )
+    else:
+        dirname.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    return dirname

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
@@ -8,11 +8,9 @@ from globus_compute_sdk.sdk.login_manager.protocol import LoginManagerProtocol
 from globus_compute_sdk.sdk.web_client import WebClient
 from globus_sdk.scopes import AuthScopes
 
-from .manager import ComputeScopeBuilder
+from ..auth.scopes import ComputeScopes
 
 log = logging.getLogger(__name__)
-
-ComputeScopes = ComputeScopeBuilder()
 
 
 class AuthorizerLoginManager(LoginManagerProtocol):

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/client_login.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/client_login.py
@@ -12,19 +12,9 @@ import uuid
 
 import globus_sdk
 
-from ..utils import get_env_var_with_deprecation
+from ..auth.client_login import get_client_creds
 
 log = logging.getLogger(__name__)
-
-
-def _get_client_creds_from_env() -> tuple[str | None, str | None]:
-    client_id = get_env_var_with_deprecation(
-        "GLOBUS_COMPUTE_CLIENT_ID", "FUNCX_SDK_CLIENT_ID"
-    )
-    client_secret = get_env_var_with_deprecation(
-        "GLOBUS_COMPUTE_CLIENT_SECRET", "FUNCX_SDK_CLIENT_SECRET"
-    )
-    return client_id, client_secret
 
 
 def is_client_login() -> bool:
@@ -32,7 +22,7 @@ def is_client_login() -> bool:
     Return True if the correct env variables have been set to use a
     client identity with the Globus Compute SDK
     """
-    client_id, client_secret = _get_client_creds_from_env()
+    client_id, client_secret = get_client_creds()
 
     if client_secret and not client_id:
         raise ValueError(
@@ -52,7 +42,7 @@ def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
     if not is_client_login():
         raise ValueError("No client is logged in")
 
-    client_id, client_secret = _get_client_creds_from_env()
+    client_id, client_secret = get_client_creds()
 
     try:
         uuid.UUID(client_id)

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/manager.py
@@ -6,9 +6,9 @@ import threading
 import typing as t
 
 import globus_sdk
-from globus_sdk.scopes import AuthScopes, ScopeBuilder
+from globus_sdk.scopes import AuthScopes
 
-from ..utils import get_env_var_with_deprecation
+from ..auth.scopes import ComputeScopeBuilder
 from ..web_client import WebClient
 from .client_login import get_client_login, is_client_login
 from .globus_auth import internal_auth_client
@@ -17,29 +17,6 @@ from .tokenstore import get_token_storage_adapter
 
 log = logging.getLogger(__name__)
 
-
-def _get_funcx_all_scope() -> str:
-    return get_env_var_with_deprecation(
-        "GLOBUS_COMPUTE_SCOPE",
-        "FUNCX_SCOPE",
-        "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
-    )
-
-
-class ComputeScopeBuilder(ScopeBuilder):
-    # FIXME:
-    # for some reason, the funcx resource server name on the production scope is
-    # "funcx_service" even though this doesn't match the resource server ID and the
-    # scope is in URL format
-    # at some point, we ought to work out how to fix this to normalize this so that it
-    # conforms to one of the known, pre-existing modes for scopes
-    def __init__(self):
-        super().__init__("funcx_service")
-        self.all = _get_funcx_all_scope()
-
-
-#: a ScopeBuilder in the style of globus_sdk.scopes for the Globus Compute service
-#: it supports one scope named 'all', as in ``ComputeScopes.all``
 ComputeScopes = ComputeScopeBuilder()
 
 

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
@@ -1,39 +1,12 @@
 from __future__ import annotations
 
 import os
-import pathlib
 
 from globus_sdk.tokenstorage import SQLiteAdapter
 
 from .._environments import _get_envname
+from ..compute_dir import ensure_compute_dir
 from .client_login import get_client_login, is_client_login
-
-
-def _home() -> pathlib.Path:
-    # this is a hook point for tests to patch over
-    # it just returns `pathlib.Path.home()`
-    # replace this with a mock to return some test directory
-    return pathlib.Path.home()
-
-
-def ensure_compute_dir(home: os.PathLike | None = None) -> pathlib.Path:
-    dirname = _home() / ".globus_compute"
-
-    user_dir = os.getenv("GLOBUS_COMPUTE_USER_DIR")
-    if user_dir:
-        dirname = pathlib.Path(user_dir)
-
-    if dirname.is_dir():
-        pass
-    elif dirname.is_file():
-        raise FileExistsError(
-            f"Error creating directory {dirname}, "
-            "please remove or rename the conflicting file"
-        )
-    else:
-        dirname.mkdir(mode=0o700, parents=True, exist_ok=True)
-
-    return dirname
 
 
 def _get_storage_filename():

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -17,6 +17,10 @@ from globus_compute_sdk.sdk.utils.uuid_like import UUID_LIKE_T
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.version import __version__
 from globus_sdk.exc.api import GlobusAPIError
+from globus_sdk.experimental.globus_app import GlobusApp
+from globus_sdk.scopes import Scope
+
+from .auth.scopes import ComputeScopes
 
 
 def _get_packed_code(
@@ -96,11 +100,15 @@ class WebClient(globus_sdk.BaseClient):
     # use the Globus Compute-specific error class
     error_class = GlobusAPIError
 
+    scopes = ComputeScopes
+    default_scope_requirements = [Scope(ComputeScopes.all)]
+
     def __init__(
         self,
         *,
         environment: t.Optional[str] = None,
         base_url: t.Optional[str] = None,
+        app: t.Optional[GlobusApp] = None,
         app_name: t.Optional[str] = None,
         **kwargs,
     ):
@@ -112,7 +120,11 @@ class WebClient(globus_sdk.BaseClient):
             app_name = user_agent_substring(__version__)
 
         super().__init__(
-            environment=environment, base_url=base_url, app_name=app_name, **kwargs
+            environment=environment,
+            base_url=base_url,
+            app=app,
+            app_name=app_name,
+            **kwargs,
         )
 
     @property

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.35.0,<4",
+    "globus-sdk>=3.45.0,<4",
     "globus-compute-common==0.4.1",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear

--- a/compute_sdk/tests/unit/auth/test_auth_client.py
+++ b/compute_sdk/tests/unit/auth/test_auth_client.py
@@ -1,0 +1,11 @@
+from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
+from globus_sdk.scopes import AuthScopes
+
+
+def test_default_scope_requirements():
+    client = ComputeAuthClient()
+    expected_scopes = [AuthScopes.openid, AuthScopes.manage_projects]
+    scopes = [str(s) for s in client.default_scope_requirements]
+    assert len(expected_scopes) == len(scopes)
+    for scope in expected_scopes:
+        assert scope in scopes

--- a/compute_sdk/tests/unit/auth/test_client_login.py
+++ b/compute_sdk/tests/unit/auth/test_client_login.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from globus_compute_sdk.sdk.auth.client_login import get_client_creds
+
+
+@pytest.mark.parametrize("client_id", ["foo", "", None])
+@pytest.mark.parametrize("client_secret", ["foo", "", None])
+def test_get_client_creds(
+    client_id: str | None, client_secret: str | None, monkeypatch: pytest.MonkeyPatch
+):
+    if client_id is not None:
+        monkeypatch.setenv("GLOBUS_COMPUTE_CLIENT_ID", client_id)
+    if client_secret is not None:
+        monkeypatch.setenv("GLOBUS_COMPUTE_CLIENT_SECRET", client_secret)
+    assert get_client_creds() == (client_id, client_secret)
+
+
+@pytest.mark.parametrize("env_var", ["FUNCX_SDK_CLIENT_ID", "FUNCX_SDK_CLIENT_SECRET"])
+def test_get_client_creds_deprecated_env_var(
+    env_var: str, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(env_var, "foo")
+    with pytest.warns(UserWarning) as record:
+        get_client_creds()
+    assert any(env_var in str(r.message) for r in record)

--- a/compute_sdk/tests/unit/auth/test_globus_app.py
+++ b/compute_sdk/tests/unit/auth/test_globus_app.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+from globus_compute_sdk.sdk.auth.globus_app import DEFAULT_CLIENT_ID, get_globus_app
+from globus_sdk.experimental.globus_app import ClientApp, UserApp
+from pytest_mock import MockerFixture
+
+_MOCK_BASE = "globus_compute_sdk.sdk.auth.globus_app."
+
+
+@pytest.mark.parametrize(
+    "client_id,client_secret", [(None, None), ("123", None), ("123", "456")]
+)
+def test_get_globus_app(
+    client_id: str | None, client_secret: str | None, mocker: MockerFixture
+):
+    mocker.patch(
+        f"{_MOCK_BASE}get_client_creds", return_value=(client_id, client_secret)
+    )
+    mock_stdin = mocker.patch(f"{_MOCK_BASE}sys.stdin")
+    mock_stdin.isatty.return_value = True
+    mock_stdin.closed = False
+
+    app = get_globus_app()
+
+    if client_id and client_secret:
+        assert isinstance(app, ClientApp)
+    else:
+        assert isinstance(app, UserApp)
+
+    if client_id:
+        assert app.client_id == client_id
+    else:
+        assert app.client_id == DEFAULT_CLIENT_ID
+
+
+def test_get_globus_app_with_environment(mocker: MockerFixture, randomstring):
+    mock_get_token_storage = mocker.patch(f"{_MOCK_BASE}get_token_storage")
+    mocker.patch(f"{_MOCK_BASE}UserApp", autospec=True)
+    mock_stdin = mocker.patch(f"{_MOCK_BASE}sys.stdin")
+    mock_stdin.isatty.return_value = True
+    mock_stdin.closed = False
+
+    env = randomstring()
+    get_globus_app(environment=env)
+
+    mock_get_token_storage.assert_called_once_with(environment=env)
+
+
+def test_client_app_requires_creds(mocker: MockerFixture):
+    mocker.patch(f"{_MOCK_BASE}get_client_creds", return_value=(None, "456"))
+    with pytest.raises(ValueError) as err:
+        get_globus_app()
+    assert "GLOBUS_COMPUTE_CLIENT_SECRET must be set" in str(err.value)
+
+
+def test_user_app_requires_stdin(mocker: MockerFixture):
+    mock_stdin = mocker.patch(f"{_MOCK_BASE}sys.stdin")
+    mock_stdin.isatty.return_value = False
+
+    with pytest.raises(RuntimeError) as err:
+        get_globus_app()
+    assert "stdin is closed" in err.value.args[0]
+    assert "is not a TTY" in err.value.args[0]
+    assert "native app" in err.value.args[0]
+
+    mock_stdin.isatty.return_value = True
+    mock_stdin.closed = False
+
+    app = get_globus_app()
+    assert isinstance(app, UserApp)

--- a/compute_sdk/tests/unit/auth/test_scope_builder.py
+++ b/compute_sdk/tests/unit/auth/test_scope_builder.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+from globus_compute_sdk.sdk.auth.scopes import DEFAULT_SCOPE, ComputeScopeBuilder
+
+
+@pytest.mark.parametrize("env_var_name", ["GLOBUS_COMPUTE_SCOPE", "FUNCX_SCOPE"])
+@pytest.mark.parametrize("env_var_val", ["some-scope", None])
+def test_scope_builder(
+    env_var_name: str, env_var_val: str | None, monkeypatch: pytest.MonkeyPatch
+):
+    if env_var_val is not None:
+        monkeypatch.setenv(env_var_name, env_var_val)
+
+    sb = ComputeScopeBuilder()
+
+    assert sb.resource_server == "funcx_service"
+    if env_var_val:
+        assert sb.all == env_var_val
+    else:
+        assert sb.all == DEFAULT_SCOPE

--- a/compute_sdk/tests/unit/auth/test_token_storage.py
+++ b/compute_sdk/tests/unit/auth/test_token_storage.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from globus_compute_sdk.sdk.auth.token_storage import (
+    _resolve_namespace,
+    get_token_storage,
+)
+from globus_sdk.experimental.tokenstorage import SQLiteTokenStorage
+from pytest_mock import MockerFixture
+
+_MOCK_BASE = "globus_compute_sdk.sdk.auth.token_storage."
+
+
+@pytest.mark.parametrize("env", ("foo-env", None))
+@pytest.mark.parametrize("env_var", ("foo-env-var", "production"))
+@pytest.mark.parametrize("client_id", ("foo-client-id", None))
+@pytest.mark.parametrize("client_secret", ("foo-client-secret", None))
+def test_resolve_namespace(
+    env: str | None,
+    env_var: str | None,
+    client_id: str | None,
+    client_secret: str | None,
+    mocker: MockerFixture,
+):
+    mocker.patch(f"{_MOCK_BASE}_get_envname", return_value=env_var)
+    mocker.patch(
+        f"{_MOCK_BASE}get_client_creds", return_value=(client_id, client_secret)
+    )
+
+    namespace = _resolve_namespace(env)
+
+    env = env or env_var
+    if client_id and client_secret:
+        assert namespace == f"clientprofile/{env}/{client_id}"
+    else:
+        assert namespace == f"user/{env}"
+
+
+def test_get_token_storage(tmp_path: pathlib.Path, mocker: MockerFixture, randomstring):
+    env = randomstring()
+    namespace = f"foo/{env}"
+    compute_dir = tmp_path / ".globus_compute"
+    mock_resolve_namespace = mocker.patch(
+        f"{_MOCK_BASE}_resolve_namespace", return_value=namespace
+    )
+    mocker.patch(f"{_MOCK_BASE}ensure_compute_dir", return_value=compute_dir)
+
+    storage = get_token_storage(environment=env)
+
+    assert isinstance(storage, SQLiteTokenStorage)
+    assert storage.filepath == f"{compute_dir}/storage.db"
+    mock_resolve_namespace.assert_called_once_with(env)
+    assert storage.namespace == namespace

--- a/compute_sdk/tests/unit/test_authorizer_login_manager.py
+++ b/compute_sdk/tests/unit/test_authorizer_login_manager.py
@@ -11,8 +11,9 @@ _MOCK_BASE = "globus_compute_sdk.sdk.login_manager."
 
 @pytest.fixture
 def logman(mocker, tmp_path):
-    home = mocker.patch(f"{_MOCK_BASE}tokenstore._home")
-    home.return_value = tmp_path
+    compute_dir = tmp_path / ".globus_compute"
+    compute_dir.mkdir()
+    mocker.patch(f"{_MOCK_BASE}tokenstore.ensure_compute_dir", return_value=compute_dir)
     return AuthorizerLoginManager({})
 
 

--- a/compute_sdk/tests/unit/test_compute_dir.py
+++ b/compute_sdk/tests/unit/test_compute_dir.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+
+@pytest.mark.parametrize("dir_exists", [True, False])
+@pytest.mark.parametrize("user_dir", ["/my/dir", None, ""])
+def test_ensure_compute_dir(
+    dir_exists: bool,
+    user_dir: str | None,
+    fs: FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    home = pathlib.Path.home()
+    dirname = home / ".globus_compute"
+
+    if dir_exists:
+        fs.create_dir(dirname)
+
+    if user_dir is not None:
+        dirname = pathlib.Path(user_dir)
+        monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(dirname))
+
+    compute_dirname = ensure_compute_dir()
+
+    assert compute_dirname.is_dir()
+    assert compute_dirname == dirname
+
+
+@pytest.mark.parametrize("user_dir_defined", [True, False])
+def test_conflicting_compute_file(
+    user_dir_defined: bool, fs: FakeFilesystem, monkeypatch: pytest.MonkeyPatch
+):
+    filename = pathlib.Path.home() / ".globus_compute"
+    fs.create_file(filename)
+
+    with pytest.raises(FileExistsError) as exc:
+        if user_dir_defined:
+            monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(filename))
+        ensure_compute_dir()
+
+    assert "Error creating directory" in str(exc)
+
+
+def test_restricted_user_dir(fs: FakeFilesystem, monkeypatch: pytest.MonkeyPatch):
+    parent_dirname = pathlib.Path("/parent/dir/")
+    compute_dirname = parent_dirname / "compute"
+
+    fs.create_dir(parent_dirname)
+    os.chmod(parent_dirname, 0o000)
+
+    with pytest.raises(PermissionError) as exc:
+        monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(compute_dirname))
+        ensure_compute_dir()
+
+    assert "Permission denied" in str(exc)

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -60,37 +60,13 @@ def test_get_version_service_param(client, service_param):
     assert res["version"] == 100
 
 
-@pytest.mark.parametrize("user_app_name", [None, "bar"])
-def test_app_name_from_constructor(user_app_name):
-    client = WebClient(
-        # use the same fake URL and disable retries as in the default test case
-        base_url=_BASE_URL,
-        transport_params={"max_retries": 0},
-        # and also pass in the app_name
-        app_name=user_app_name,
-    )
-
-    assert client.user_app_name == user_app_name
-    assert __version__ in client.app_name
-    assert "globus-compute-sdk" in client.app_name
-    if user_app_name:
-        assert user_app_name in client.app_name
-
-
-@pytest.mark.parametrize("user_app_name", [None, "baz"])
-def test_user_app_name_property(client, user_app_name):
-    client.user_app_name = user_app_name
-
-    assert client.user_app_name == user_app_name
-    assert __version__ in client.app_name
-    assert "globus-compute-sdk" in client.app_name
-    if user_app_name:
-        assert user_app_name in client.app_name
-
-
-def test_app_name_not_settable(client):
-    with pytest.raises(NotImplementedError):
-        client.app_name = "qux"
+@pytest.mark.parametrize("app_name", [None, str(uuid.uuid4())])
+def test_app_name_value(app_name: str | None):
+    wc = WebClient(base_url=_BASE_URL, app_name=app_name)
+    if app_name is None:
+        assert wc.app_name == f"globus-compute-sdk-{__version__}"
+    else:
+        assert wc.app_name == app_name
 
 
 def test_get_amqp_url(client, randomstring):

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -69,6 +69,22 @@ def test_app_name_value(app_name: str | None):
         assert wc.app_name == app_name
 
 
+@pytest.mark.parametrize("user_app_name", [None, "baz"])
+def test_user_app_name_property(client: WebClient, user_app_name: str | None):
+    client.user_app_name = user_app_name
+    assert client.user_app_name == client.app_name
+    assert f"globus-compute-sdk-{__version__}" in client.app_name
+    if user_app_name:
+        assert user_app_name in client.app_name
+
+
+def test_user_app_name_deprecated(client: WebClient):
+    with pytest.warns(DeprecationWarning):
+        client.user_app_name
+    with pytest.warns(DeprecationWarning):
+        client.user_app_name = "foo"
+
+
 def test_get_amqp_url(client, randomstring):
     expected_response = randomstring()
     responses.add(

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import typing as t
 import uuid

--- a/compute_sdk/tests/unit/test_whoami.py
+++ b/compute_sdk/tests/unit/test_whoami.py
@@ -1,14 +1,17 @@
-import globus_compute_sdk.sdk.login_manager
 import pytest
-from globus_compute_sdk.sdk.login_manager.whoami import print_whoami_info
+from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
+from globus_compute_sdk.sdk.auth.whoami import NOT_LOGGED_IN_MSG, print_whoami_info
+from globus_sdk.experimental.globus_app import UserApp
+from pytest_mock import MockerFixture
 
-MOCK_BASE = "globus_compute_sdk.sdk.login_manager.whoami"
+MOCK_BASE = "globus_compute_sdk.sdk.auth.whoami"
 
 
 @pytest.mark.parametrize(
     "response_output",
     [
         [
+            True,
             False,
             {
                 "sub": "id_abc",
@@ -31,6 +34,7 @@ MOCK_BASE = "globus_compute_sdk.sdk.login_manager.whoami"
             ["abc@example.com", "first last", "id_abc", "abc@example.com"],
         ],
         [
+            True,
             True,
             {
                 "sub": "id_abc",
@@ -57,6 +61,7 @@ MOCK_BASE = "globus_compute_sdk.sdk.login_manager.whoami"
         ],
         [
             True,
+            True,
             {
                 "sub": "abc",
                 "last_authentication": 1674588197,
@@ -76,24 +81,36 @@ MOCK_BASE = "globus_compute_sdk.sdk.login_manager.whoami"
             0,
             [],
         ],
+        [
+            False,
+            False,
+            {},
+            {},
+            True,
+            NOT_LOGGED_IN_MSG,
+            0,
+            [],
+        ],
     ],
 )
-def test_whoami(response_output, mocker, monkeypatch):
-    linked, resp, profile, has_err, err_msg, num_rows, user_info = response_output
+def test_whoami(response_output, mocker: MockerFixture):
+    logged_in, linked, resp, profile, has_err, err_msg, num_rows, user_info = (
+        response_output
+    )
 
     print_mock = mocker.patch(f"{MOCK_BASE}.print_table")
-    oa_mock = mocker.Mock()
-    oa_mock.return_value.oauth2_userinfo.return_value = resp
-    oa_mock.return_value.get_identities.return_value = profile
-    monkeypatch.setattr(
-        globus_compute_sdk.sdk.login_manager.LoginManager, "get_auth_client", oa_mock
-    )
+    mock_auth_client = mocker.Mock(spec=ComputeAuthClient)
+    mock_auth_client.oauth2_userinfo.return_value = resp
+    mock_auth_client.get_identities.return_value = profile
+    mocker.patch(f"{MOCK_BASE}.ComputeAuthClient", return_value=mock_auth_client)
+    mock_app = mocker.Mock(spec=UserApp)
+    mock_app.login_required.return_value = not logged_in
 
     if has_err:
         with pytest.raises(ValueError, match=err_msg):
-            print_whoami_info(linked)
+            print_whoami_info(mock_app, linked)
     else:
-        print_whoami_info(linked)
+        print_whoami_info(mock_app, linked)
         print_mock.assert_called_once()
         assert num_rows == len(print_mock.call_args[0][1])
         assert user_info == print_mock.call_args[0][1][-1]


### PR DESCRIPTION
# Description

- The SDK `Client` and `WebClient` now support using a `GlobusApp` for authentication. For standard interactive login flows, users can leave the `app` argument blank when initializing the `Client`, or pass in a custom `UserApp`. For client authentication, users can specify the `GLOBUS_COMPUTE_CLIENT_ID` an `GLOBUS_COMPUTE_CLIENT_SECRET` environment variables, or pass in a custom `ClientApp`.

  Users can still pass in a custom ``LoginManager`` to the ``login_manager`` argument, but this is mutually exclusive with the ``app`` argument.

-  Migrated from the Globus SDK's `SQLiteAdapter` class to `SQLiteTokenStorage`. The main difference between the two is that the former creates an additional `config_storage` table, which we do not utilize.

- Created a new `globus_compute_sdk.sdk.auth` subpackage to organize various auth components.

- Marked the `WebClient.user_app_name` attribute for deprecation because `GlobusApp` objects need to directly modify the `WebClient.app_name` attribute. Users are directed to do the same.

- Modified endpoint code to use a `GlobusApp` for authentication instead of a `LoginManager`.

[sc-35168]

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup