### PR TITLE
Implement JSON serialization strategy

### DIFF
--- a/changelog.d/20240919_155327_chris_json_serializer.rst
+++ b/changelog.d/20240919_155327_chris_json_serializer.rst
@@ -1,0 +1,17 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added a new data serialization strategy, ``JSONData``, which serializes/deserializes
+  function args and kwargs via JSON. Usage example:
+
+  .. code-block:: python
+
+    from globus_compute_sdk import Client, Executor
+    from globus_compute_sdk.serialize import JSONData
+
+    gcc = Client(
+        data_serialization_strategy=JSONData()
+    )
+
+    with Executor(<your endpoint UUID>, client=gcc) as gcx:
+        # do something with gcx

--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -33,7 +33,7 @@ class SerializationError(SerdeError):
         self.reason = reason
 
     def __repr__(self):
-        return f"Serialization failed due to {self.reason}"
+        return f"Serialization failed: {self.reason}"
 
 
 class DeserializationError(SerdeError):
@@ -43,7 +43,7 @@ class DeserializationError(SerdeError):
         self.reason = reason
 
     def __repr__(self):
-        return f"Deserialization failed due to {self.reason}"
+        return f"Deserialization failed: {self.reason}"
 
 
 class TaskPending(ComputeError):

--- a/compute_sdk/globus_compute_sdk/serialize/__init__.py
+++ b/compute_sdk/globus_compute_sdk/serialize/__init__.py
@@ -7,6 +7,7 @@ from globus_compute_sdk.serialize.concretes import (
     DillCodeSource,
     DillCodeTextInspect,
     DillDataBase64,
+    JSONData,
 )
 from globus_compute_sdk.serialize.facade import ComputeSerializer
 
@@ -21,4 +22,5 @@ __all__ = [
     "DillCodeSource",
     "DillCodeTextInspect",
     "DillDataBase64",
+    "JSONData",
 ]

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import codecs
 import inspect
+import json
 import logging
 import pickle
 import typing as t
@@ -28,6 +29,22 @@ class DillDataBase64(SerializationStrategy):
     def deserialize(self, payload: str):
         chomped = self.chomp(payload)
         data = dill.loads(codecs.decode(chomped.encode(), "base64"))
+        return data
+
+
+class JSONData(SerializationStrategy):
+    identifier = "11\n"
+    _for_code = False
+
+    def __init__(self):
+        super().__init__()
+
+    def serialize(self, data) -> str:
+        return self.identifier + json.dumps(data)
+
+    def deserialize(self, payload: str):
+        chomped = self.chomp(payload)
+        data = json.loads(chomped)
         return data
 
 
