### PR TITLE
Make UEP endpoint.log readable by default

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1018,7 +1018,7 @@ class EndpointManager:
 
             log.debug("Convey credentials; redirect stdout, stderr (to '%s')", ep_log)
             log_fd_flags = os.O_CREAT | os.O_WRONLY | os.O_APPEND | os.O_SYNC
-            log_fd = os.open(ep_log, log_fd_flags, mode=0o200)
+            log_fd = os.open(ep_log, log_fd_flags, mode=0o600)
             with os.fdopen(log_fd, "w") as log_f:
                 if os.dup2(log_f.fileno(), 1) != 1:
                     raise OSError(f"Unable to redirect stdout to {ep_log}")

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -1972,6 +1972,7 @@ def test_redirect_stdstreams_to_user_log(
 
     a, k = next((a, k) for a, k in mock_os.open.call_args_list if a[0] == ep_log)
     assert a[1] == exp_flags, "Expect replacement stdout/stderr: append, wronly, sync"
+    assert k["mode"] == 0o600, "Expect default to writable *and* readable"
 
 
 @pytest.mark.parametrize("debug", (True, False))


### PR DESCRIPTION
There's a distinction between the file permissions, and the descriptor permissions.  The descriptor, per stdout and stderr needs only to be writable. But the file, per other tools, needs to be readable.  `chmod` is easy enough to invoke, but there's no need to for us to do the weird thing here.  So, create the file with user rw perms.

Before:

```console
$ cd ~/.globus_compute/uep.[mep_uuid].[uep_uuid1]/
$ ls -l endpoint.log
--w------- 1 kevin kevin 367 Sep 30  7:49 endpoint.log
```

After:

```console
$ cd ~/.globus_compute/uep.[mep_uuid].[uep_uuid2]/
$ ls -l endpoint.log
-rw------- 1 kevin kevin 367 Sep 30  7:51 endpoint.log
```

## Type of change

- Code maintenance/cleanup