### PR TITLE
Reduce spurious DNS lookups in tests

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -65,7 +65,8 @@ class ReportingThread:
 
     def stop(self) -> None:
         self._shutdown_event.set()
-        self._thread.join(timeout=0.1)
+        if self._thread.is_alive():
+            self._thread.join(timeout=0.1)
 
 
 class GlobusComputeEngineBase(ABC):

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -504,5 +504,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
 
     def shutdown(self, /, **kwargs) -> None:
         self._status_report_thread.stop()
-        self.job_status_poller.close()
+        if hasattr(self, "job_status_poller"):
+            self.job_status_poller.close()
         self.executor.shutdown()

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -33,6 +33,7 @@ detach_endpoint: false
 display_name: null
 engine:
     type: GlobusComputeEngine
+    address: 127.0.0.1
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -8,7 +8,7 @@ from globus_compute_endpoint.endpoint.config.model import ConfigModel
 
 @pytest.fixture
 def config_dict():
-    return {"engine": {"type": "GlobusComputeEngine"}}
+    return {"engine": {"type": "GlobusComputeEngine", "address": "127.0.0.1"}}
 
 
 @pytest.fixture
@@ -18,6 +18,7 @@ def config_dict_mu(tmp_path):
     return {
         "identity_mapping_config_path": idc,
         "multi_user": True,
+        "executors": [],  # remove unnecessary DNS calls; given historical design
     }
 
 
@@ -95,7 +96,7 @@ def test_config_warns_bad_identity_mapping_path(mocker, config_dict_mu, tmp_path
 
 @pytest.mark.parametrize("public", (None, True, False, "a", 1))
 def test_public(public: t.Any):
-    c = Config(public=public)
+    c = Config(public=public, executors=[])
     assert c.public is (public is True)
 
 
@@ -106,6 +107,7 @@ def test_conditional_engine_strategy(
 ):
     config_dict["engine"]["type"] = engine_type
     config_dict["engine"]["strategy"] = strategy
+    config_dict["engine"]["address"] = "127.0.0.1"
 
     if engine_type == "GlobusComputeEngine":
         if isinstance(strategy, str) or strategy is None:
@@ -138,6 +140,7 @@ def test_provider_container_compatibility(
 ):
     config_dict["engine"]["container_uri"] = "docker://ubuntu"
     config_dict["engine"]["provider"] = {"type": provider_type}
+    config_dict["engine"]["address"] = "127.0.0.1"
 
     if compatible:
         ConfigModel(**config_dict)

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -155,7 +155,7 @@ def test_serialized_engine_config_has_provider(
 
 
 def test_gcengine_compute_launch_cmd():
-    engine = GlobusComputeEngine()
+    engine = GlobusComputeEngine(address="127.0.0.1")
     assert engine.executor.launch_cmd.startswith(
         "globus-compute-endpoint python-exec"
         " parsl.executors.high_throughput.process_worker_pool"
@@ -164,7 +164,7 @@ def test_gcengine_compute_launch_cmd():
 
 
 def test_gcengine_compute_interchange_launch_cmd():
-    engine = GlobusComputeEngine()
+    engine = GlobusComputeEngine(address="127.0.0.1")
     assert engine.executor.interchange_launch_cmd[:3] == [
         "globus-compute-endpoint",
         "python-exec",
@@ -250,12 +250,12 @@ def test_gcengine_encrypted(encrypted: bool, engine_runner):
 
 
 def test_gcengine_new_executor_not_exceptional():
-    gce = GlobusComputeEngine()
+    gce = GlobusComputeEngine(address="127.0.0.1")
     assert gce.executor_exception is None, "Expect no exception from fresh Executor"
 
 
 def test_gcengine_executor_exception_passthrough(randomstring):
-    gce = GlobusComputeEngine()
+    gce = GlobusComputeEngine(address="127.0.0.1")
     exc_text = randomstring()
     gce.executor.set_bad_state_and_fail_all(ZeroDivisionError(exc_text))
     assert isinstance(gce.executor_exception, ZeroDivisionError)
@@ -263,7 +263,7 @@ def test_gcengine_executor_exception_passthrough(randomstring):
 
 
 def test_gcengine_bad_state_futures_failed_immediately(randomstring, task_uuid):
-    gce = GlobusComputeEngine()
+    gce = GlobusComputeEngine(address="127.0.0.1")
     exc_text = randomstring()
     gce.executor.set_bad_state_and_fail_all(ZeroDivisionError(exc_text))
 
@@ -278,7 +278,7 @@ def test_gcengine_bad_state_futures_failed_immediately(randomstring, task_uuid):
 
 
 def test_gcengine_exception_report_from_bad_state(task_uuid):
-    gce = GlobusComputeEngine()
+    gce = GlobusComputeEngine(address="127.0.0.1")
     gce.executor.set_bad_state_and_fail_all(ZeroDivisionError())
 
     gce.submit(
@@ -300,19 +300,19 @@ def test_gcengine_exception_report_from_bad_state(task_uuid):
 
 def test_gcengine_rejects_mpi_mode(randomstring):
     with pytest.raises(ValueError) as pyt_exc_1:
-        GlobusComputeEngine(enable_mpi_mode=True)
+        GlobusComputeEngine(enable_mpi_mode=True, address="127.0.0.1")
 
     assert "is not supported" in str(pyt_exc_1)
 
     with pytest.raises(ValueError) as pyt_exc_2:
-        GlobusComputeEngine(mpi_launcher=randomstring())
+        GlobusComputeEngine(mpi_launcher=randomstring(), address="127.0.0.1")
 
     assert "is not supported" in str(pyt_exc_2)
 
 
 def test_gcengine_rejects_resource_specification(task_uuid):
     with pytest.raises(ValueError) as pyt_exc:
-        GlobusComputeEngine().submit(
+        GlobusComputeEngine(address="127.0.0.1").submit(
             str(task_uuid),
             packed_task=b"packed_task",
             resource_specification={"foo": "bar"},
@@ -342,7 +342,7 @@ def test_gcmpiengine_accepts_resource_specification(task_uuid, randomstring):
     with mock.patch.object(GlobusMPIEngine, "_ExecutorClass") as mock_ex:
         mock_ex.__name__ = "ClassName"
         mock_ex.return_value = mock.Mock(launch_cmd="")
-        engine = GlobusMPIEngine()
+        engine = GlobusMPIEngine(address="127.0.0.1")
         engine.submit(str(task_uuid), b"some task", resource_specification=spec)
 
     assert engine.executor.submit.called, "Verify test: correct internal method invoked"


### PR DESCRIPTION
The core of this change revolves around:

- reducing splatter of tests that don't need the `GlobusComputeEngine`; these mostly use `ThreadPoolEngine` now

- Specifying `address="127.0.0.1"` for those tests that do need the `GlobusComputeEngine`&nbsp;&mdash;&nbsp;for the tests, there should be no need to look farther than home

At a cleanliness level, this set of changes should not be controversial&nbsp;&mdash;&nbsp;the tests have no business making arbitrary lookups of the network.  Pragmatically, this also improves performance (negligible on fast networks, but by a good amount on slow networks).

To the reviewer: I waffled on `quick-review`, but I think the changes, while somewhat numerous, are basically the same thing over and over.

## Type of change

- Code maintenance/cleanup