### PR TITLE
Skip errors when stdin closed if creds cached

### DIFF
--- a/changelog.d/20241030_122237_30907815+rjmello_fix_globus_app_stdin_check.rst
+++ b/changelog.d/20241030_122237_30907815+rjmello_fix_globus_app_stdin_check.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- In cases where stdin is closed or not a TTY, we now only raise an error
+  if the user requires an interactive login flow (i.e., does not have cached
+  credentials).

--- a/compute_sdk/tests/unit/auth/test_globus_app.py
+++ b/compute_sdk/tests/unit/auth/test_globus_app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from globus_compute_sdk.sdk.auth.globus_app import DEFAULT_CLIENT_ID, get_globus_app
-from globus_sdk import ClientApp, UserApp
+from globus_sdk import ClientApp, GlobusApp, UserApp
 from pytest_mock import MockerFixture
 
 _MOCK_BASE = "globus_compute_sdk.sdk.auth.globus_app."
@@ -54,18 +54,32 @@ def test_client_app_requires_creds(mocker: MockerFixture):
     assert "GLOBUS_COMPUTE_CLIENT_SECRET must be set" in str(err.value)
 
 
-def test_user_app_requires_stdin(mocker: MockerFixture):
+@pytest.mark.parametrize("login_required", [True, False])
+@pytest.mark.parametrize("stdin_isatty", [True, False])
+@pytest.mark.parametrize("stdin_closed", [True, False])
+@pytest.mark.parametrize("is_jupyter", [True, False])
+def test_user_app_login_requires_stdin(
+    mocker: MockerFixture,
+    login_required: bool,
+    stdin_isatty: bool,
+    stdin_closed: bool,
+    is_jupyter: bool,
+):
+    mock_login_required = mocker.patch.object(GlobusApp, "login_required")
+    mock_is_jupyter = mocker.patch(f"{_MOCK_BASE}_is_jupyter")
     mock_stdin = mocker.patch(f"{_MOCK_BASE}sys.stdin")
-    mock_stdin.isatty.return_value = False
 
-    with pytest.raises(RuntimeError) as err:
-        get_globus_app()
-    assert "stdin is closed" in err.value.args[0]
-    assert "is not a TTY" in err.value.args[0]
-    assert "native app" in err.value.args[0]
+    mock_login_required.return_value = login_required
+    mock_stdin.closed = stdin_closed
+    mock_stdin.isatty.return_value = stdin_isatty
+    mock_is_jupyter.return_value = is_jupyter
 
-    mock_stdin.isatty.return_value = True
-    mock_stdin.closed = False
-
-    app = get_globus_app()
-    assert isinstance(app, UserApp)
+    if login_required and (not stdin_isatty or stdin_closed) and not is_jupyter:
+        with pytest.raises(RuntimeError) as err:
+            get_globus_app()
+        assert "stdin is closed" in err.value.args[0]
+        assert "is not a TTY" in err.value.args[0]
+        assert "native app" in err.value.args[0]
+    else:
+        app = get_globus_app()
+        assert isinstance(app, UserApp)


### PR DESCRIPTION
# Description

In cases where stdin is closed or not a TTY, we now only raise an error if the user requires an interactive login flow (i.e., does not have cached credentials).

[sc-37125]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
