### PR TITLE
Add short label to Kubernetes example config

### DIFF
--- a/docs/endpoints/configs/kube.yaml
+++ b/docs/endpoints/configs/kube.yaml
@@ -3,6 +3,7 @@ heartbeat_threshold: 200
 
 engine:
     type: GlobusComputeEngine
+    label: kube
     max_workers_per_node: 1
 
     # Encryption is not currently supported for KubernetesProvider


### PR DESCRIPTION
# Description

A recent change (PR #1654) to the default `label` argument value passed to the `HighThroughputExecutor` causes Parsl's `KubernetesProvider` to hit a maximum character limit for pod labels.

Users should be able to specify labels of almost any length without causing issues, so this should be addressed directly in Parsl. For now, to help users avoid this bug, the example config manually sets a short label value.

## Type of change

- Documentation update
