### PR TITLE
Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   rev: v3.15.2
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py39-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 24.3.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   hooks:
     - id: check-hooks-apply
     - id: check-useless-excludes
-- repo: https://github.com/pre-commit/pre-commit-hooks.git
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:
     - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,21 +4,21 @@ repos:
     - id: check-hooks-apply
     - id: check-useless-excludes
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.1
+  rev: 0.29.4
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.2
+  rev: v3.19.0
   hooks:
     - id: pyupgrade
       args: ["--py39-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.3.0
+  rev: 24.10.0
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort
@@ -29,7 +29,7 @@ repos:
       # which settings to use based on a file's directory
       args: ["--settings-path", ".isort.cfg"]
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.0.0
+  rev: 7.1.1
   hooks:
     - id: flake8
       additional_dependencies: ['flake8-bugbear==22.10.27']

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -589,15 +589,7 @@ def _upgrade_funcx_imports_in_config(ep_dir: pathlib.Path, force=False) -> str:
         tmp_output_path.write_text(upd_config_text)
 
         # Rename files last, as it's the least likely to err
-        if sys.version_info < (3, 8):
-            try:
-                # Dropping support for Python 3.7 "real soon", so this branch will
-                # soon go away
-                config_backup.unlink()
-            except FileNotFoundError:
-                pass
-        else:
-            config_backup.unlink(missing_ok=True)
+        config_backup.unlink(missing_ok=True)
         shutil.move(config_path, config_backup)  # Preserve file timestamp
         shutil.move(tmp_output_path, config_path)
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/result_store.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/result_store.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import pathlib
-import sys
 import typing as t
 
 
@@ -96,13 +95,7 @@ class ResultStore:
         ----------
         key - the key for the result
         """
-        if sys.version_info < (3, 8):
-            try:
-                (self.data_path / key).unlink()
-            except FileNotFoundError:
-                pass
-        else:
-            (self.data_path / key).unlink(missing_ok=True)
+        (self.data_path / key).unlink(missing_ok=True)
 
     def _iter_result_paths(self) -> t.Iterable[pathlib.Path]:
         yield from self.data_path.glob("[!.]*")
@@ -154,12 +147,5 @@ class ResultStore:
         storage for all non-hidden files (those that don't begin with a dot)
         and safely unlinks them.
         """
-        if sys.version_info < (3, 8):
-            for result_path in self._iter_result_paths():
-                try:
-                    result_path.unlink()
-                except FileNotFoundError:
-                    pass
-        else:
-            for result_path in self._iter_result_paths():
-                result_path.unlink(missing_ok=True)
+        for result_path in self._iter_result_paths():
+            result_path.unlink(missing_ok=True)

--- a/compute_endpoint/globus_compute_endpoint/providers/kubernetes/kube.py
+++ b/compute_endpoint/globus_compute_endpoint/providers/kubernetes/kube.py
@@ -2,7 +2,7 @@ import logging
 import os
 import queue
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import typeguard
 from globus_compute_endpoint.providers.kubernetes.template import template_string
@@ -96,7 +96,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         run_as_non_root: bool = False,
         secret: Optional[str] = None,
         incluster_config: Optional[bool] = True,
-        persistent_volumes: Optional[List[Tuple[str, str]]] = None,
+        persistent_volumes: Optional[list[tuple[str, str]]] = None,
     ) -> None:
         if persistent_volumes is None:
             persistent_volumes = []
@@ -138,9 +138,9 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.kube_client = client.CoreV1Api()
 
         # Dictionary that keeps track of jobs, keyed on job_id
-        self.resources_by_pod_name: Dict[str, Any] = {}
+        self.resources_by_pod_name: dict[str, Any] = {}
         # Dictionary that keeps track of jobs, keyed on task_type
