### PR TITLE
Disallow function and function_name

### DIFF
--- a/changelog.d/20241101_153924_chris_function_name_code.rst
+++ b/changelog.d/20241101_153924_chris_function_name_code.rst
@@ -1,0 +1,6 @@
+Deprecated
+^^^^^^^^^^
+
+- Before this version, the ``function_name`` argument to ``Client.register_function``
+  was not used, so it has now been deprecated. As before, function names are
+  determined by the function's ``__name__`` and cannot be manually specified.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -587,6 +587,7 @@ class Client:
             The function to be registered for remote execution
         function_name : str
             The entry point (function name) of the function. Default: None
+            DEPRECATED - functions' names are derived from their ``__name__`` attribute
         container_uuid : str
             Container UUID from registration with Globus Compute
         description : str
@@ -608,11 +609,14 @@ class Client:
         function uuid : str
             UUID identifier for the registered function
         """
-        if searchable is not None:
-            warnings.warn(
-                "The 'searchable' argument is deprecated and no longer functional. "
-                "It will be removed in a future release."
-            )
+        deprecated = ["searchable", "function_name"]
+        for arg in deprecated:
+            if locals()[arg] is not None:
+                warnings.warn(
+                    f"The '{arg}' argument is deprecated and no longer functional. "
+                    "It will be removed in a future release.",
+                    DeprecationWarning,
+                )
 
         data = FunctionRegistrationData(
             function=function,

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -55,13 +55,18 @@ class FunctionRegistrationData:
         serializer: t.Optional[ComputeSerializer] = None,
     ):
         if function is not None:
+            if function_name is not None or function_code is not None:
+                raise ValueError(
+                    "Cannot specify 'function_name' or 'function_code'"
+                    " if 'function' is provided."
+                )
             function_name = function.__name__
             function_code = _get_packed_code(function, serializer=serializer)
 
         if function_name is None or function_code is None:
             raise ValueError(
                 "Either 'function' must be provided, or "
-                "both of 'function_name' and 'function_code'"
+                "both of 'function_name' and 'function_code'."
             )
 
         self.function_name = function_name


### PR DESCRIPTION
# Description

* Add a check to ensure function_name and function_code cannot be present if function is provided to FunctionRegistrationData
* Deprecate the function_name argument to Client.register_function, as it was not being used

[[sc-34831]](https://app.shortcut.com/globus/story/34831/sdk-behavior-when-function-code-and-function-name-are-both-specified)

## Type of change

- Code maintenance/cleanup
