### PR TITLE
Remove obsolete Executor args

### DIFF
--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -15,7 +15,7 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy==1.10.0
+    mypy==1.11.2
     # Ensure that the Pydantic mypy plugin uses the V1 API
     pydantic>=1,<2
     ../compute_sdk/

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -135,7 +135,6 @@ class Executor(concurrent.futures.Executor):
         user_endpoint_config: dict[str, t.Any] | None = None,
         label: str = "",
         batch_size: int = 128,
-        funcx_client: Client | None = None,
         amqp_port: int | None = None,
         **kwargs,
     ):
@@ -155,14 +154,10 @@ class Executor(concurrent.futures.Executor):
             logging and advanced needs with multiple executors.
         :param batch_size: the maximum number of tasks to coalesce before
             sending upstream [min: 1, default: 128]
-        :param funcx_client: [DEPRECATED] alias for client.
-        :param batch_interval: [DEPRECATED; unused] number of seconds to coalesce tasks
-            before submitting upstream
-        :param batch_enabled: [DEPRECATED; unused] whether to batch results
         :param amqp_port: Port to use when connecting to results queue. Note that the
             Compute web services only support 5671, 5672, and 443.
         """
-        deprecated_kwargs = {"batch_interval", "batch_enabled"}
+        deprecated_kwargs = {""}
         for key in kwargs:
             if key in deprecated_kwargs:
                 warnings.warn(
@@ -173,17 +168,7 @@ class Executor(concurrent.futures.Executor):
             msg = f"'{key}' is an invalid argument for {self.__class__.__name__}"
             raise TypeError(msg)
 
-        if funcx_client:
-            warnings.warn(
-                "'funcx_client' is superseded by 'client'"
-                " and will be removed in a future release",
-                DeprecationWarning,
-            )
-
-        if not client:
-            client = funcx_client if funcx_client else Client()
-
-        self.client = client
+        self.client = client or Client()
 
         self.endpoint_id = endpoint_id
 

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -191,17 +191,6 @@ def test_task_submission_snapshots_data(tg_id, fn_id, ep_id, res_spec, uep_confi
     assert before_changes == after_changes
 
 
-@pytest.mark.parametrize("argname", ("batch_interval", "batch_enabled"))
-def test_deprecated_args_warned(argname, mocker):
-    mock_warn = mocker.patch(f"{_MOCK_BASE}warnings")
-    gcc = mock.Mock(spec=Client)
-    Executor(client=gcc).shutdown()
-    mock_warn.warn.assert_not_called()
-
-    Executor(client=gcc, **{argname: 1}).shutdown()
-    mock_warn.warn.assert_called()
-
-
 def test_invalid_args_raise(randomstring):
     invalid_arg = f"abc_{randomstring()}"
     with pytest.raises(TypeError) as wrapped_err:

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -13,7 +13,7 @@ commands =
     coverage report --skip-covered
 
 [testenv:mypy]
-deps = mypy==1.10.0
+deps = mypy==1.11.2
 commands = mypy -p globus_compute_sdk {posargs}
 
 [testenv:pip-audit]


### PR DESCRIPTION
Update mypy as consequence of an unrelated change that removing these deprecated args now seems to trigger.  1.11.2 does not fail where 1.10.0 did. :shrug:

## Type of change

- Code maintenance/cleanup