### PR TITLE
Improve error message for errant func registration

### DIFF
--- a/changelog.d/20241008_092953_kevin_improve_double_registration_error_message.rst
+++ b/changelog.d/20241008_092953_kevin_improve_double_registration_error_message.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fix ``function_id`` in error message that previously referenced ``None``


### PR DESCRIPTION
The observed behavior in the wild was that a double registration would complain (correctly), but reference `None` as the function id.  Clearly not helpful. Improve the situation by referencing the cached value, but also relax the double-registration constraint slightly: if the calling code attempts to re-register the function with the _same_ id, then that's odd -- so warn about it -- but let it go.  Still raise the exception for other errant registration attempts.

[sc-36241]

## Type of change

- Bug fix (non-breaking change that fixes an issue)