### PR TITLE
Bump globus-sdk dependency to at least v3.46.0

### DIFF
--- a/changelog.d/20241015_192243_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20241015_192243_30907815+rjmello_HEAD.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bumped ``globus-sdk`` dependency to at least 3.46.0.

--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -6,7 +6,7 @@ import textwrap
 from click import ClickException
 from globus_compute_endpoint.endpoint.config.utils import get_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_sdk.experimental.globus_app import GlobusApp
+from globus_sdk import GlobusApp
 
 _SYSTEMD_UNIT_DIR = pathlib.Path("/etc/systemd/system")
 

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -30,8 +30,7 @@ from globus_compute_sdk.sdk.auth.whoami import print_whoami_info
 from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
 from globus_compute_sdk.sdk.diagnostic import do_diagnostic_base
 from globus_compute_sdk.sdk.web_client import WebClient
-from globus_sdk import MISSING, AuthClient, GlobusAPIError, MissingType
-from globus_sdk.experimental.globus_app import GlobusApp
+from globus_sdk import MISSING, AuthClient, GlobusAPIError, GlobusApp, MissingType
 
 try:
     from globus_compute_endpoint.endpoint.endpoint_manager import EndpointManager

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -11,7 +11,7 @@ from globus_compute_endpoint.boot_persistence import (
     enable_on_boot,
 )
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_sdk.experimental.globus_app import UserApp
+from globus_sdk import UserApp
 from pyfakefs import fake_filesystem as fakefs
 
 _MOCK_BASE = "globus_compute_endpoint.boot_persistence."

--- a/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import platform
 import sys
 
-from globus_sdk.experimental.globus_app import ClientApp, GlobusAppConfig, UserApp
+from globus_sdk import ClientApp, GlobusAppConfig, UserApp
 
 from .client_login import get_client_creds
 from .token_storage import get_token_storage

--- a/compute_sdk/globus_compute_sdk/sdk/auth/token_storage.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/token_storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-from globus_sdk.experimental.tokenstorage import SQLiteTokenStorage
+from globus_sdk.tokenstorage import SQLiteTokenStorage
 
 from .._environments import _get_envname
 from ..compute_dir import ensure_compute_dir

--- a/compute_sdk/globus_compute_sdk/sdk/auth/whoami.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/whoami.py
@@ -4,8 +4,7 @@ import logging
 
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.utils.printing import print_table
-from globus_sdk import AuthAPIError
-from globus_sdk.experimental.globus_app import GlobusApp
+from globus_sdk import AuthAPIError, GlobusApp
 
 NOT_LOGGED_IN_MSG = "Unable to retrieve user information. Please log in again."
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -21,7 +21,7 @@ from globus_compute_sdk.sdk.web_client import (
 )
 from globus_compute_sdk.serialize import ComputeSerializer, SerializationStrategy
 from globus_compute_sdk.version import __version__, compare_versions
-from globus_sdk.experimental.globus_app import GlobusApp
+from globus_sdk import GlobusApp
 from globus_sdk.version import __version__ as __version_globus__
 
 from .auth.auth_client import ComputeAuthClient

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -16,9 +16,7 @@ from globus_compute_sdk.sdk._environments import get_web_service_url, remove_url
 from globus_compute_sdk.sdk.utils.uuid_like import UUID_LIKE_T
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.version import __version__
-from globus_sdk.exc.api import GlobusAPIError
-from globus_sdk.experimental.globus_app import GlobusApp
-from globus_sdk.scopes import Scope
+from globus_sdk import GlobusAPIError, GlobusApp, Scope
 
 from .auth.scopes import ComputeScopes
 

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.45.0,<4",
+    "globus-sdk>=3.46.0,<4",
     "globus-compute-common==0.4.1",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear

--- a/compute_sdk/tests/unit/auth/test_globus_app.py
+++ b/compute_sdk/tests/unit/auth/test_globus_app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from globus_compute_sdk.sdk.auth.globus_app import DEFAULT_CLIENT_ID, get_globus_app
-from globus_sdk.experimental.globus_app import ClientApp, UserApp
+from globus_sdk import ClientApp, UserApp
 from pytest_mock import MockerFixture
 
 _MOCK_BASE = "globus_compute_sdk.sdk.auth.globus_app."

--- a/compute_sdk/tests/unit/auth/test_token_storage.py
+++ b/compute_sdk/tests/unit/auth/test_token_storage.py
@@ -7,7 +7,7 @@ from globus_compute_sdk.sdk.auth.token_storage import (
     _resolve_namespace,
     get_token_storage,
 )
-from globus_sdk.experimental.tokenstorage import SQLiteTokenStorage
+from globus_sdk.tokenstorage import SQLiteTokenStorage
 from pytest_mock import MockerFixture
 
 _MOCK_BASE = "globus_compute_sdk.sdk.auth.token_storage."

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -16,8 +16,8 @@ from globus_compute_sdk.sdk.web_client import (
 )
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.serialize.concretes import SELECTABLE_STRATEGIES
+from globus_sdk import UserApp
 from globus_sdk import __version__ as __version_globus__
-from globus_sdk.experimental.globus_app import UserApp
 from pytest_mock import MockerFixture
 
 _MOCK_BASE = "globus_compute_sdk.sdk.client."

--- a/compute_sdk/tests/unit/test_whoami.py
+++ b/compute_sdk/tests/unit/test_whoami.py
@@ -1,7 +1,7 @@
 import pytest
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.auth.whoami import NOT_LOGGED_IN_MSG, print_whoami_info
-from globus_sdk.experimental.globus_app import UserApp
+from globus_sdk import UserApp
 from pytest_mock import MockerFixture
 
 MOCK_BASE = "globus_compute_sdk.sdk.auth.whoami"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,7 @@ New Functionality
   ``GLOBUS_COMPUTE_CLIENT_SECRET`` environment variables, or pass in a custom ``ClientApp``.
 
   For more information on how to use a ``GlobusApp``, see the `Globus SDK documentation
-  <https://globus-sdk-python.readthedocs.io/en/stable/experimental/examples/oauth2/globus_app.html>`_.
+  <https://globus-sdk-python.readthedocs.io/en/stable/authorization/globus_app/apps.html>`_.
 
   Users can still pass in a custom ``LoginManager`` to the ``login_manager`` argument, but
   this is mutually exclusive with the ``app`` argument.
@@ -32,8 +32,7 @@ New Functionality
 
   .. code-block:: python
 
-     from globus_compute_sdk import Client
-     from globus_sdk.experimental.globus_app import UserApp
+     from globus_compute_sdk import Client, UserApp
 
      gcc = Client()
 


### PR DESCRIPTION
# Description

Version 3.46.0 moves `GlobusApp` and `TokenStorage` objects out of the `globus_sdk.experimental` module, so I also updated the relevant import paths.

## Type of change

- Code maintenance/cleanup
