### PR TITLE
Allow UEPs to create log files

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1017,7 +1017,8 @@ class EndpointManager:
             exit_code += 1
 
             log.debug("Convey credentials; redirect stdout, stderr (to '%s')", ep_log)
-            log_fd = os.open(ep_log, os.O_WRONLY | os.O_APPEND | os.O_SYNC, mode=0o200)
+            log_fd_flags = os.O_CREAT | os.O_WRONLY | os.O_APPEND | os.O_SYNC
+            log_fd = os.open(ep_log, log_fd_flags, mode=0o200)
             with os.fdopen(log_fd, "w") as log_f:
                 if os.dup2(log_f.fileno(), 1) != 1:
                     raise OSError(f"Unable to redirect stdout to {ep_log}")

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -1958,7 +1958,8 @@ def test_redirect_stdstreams_to_user_log(
     mock_os.O_WRONLY = 0x1
     mock_os.O_APPEND = 0x2
     mock_os.O_SYNC = 0x4
-    exp_flags = mock_os.O_WRONLY | mock_os.O_APPEND | mock_os.O_SYNC
+    mock_os.O_CREAT = 0x8
+    exp_flags = mock_os.O_CREAT | mock_os.O_WRONLY | mock_os.O_APPEND | mock_os.O_SYNC
 
     uep_name = command_payload["kwargs"]["name"]
     uep_dir = mock_ensure_compute_dir() / uep_name


### PR DESCRIPTION
If a log file exists, then `os.open` was opening the file as expected.  But I forgot to include the `O_CREAT` flag so new endpoints would fail to start when the log file would fail to open.  Whoops!

Luckily we caught this before the recent log changes were released; no changelog necessary.

## Type of change

- Bug fix (but caught before feature release so win!)