### PR TITLE
Drop temporary fixes to Kubernetes example config

### DIFF
--- a/docs/endpoints/configs/kube.yaml
+++ b/docs/endpoints/configs/kube.yaml
@@ -3,7 +3,6 @@ heartbeat_threshold: 200
 
 engine:
     type: GlobusComputeEngine
-    label: kube
     max_workers_per_node: 1
 
     # Encryption is not currently supported for KubernetesProvider
@@ -24,10 +23,6 @@ engine:
 
         # e.g., default
         namespace: {{ NAMESPACE }}
-
-        # Must follow Kubernetes naming rules
-        # e.g., globus-compute-pod
-        pod_name: {{ POD_NAME }}
 
         # e.g., python:3.12-bookworm
         image: {{ IMAGE }}


### PR DESCRIPTION
# Description

We recently bumped our parsl dependency to version 2024.10.21 (#1693), which [includes a fix](https://github.com/Parsl/parsl/pull/3639) ensuring that the default pod names and labels for the `KubernetesProvider` comply with Kubernetes naming conventions.

Cross-ref: https://github.com/globus/globus-compute/pull/1681

## Type of change

- Documentation update
