### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -78,7 +78,7 @@ jobs:
         options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Quickstart
 
 Globus Compute is currently available on PyPI.
 
-To install Globus Compute, please ensure you have python3.8+.::
+To install Globus Compute, please ensure you have python3.9+.::
 
    $ python3 --version
 

--- a/changelog.d/20241023_194824_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20241023_194824_30907815+rjmello_HEAD.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Drop support for Python 3.8, which entered the end-of-life phase on
+  10-07-2024 (https://peps.python.org/pep-0569/).

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -74,7 +74,7 @@ setup(
     extras_require={
         "test": TEST_REQUIRES,
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,310,39,38}
+envlist = py{311,310,39}
 skip_missing_interpreters = true
 
 [testenv]

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -81,7 +81,7 @@ setup(
         "test": TEST_REQUIRES,
         "docs": DOCS_REQUIRES,
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,310,39,38,37}
+envlist = py{311,310,39}
 skip_missing_interpreters = true
 
 [testenv]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,7 +13,7 @@ Installation
 
 The pre-requisites for the `Globus Compute endpoint` and the `Globus Compute client` are
 
-  1. Python3.8+
+  1. Python3.9+
   2. The machine must have outbound network access
 
 The ``-V`` or ``--version`` arguments to the Python executable will return the version on the local system.  An example


### PR DESCRIPTION
# Description

Python 3.8 entered the end-of-life phase on 10-07-2024, and Parsl dropped support in v2024.10.14.

Ref: https://peps.python.org/pep-0569/

## Type of change

- Code maintenance/cleanup
