### PR TITLE
Enable working_dir configurability and safety

### DIFF
--- a/changelog.d/20241023_095610_yadudoc1729_configure_tasks_working_dir.rst
+++ b/changelog.d/20241023_095610_yadudoc1729_configure_tasks_working_dir.rst
@@ -1,0 +1,20 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- ``GlobusComputeEngine``, ``ThreadPoolEngine``, and ``ProcessPoolEngine`` can
+  now be configured with ``working_dir`` to specify the tasks working directory.
+  If a relative path is specified, it is set in relation to the endpoint
+  run directory (usually ``~/.globus_compute/<endpoint_name>``). Here's an example
+  config file:
+
+  .. code-block:: yaml
+
+    engine:
+      type: GlobusComputeEngine
+      working_dir: /absolute/path/to/tasks_working_dir
+
+Bug Fixes
+^^^^^^^^^
+
+ - Fixed a bug where functions run with ``ThreadPoolEngine`` and ``ProcessPoolEngine``
+   create and switch into the ``tasks_working_dir`` creating endless nesting.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -50,7 +50,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         encrypted: bool = True,
         strategy: str | None = None,
         job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
-        working_dir: str | os.PathLike = "tasks_working_dir",
         run_in_sandbox: bool = False,
         **kwargs,
     ):
@@ -89,13 +88,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
 
         encrypted: bool
             Flag to enable/disable encryption (CurveZMQ). Default is True.
-
-        working_dir: str | os.PathLike
-            Directory within which functions should execute, defaults to
-            (~/.globus_compute/<endpoint_name>/tasks_working_dir)
-            If a relative path is supplied, the working dir is set relative
-            to the endpoint.run_dir. If an absolute path is supplied, it is
-            used as is.
 
         run_in_sandbox: bool
             Functions will run in a sandbox directory under the working_dir
@@ -146,7 +138,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.executor.interchange_launch_cmd = self._get_compute_ix_launch_cmd()
         self.executor.launch_cmd = self._get_compute_launch_cmd()
 
-        self.working_dir = working_dir
         self.run_in_sandbox = run_in_sandbox
         if strategy is None:
             strategy = "simple"
@@ -249,9 +240,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         assert endpoint_id, "GCExecutor requires kwarg:endpoint_id at start"
         assert run_dir, "GCExecutor requires kwarg:run_dir at start"
 
-        if not os.path.isabs(self.working_dir):
-            # set relative to run_dir
-            self.working_dir = os.path.join(run_dir, self.working_dir)
+        self.set_working_dir(run_dir=run_dir)
 
         self.endpoint_id = endpoint_id
         self.run_dir = run_dir

--- a/compute_endpoint/globus_compute_endpoint/engines/helper.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/helper.py
@@ -58,14 +58,19 @@ def execute_task(
 
     os.environ.pop("GC_TASK_SANDBOX_DIR", None)
     os.environ["GC_TASK_UUID"] = str(task_id)
-    if run_dir:
-        os.makedirs(run_dir, exist_ok=True)
-        os.chdir(run_dir)
-        if run_in_sandbox:
-            os.makedirs(str(task_id))  # task_id is expected to be unique
-            os.chdir(str(task_id))
-            # Set sandbox dir so that apps can use it
-            os.environ["GC_TASK_SANDBOX_DIR"] = os.getcwd()
+
+    if not run_dir or not os.path.isabs(run_dir):
+        raise RuntimeError(
+            f"execute_task requires an absolute path for run_dir, got {run_dir=}"
+        )
+
+    os.makedirs(run_dir, exist_ok=True)
+    os.chdir(run_dir)
+    if run_in_sandbox:
+        os.makedirs(str(task_id))  # task_id is expected to be unique
+        os.chdir(str(task_id))
+        # Set sandbox dir so that apps can use it
+        os.environ["GC_TASK_SANDBOX_DIR"] = os.getcwd()
 
     env_details = get_env_details()
     try:

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
@@ -779,7 +779,11 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
 
         container_loc = self._get_container_location(packed_task)
         ser = serializer.serialize(
-            (execute_task, [task_id, packed_task, self.endpoint_id], {})
+            (
+                execute_task,
+                [task_id, packed_task, self.endpoint_id],
+                {"run_dir": self.run_dir},
+            )
         )
         payload = Task(task_id, container_loc, ser).pack()
         assert self.outgoing_q  # Placate mypy

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -34,6 +34,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         self,
         *args,
         endpoint_id: t.Optional[uuid.UUID] = None,
+        run_dir: t.Optional[str] = None,
         results_passthrough: t.Optional[queue.Queue] = None,
         **kwargs,
     ) -> None:
@@ -41,6 +42,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         Parameters
         ----------
         endpoint_id: Endpoint UUID
+        run_dir: endpoint run directory
         results_passthrough: Queue to which packed results will be posted
         Returns
         -------
@@ -59,6 +61,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         if results_passthrough:
             self.results_passthrough = results_passthrough
         assert self.results_passthrough
+        self.set_working_dir(run_dir=run_dir)
 
         self._status_report_thread.start()
 

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -32,6 +32,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         self,
         *args,
         endpoint_id: t.Optional[uuid.UUID] = None,
+        run_dir: t.Optional[str] = None,
         results_passthrough: t.Optional[queue.Queue] = None,
         **kwargs,
     ) -> None:
@@ -39,8 +40,8 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         Parameters
         ----------
         endpoint_id: Endpoint UUID
+        run_dir: endpoint run directory
         results_passthrough: Queue to which packed results will be posted
-        run_dir Not used
         Returns
         -------
         """
@@ -50,6 +51,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
             self.results_passthrough = results_passthrough
         assert self.results_passthrough
 
+        self.set_working_dir(run_dir=run_dir)
         # mypy think the thread can be none
         self._status_report_thread.start()
 

--- a/compute_endpoint/tests/utils.py
+++ b/compute_endpoint/tests/utils.py
@@ -131,3 +131,9 @@ def get_env_vars():
     import os
 
     return os.environ
+
+
+def get_cwd():
+    import os
+
+    return os.getcwd()


### PR DESCRIPTION
# Description


Currently `ThreadPoolEngine` and `ProcessPoolEngine` now pass the working_dir: default `tasks_working_dir`. 
Executing functions on these engines affect subsequent function execution when they say change directory for eg, unlike `GlobusComputeEngine`. When executing functions, our `execute_task` wrapper currently attempts to look for a `tasks_working_dir` in the current dir, creates it if not present, and then switches into it. Unfortunately, each subsequent function finds itself one directory deeper.

* This PR updates `GlobusComputeEngineBase` to check if the `working_dir` is an absolute path, and if not make it absolute. This ensures that every function would run in `~/.globus_compute/<endpoint_name>/tasks_working_dir`.
* `working_dir` is now a configurable option for all engines.
* tests to confirm that running multiple functions do not change directory 


Fixes # (issue)

[sc-36710]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Documentation update
- Code maintenance/cleanup
