### PR TITLE
Teach Executor a bursty rate-limit

### DIFF
--- a/changelog.d/20240918_223810_kevin_bursty_rate_limit_executor_submit.rst
+++ b/changelog.d/20240918_223810_kevin_bursty_rate_limit_executor_submit.rst
@@ -1,0 +1,15 @@
+Changed
+^^^^^^^
+
+- The Executor now implements a bursty rate-limit in the background submission
+  thread.  The Executor is designed to coalesce up to ``.batch_size`` of tasks
+  and submit them in a single API call.  But if tasks are supplied to the
+  Executor at just the right frequency, it will send much smaller batches more
+  frequently which is "not nice" to the API.  This change allows "bursts" of up
+  to 4 API calls in a 16s window, and then will back off to submit every 4
+  seconds.  Notes:
+
+  - ``.batch_size`` currently defaults to 128 but is user-settable
+
+  - If the Executor is able to completely fill the batch of tasks sent to the
+    API, that call is not counted toward the burst limit


### PR DESCRIPTION
The Executor currently drains the incoming task queue or stops draining at `.batch_size` before submitting to the API.  If tasks are `.submit()`ed at just the right cadence, it's possible to get the Executor to send lots of small batches very frequently rather than coalescing more tasks.

The fix implemented here is to allow up to 5 back-to-back API `/submit` calls within a window of 25s.  If more API calls come in after than, then induce up to a 6s delay so as to play nice with the API.  The burst window will hopefully be ample to work within a Jupyter notebook and not be an annoyance to a human working through cells, and only up to a 6s delay after that until the window clears.

(Discovered via log trawling and conversations with a user in funcx#help.)

[sc-35759]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)