### PR TITLE
Bump parsl dependency to 2024.10.21

### DIFF
--- a/changelog.d/20241023_153605_30907815+rjmello_bump_parsl_2024_10_21.rst
+++ b/changelog.d/20241023_153605_30907815+rjmello_bump_parsl_2024_10_21.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version to `2024.10.21 <https://pypi.org/project/parsl/2024.10.21/>`_.

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.9.9",
+    "parsl==2024.10.21",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -326,5 +326,5 @@ def test_bad_resource_specification(
                 result = unpack(mbody)
                 break
     assert result.task_id == task_uuid
-    assert "Invalid resource specification options supplied: BAD_KEY" in result.data
+    assert "Invalid Resource Specification Supplied: {'BAD_KEY'}" in result.data
     assert result.error_details.code == "RemoteExecutionError"

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -8,9 +8,7 @@ import uuid
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result, Task
 from globus_compute_sdk import Client
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
-)
+from parsl.executors.errors import InvalidResourceSpecification
 
 
 class MockExecutor(unittest.mock.Mock):
@@ -42,7 +40,7 @@ class MockExecutor(unittest.mock.Mock):
 
         # This is a hack to trigger an InvalidResourceSpecification
         if "BAD_KEY" in resource_specification:
-            raise InvalidResourceSpecification("BAD_KEY")
+            raise InvalidResourceSpecification({"BAD_KEY"})
 
         packed_result = messagepack.pack(res)
         msg = {"task_id": str(task_id), "message": packed_result}

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -6,9 +6,7 @@ from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import GlobusMPIEngine
 from globus_compute_sdk.sdk.mpi_function import MPIFunction
 from globus_compute_sdk.sdk.shell_function import ShellResult
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
-)
+from parsl.executors.errors import InvalidResourceSpecification
 from tests.utils import get_env_vars
 
 


### PR DESCRIPTION
# Description

Pinned `parsl` dependency to version 2024.10.21.

[sc-36694]

## Type of change

- Code maintenance/cleanup