-        self.resources_by_task_type: Dict[str, Any] = {}
+        self.resources_by_task_type: dict[str, Any] = {}
 
     def submit(
         self, cmd_string, tasks_per_node, task_type, job_name="globus-compute-worker"

--- a/compute_endpoint/tests/utils.py
+++ b/compute_endpoint/tests/utils.py
@@ -116,15 +116,15 @@ def succeed_after_n_runs(dirpath: pathlib.Path, fail_count: int = 1):
     from glob import glob
 
     prior_run_count = len(glob(os.path.join(dirpath, "foo.*.txt")))
-    with open(os.path.join(dirpath, f"foo.{prior_run_count+1}.txt"), "w+") as f:
-        f.write(f"Hello at {time} counter={prior_run_count+1}")
+    with open(os.path.join(dirpath, f"foo.{prior_run_count + 1}.txt"), "w+") as f:
+        f.write(f"Hello at {time} counter={prior_run_count + 1}")
 
     if prior_run_count < fail_count:
         manager_pid = os.getppid()
         manager_pgid = os.getpgid(manager_pid)
         os.killpg(manager_pgid, signal.SIGKILL)
 
-    return f"Success on attempt: {prior_run_count+1}"
+    return f"Success on attempt: {prior_run_count + 1}"
 
 
 def get_env_vars():

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -15,16 +15,7 @@ import typing as t
 import uuid
 import warnings
 from collections import defaultdict
-
-from globus_compute_sdk.sdk.hardware_report import run_hardware_report
-
-if sys.version_info >= (3, 8):
-    from concurrent.futures import InvalidStateError
-else:
-
-    class InvalidStateError(Exception):
-        pass
-
+from concurrent.futures import InvalidStateError
 
 import pika
 from globus_compute_common import messagepack
@@ -33,6 +24,7 @@ from globus_compute_sdk import __version__
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.client import Client
+from globus_compute_sdk.sdk.hardware_report import run_hardware_report
 from globus_compute_sdk.sdk.utils import chunk_by
 from globus_compute_sdk.sdk.utils.uuid_like import (
     UUID_LIKE_T,

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/protocol.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/protocol.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-import sys
+from typing import Protocol, runtime_checkable
 
 import globus_sdk
 
 from ..web_client import WebClient
-
-# these were added to stdlib typing in 3.8, so the import must be conditional
-# mypy and other tools expect and document a sys.version_info check
-if sys.version_info >= (3, 8):
-    from typing import Protocol, runtime_checkable
-else:
-    from typing_extensions import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/compute_sdk/globus_compute_sdk/sdk/utils/printing.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/printing.py
@@ -26,7 +26,9 @@ def print_table(
             max_columns = len(row)
 
     if len(headers) < max_columns:
-        headers = headers + [f"Column {i+1}" for i in range(max_columns - len(headers))]
+        headers = headers + [
+            f"Column {i + 1}" for i in range(max_columns - len(headers))
+        ]
 
     table = texttable.Texttable()
     table.header(headers)

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import collections
 import json
 import os
-import sys
 import time
 
 import pytest
@@ -158,9 +157,8 @@ def _add_args_for_client_creds_login(api_client_id, api_client_secret, client_ar
 
         login_manager = TestsuiteLoginManager()
 
-        # check runtime-checkable protocol on python versions which support it
-        if sys.version_info >= (3, 8):
-            assert isinstance(login_manager, LoginManagerProtocol)
+        # check runtime-checkable protocol
+        assert isinstance(login_manager, LoginManagerProtocol)
 
         client_args["login_manager"] = login_manager
 


### PR DESCRIPTION
# Description

This PR resolves pre-commit deprecation warnings that are appearing in CI ([recent example](https://github.com/globus/globus-compute/actions/runs/11669575175/job/32491828042#step:5:6)).

In addition, it updates the pyupgrade configuration to target Python 3.9+ compatibility, and commits the changes introduced by `pre-commit run -a`, and fixes the resulting flake8 complaints.

While this resolves existing deprecation warnings, I recommend updating the flake8-bugbear plugin to the latest version (you can install and run `upadup` to accomplish this automatically, or copy-and-paste the version shown in the console logs below). The plugin version in the pre-commit config is two years old, and new versions are throwing new warnings.

```console
$ upadup
upadup is checking additional_dependencies of flake8...
  flake8-bugbear==22.10.27 => flake8-bugbear==24.10.31
apply updates...done

$ pre-commit run -a
compute_endpoint/globus_compute_endpoint/endpoint/config/config.py:188:13:
B028 No explicit stacklevel argument found.
The warn method from the warnings module uses a stacklevel of 1 by default.
This will only show a stack trace for the line on which the warn method is called.
It is therefore recommended to use a stacklevel of 2 or greater
to provide more information to the user.

compute_endpoint/tests/unit/test_endpointmanager_unit.py:765:5:
B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil.
They can lead to your test passing even if the code being tested is never executed due to a typo.
Assert for a more specific exception (builtin or custom),
or use `assertRaisesRegex` (if using `assertRaises`),
or add the `match` keyword argument (if using `pytest.raises`),
or use the context manager form with a target.

...
```

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