@@ -230,6 +247,7 @@ class CombinedCode(SerializationStrategy):
 
 STRATEGIES_MAP: dict[str, t.Type[SerializationStrategy]] = {
     DillDataBase64.identifier: DillDataBase64,
+    JSONData.identifier: JSONData,
     DillCodeSource.identifier: DillCodeSource,
     DillCode.identifier: DillCode,
     DillCodeTextInspect.identifier: DillCodeTextInspect,
@@ -239,6 +257,7 @@ STRATEGIES_MAP: dict[str, t.Type[SerializationStrategy]] = {
 
 SELECTABLE_STRATEGIES = [
     DillDataBase64,
+    JSONData,
     DillCodeSource,
     DillCode,
     DillCodeTextInspect,

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -282,31 +282,31 @@ another serializer, use the ``code_serialization_strategy`` and
 .. code:: python
 
   from globus_compute_sdk import Client, Executor
-  from globus_compute_sdk.serialize import DillDataBase64, CombinedCode
+  from globus_compute_sdk.serialize import CombinedCode, JSONData
 
   gcc = Client(
     code_serialization_strategy=CombinedCode(),
-    data_serialization_strategy=DillDataBase64()
+    data_serialization_strategy=JSONData()
   )
   gcx = Executor('4b116d3c-1703-4f8f-9f6f-39921e5864df', client=gcc)
 
   # do something with gcx
 
-Note that currently the only supported data serialization strategy is ``DillDataBase64``.
+Note that currently the only alternative data serialization strategy is ``JSONData``.
 
 To check whether a strategy works for a given use-case, use the ``check_strategies``
 method:
 
 .. code:: python
 
-  from globus_compute_sdk.serialize import ComputeSerializer, DillCodeSource, DillDataBase64
+  from globus_compute_sdk.serialize import ComputeSerializer, DillCodeSource, JSONData
 
   def greet(name, greeting = "greetings"):
     return f"{greeting} {name}"
 
   serializer = ComputeSerializer(
     strategy_code=DillCodeSource(),
-    strategy_data=DillDataBase64()
+    strategy_data=JSONData()
   )
 
   serializer.check_strategies(greet, "world", greeting="hello")
@@ -317,8 +317,8 @@ method:
   fn, args, kwargs = serializer.check_strategies(greet, "world", greeting="hello")
   assert fn(*args, **kwargs) == greet("world", greeting="hello")
 
-Supported Method Serialization Strategies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Supported Serialization Strategies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Note that if ``DillCode`` does not work for your use case, whether it is due
 to differing python/dill version or because of the construction of your method,
@@ -327,6 +327,13 @@ the other alternatives that we currently support are ``DillTextInspect`` and
 strategies and will use the first one that deserializes successfully at
 execution time.
 
+For data, the available strategies are ``DillDataBase64``, which serializes data to
+binary via dill and then to a string format via base-64 encoding, and ``JSONData``,
+which serializes data to JSON. ``DillDataBase64`` can serialize arbitrary python
+objects, while ``JSONData`` can only serialize JSON-able objects: generally ``str``,
+``int``, ``float``, ``bool``, and ``None``, and (potentially nested) ``dict``\s and
+``list``\s containing only those data types. ``JSONData`` is ideal for low-trust
+workflows, because deserialization via dill can result in arbitrary code execution.
 
 Avoiding Serialization Errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description

Adds `JSONData` serialization strategy. Also tweaks the serde error message wording a little bit.

```python
from globus_compute_sdk.serialize import ComputeSerializer, JSONData

serde = ComputeSerializer(strategy_data=JSONData())

print(serde.deserialize(serde.serialize({"some": ["json", "data"]})))
# >>> {"some": ["json", "data"]}

not_json = JSONData()
serde.serialize(not_json)
# ---------------------------------------------------------------------------
# TypeError                                 Traceback (most recent call last)
# 
# 
# ...
# 
# 
# File ~/opt/anaconda3/envs/compute/lib/python3.10/json/encoder.py:179, in JSONEncoder.default(self, o)
#     161 """Implement this method in a subclass such that it returns
#     162 a serializable object for ``o``, or calls the base implementation
#     163 (to raise a ``TypeError``).
#    (...)
#     177 
#     178 """
# --> 179 raise TypeError(f'Object of type {o.__class__.__name__} '
#     180                 f'is not JSON serializable')

# TypeError: Object of type JSONData is not JSON serializable

# The above exception was the direct cause of the following exception:

# SerializationError                        Traceback (most recent call last)
# Cell In[1], line 8
#       5 print(serde.deserialize(serde.serialize({"some": ["json", "data"]})))
#       7 not_json = JSONData()
# ----> 8 serde.serialize(not_json)

# File ~/ws/compute/globus-compute/compute_sdk/globus_compute_sdk/serialize/facade.py:63, in ComputeSerializer.serialize(self, data)
#      61 except Exception as e:
#      62     err_msg = f"{stype} serialization strategy {type(strategy).__name__} failed"
# ---> 63     raise SerializationError(err_msg) from e

# SerializationError: Serialization failed: Data serialization strategy JSONData failed
```

See `tests/integration/test_serialization.py:test_check_strategies` for a test that exercises this.

[[sc-35783]](https://app.shortcut.com/globus/story/35783/support-json-serializer-for-args-and-kwargs)

## Type of change

- New feature (non-breaking change that adds functionality)
