### PR TITLE
add diagnostic ack message with file name

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -476,6 +476,8 @@ def run_all_diags_wrapper(
             out_bytes = "".join(diagnostic_output).encode()
             f_out.write(out_bytes)
 
+        print(f"Compressed diagnostic output successfully writen to {zip_filename}")
+
 
 def do_diagnostic_base(diagnostic_args):
     """

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -326,8 +326,13 @@ def test_diagnostic_gzip(
                 diagnostic_heading_count += 1
         assert diagnostic_heading_count >= 5
     else:
-        # Should be an empty ''
-        assert len(captured_stdout) == 1 and not captured_stdout[0]
+        assert len(captured_stdout) == 2
+
+    assert captured_stdout[-2].startswith(
+        "Compressed diagnostic output successfully writen to globus_compute_diagnostic_"
+    )
+    # Ends with line break
+    assert not captured_stdout[-1]
 
     for random_file_data in mock_endpoint_config_dir_data.values():
         assert random_file_data in contents


### PR DESCRIPTION
The recently refactored diagnostic command is silent when doing the default zip option without the --verbose flag.

Too silent - if the diagnostic is quick, there is no information for the user of what happened, and the command completes with no output - may be confusing to the user 'did it work?'.

On Josh's suggestion, this PR adds a simple message acknowledging that the diagnostic was run, and what the generated filename is, see attached screenshot for the normal and --verbose outputs., compared to previous behavior.

![Screenshot 2024-10-15 at 5 11 26 PM](https://github.com/user-attachments/assets/0ed394d7-5f2b-4365-9597-2495581c87d5)

(previously, without info)

![Screenshot 2024-10-15 at 5 18 56 PM](https://github.com/user-attachments/assets/e57b9e27-419f-4abd-8976-8d68e692f1e7)
