### PR TITLE
Don't needlessly instantiate GlobusComputeExecutor

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -82,6 +82,13 @@ def load_config_yaml(config_str: str) -> Config:
     config_dict = config_schema.dict(exclude_unset=True)
 
     try:
+        if config_dict.get("multi_user") is True:
+            # Temporary hack to not instantiate executor for MU; necessary due to the
+            # historical design to default-instantiate an executor in the Config
+            # object; this hack will no longer be necessary when MEP and UEP configs
+            # are cleanly separated rather than the current sharing of the same basal
+            # data structure
+            config_dict["executors"] = []
         config = Config(**config_dict)
     except Exception as err:
         raise ClickException(str(err)) from err

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -563,6 +563,23 @@ def test_multi_user_enforces_no_engine(mock_command_ensure, ep_name, run_line):
     assert "no engine if multi" in rc.stderr
 
 
+def test_multi_user_instantiates_no_engine(mock_command_ensure, ep_name, run_line):
+    """different from *enforces* no engine because of historical Config()
+    implementation that default instantiates an Executor, if it's not specified"""
+    ep_dir = mock_command_ensure.endpoint_config_dir / ep_name
+    ep_dir.mkdir(parents=True)
+    data = {"config": ""}
+
+    config = {"multi_user": True}
+    data["config"] = yaml.safe_dump(config)
+
+    to_patch = "globus_compute_endpoint.endpoint.config.config.GlobusComputeEngine"
+    with mock.patch(to_patch) as mock_gce_cls:
+        rc = run_line(f"start {ep_name}", stdin=json.dumps(data), assert_exit_code=1)
+
+    assert not mock_gce_cls.called, (rc.stdout, rc.stderr)
+
+
 @pytest.mark.parametrize("use_uuid", (True, False))
 @mock.patch(f"{_MOCK_BASE}get_config")
 @mock.patch(f"{_MOCK_BASE}Endpoint.get_endpoint_id")


### PR DESCRIPTION
The MEP does not use an Executor, and even takes pains to prevent it from being specified (e.g., from user error or oversight) in the MEP configuration. However, because the MEP and UEP have initially shared the same basal data structure, and the `Config()` object historically automatically created the Executor, the MEP codes have been needlessly instantiating a useless executor. No more.

## Type of change

- Bug fix (non-breaking change that fixes an issue)