### PR TITLE
Fix AuthorizerLoginManager KeyError

### DIFF
--- a/changelog.d/20241017_111821_30907815+rjmello_fix_authz_lm_auth_client.rst
+++ b/changelog.d/20241017_111821_30907815+rjmello_fix_authz_lm_auth_client.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fixed a ``KeyError`` that occurred when using an ``AuthorizerLoginManager`` with
+  a ``Client``, or when calling the ``AuthorizerLoginManager.get_auth_client()``
+  method directly.

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
@@ -25,7 +25,9 @@ class AuthorizerLoginManager(LoginManagerProtocol):
         self.authorizers = authorizers
 
     def get_auth_client(self) -> globus_sdk.AuthClient:
-        return globus_sdk.AuthClient(authorizer=self.authorizers[AuthScopes.openid])
+        return globus_sdk.AuthClient(
+            authorizer=self.authorizers[AuthScopes.resource_server]
+        )
 
     def get_web_client(
         self, *, base_url: str | None = None, app_name: str | None = None


### PR DESCRIPTION
# Description

The `AuthorizerLoginManager.get_auth_client()` method used the wrong resource server name to get the relevant authorizer, leading to a `KeyError`. This cropped up because, as of #1661, the `Client` calls this method directly.

[sc-36693]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
