### PR TITLE
Remove pipx --include-deps flag from docs

### DIFF
--- a/docs/endpoints/single_user.rst
+++ b/docs/endpoints/single_user.rst
@@ -18,7 +18,7 @@ For those just looking for the quickstart commands:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint --include-deps
+   $ python3 -m pipx install globus-compute-endpoint
 
    $ globus-compute-endpoint configure my_first_endpoint
 
@@ -37,7 +37,7 @@ recommend use of |pipx for library isolation|_:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint --include-deps
+   $ python3 -m pipx install globus-compute-endpoint
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ how to download and configure an endpoint for local (multi-process) execution:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint --include-deps
+   $ python3 -m pipx install globus-compute-endpoint
 
    $ globus-compute-endpoint configure
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -64,7 +64,7 @@ The Globus Compute endpoint can be installed using `Pipx <https://pypa.github.io
 
 .. code-block:: console
 
-  $ python3 -m pipx install globus-compute-endpoint --include-deps
+  $ python3 -m pipx install globus-compute-endpoint
 
 or
 


### PR DESCRIPTION
# Description

As of https://github.com/globus/globus-compute/pull/1600, we call Parsl's `process_worker_pool.py` script via the `python exec` endpoint CLI subcommand. Hence, this flag is no longer necessary.

## Type of change

- Documentation update
