### PR TITLE
Function description from docstring

### DIFF
--- a/changelog.d/20241101_155044_chris_function_description_from_docstring.rst
+++ b/changelog.d/20241101_155044_chris_function_description_from_docstring.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Function docstrings are now read and used as the description for the function when it
+  is uploaded. This will support future UI changes to the webapp.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -591,7 +591,10 @@ class Client:
         container_uuid : str
             Container UUID from registration with Globus Compute
         description : str
-            Description of the file
+            Description of the function. If this is None, and the function has a
+            docstring, that docstring is uploaded as the function's description instead;
+            otherwise, if this has a value, it's uploaded as the description, even if
+            the function has a docstring.
         metadata : dict
             Function metadata (E.g., Python version used when serializing the function)
         public : bool

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -6,6 +6,7 @@ It also implements data helpers for building complex payloads. Most notably,
 `FunctionRegistrationData` which can be constructed from an arbitrary callable.
 """
 
+import inspect
 import json
 import typing as t
 import warnings
@@ -62,6 +63,8 @@ class FunctionRegistrationData:
                 )
             function_name = function.__name__
             function_code = _get_packed_code(function, serializer=serializer)
+            if description is None:
+                description = inspect.getdoc(function)
 
         if function_name is None or function_code is None:
             raise ValueError(

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -51,6 +51,8 @@ is defined in the same way as any Python function before being registered with G
 .. code-block:: python
 
   def platform_func():
+    """Get platform information about this system."""
+
     import platform
     return platform.platform()
 
@@ -106,6 +108,8 @@ The following example shows how strings can be passed to and from a function.
 .. code-block:: python
 
   def hello(firstname, lastname):
+    """Say hello to someone."""
+
     return 'Hello {} {}'.format(firstname, lastname)
 
   func_id = gcc.register_function(hello)
@@ -127,7 +131,7 @@ To share with a group, set ``group=<globus_group_id>`` when registering a functi
 
 .. code-block:: python
 
-  gcc.register_function(func, description="My function", group=<globus_group_id>)
+  gcc.register_function(func, group=<globus_group_id>)
 
 
 Upon execution, Globus Compute will check group membership to ensure that the user is authorized to execute the function.
@@ -136,7 +140,28 @@ You can also set a function to be publicly accessible by setting ``public=True``
 
 .. code-block:: python
 
-  gcc.register_function(func, description="My function", public=True)
+  gcc.register_function(func, public=True)
+
+
+To add a description to a function, you can either set ``description=<my_description>``
+when calling ``register_function``, or add a docstring to the function. Note that the
+latter also works with the ``Executor`` class.
+
+.. code-block:: python
+
+  gcc.register_function(func, description="My function")
+
+  def function_with_docstring():
+    """My function, with a docstring"""
+    return "foo"
+
+  gcc.register_function(func)  # description is automatically read from the docstring
+
+  gcx = Executor()
+  fut = gcx.submit(function_with_docstring)  # automatically registers the function with its docstring
+
+  # if both are specified, the argument wins
+  gcc.register_function(function_with_docstring, description="this has priority over docstrings")
 
 
 .. _batching:
@@ -307,6 +332,8 @@ method:
   from globus_compute_sdk.serialize import ComputeSerializer, DillCodeSource, JSONData
 
   def greet(name, greeting = "greetings"):
+    """Greet someone."""
+
     return f"{greeting} {name}"
 
   serializer = ComputeSerializer(


### PR DESCRIPTION
# Description

Following our UI discussion today, it occurred to me that we don't have a user-friendly way to add a description to a function. Reading docstrings like this is really easy, so figured I'd knock it out while its on my mind (even though we don't really do anything with function descriptions yet).

~~Currently includes the changes from the other work it's based off of from #1699, hence the draft mode.~~

[[sc-37237]](https://app.shortcut.com/globus/story/37237/register-function-docstrings-as-function-descriptions)

## Type of change

- New feature (non-breaking change that adds functionality)
