### PR TITLE
Separate MultiUser configuration

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -4,6 +4,7 @@ import shutil
 import textwrap
 
 from click import ClickException
+from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.config.utils import get_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_sdk import GlobusApp
@@ -49,7 +50,7 @@ def enable_on_boot(ep_dir: pathlib.Path, app: GlobusApp):
     ep_name = ep_dir.name
 
     config = get_config(ep_dir)
-    if not config.multi_user:
+    if isinstance(config, UserEndpointConfig):  # aka: not multi_user
         if config.detach_endpoint:
             # config.py takes priority if it exists
             if (ep_dir / "config.py").is_file():

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/__init__.py
@@ -1,1 +1,11 @@
-from .config import Config  # noqa: F401
+from .config import (  # noqa: F401
+    BaseConfig,
+    Config,
+    ManagerEndpointConfig,
+    UserEndpointConfig,
+)
+from .model import (  # noqa: F401
+    BaseConfigModel,
+    ManagerEndpointConfigModel,
+    UserEndpointConfigModel,
+)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.py
@@ -1,8 +1,8 @@
-from globus_compute_endpoint.endpoint.config import Config
+from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.engines import GlobusComputeEngine
 from parsl.providers import LocalProvider
 
-config = Config(
+config = UserEndpointConfig(
     display_name=None,  # If None, defaults to the endpoint name
     executors=[
         GlobusComputeEngine(

--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -15,7 +15,6 @@ import time
 import typing as t
 from concurrent.futures import Future
 
-import globus_compute_endpoint.endpoint.config
 import pika.exceptions
 import setproctitle
 from globus_compute_common.messagepack import InvalidMessageError, pack
@@ -25,6 +24,7 @@ from globus_compute_common.messagepack.message_types import (
     ResultErrorDetails,
 )
 from globus_compute_endpoint import __version__ as funcx_endpoint_version
+from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.rabbit_mq import (
     ResultPublisher,
     TaskQueueSubscriber,
@@ -33,6 +33,7 @@ from globus_compute_endpoint.endpoint.result_store import ResultStore
 from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
 from globus_compute_endpoint.exception_handling import get_result_error_details
 from globus_compute_sdk import __version__ as funcx_sdk_version
+from globus_compute_sdk.sdk.utils.uuid_like import UUID_LIKE_T
 from parsl.version import VERSION as PARSL_VERSION
 
 log = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class EndpointInterchange:
 
     def __init__(
         self,
-        config: globus_compute_endpoint.endpoint.config.Config,
+        config: UserEndpointConfig,
         reg_info: dict[str, dict],
         logdir=".",
         endpoint_id=None,
@@ -69,7 +70,7 @@ class EndpointInterchange:
         """
         Parameters
         ----------
-        config : globus_compute_sdk.Config object
+        config : globus_compute_sdk.UserEndpointConfig object
              Globus Compute config object describing how compute should be provisioned
 
         reg_info : dict[str, dict]
@@ -166,12 +167,12 @@ class EndpointInterchange:
         log.warning("Received SIGTERM, setting termination flag.")
         self.time_to_quit = True
 
-    def function_allowed(self, function_id: str):
+    def function_allowed(self, function_id: UUID_LIKE_T):
         if self.config.allowed_functions is None:
             # Not a restricted endpoint
             return True
 
-        return function_id in self.config.allowed_functions
+        return str(function_id) in self.config.allowed_functions
 
     def start(self):
         """Start the Interchange"""

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -20,6 +20,7 @@ from globus_compute_endpoint.exception_handling import (
     get_error_string,
     get_result_error_details,
 )
+from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
 _EXC_HISTORY_TMPL = "+" * 68 + "\nTraceback from attempt: {ndx}\n{exc}\n" + "-" * 68
@@ -69,7 +70,7 @@ class ReportingThread:
             self._thread.join(timeout=0.1)
 
 
-class GlobusComputeEngineBase(ABC):
+class GlobusComputeEngineBase(ABC, RepresentationMixin):
     """Shared functionality and interfaces required by all GlobusCompute Engines.
     This is designed to plug-in executors following the concurrent.futures.Executor
     interface as execution backends to GlobusCompute

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
@@ -128,7 +128,7 @@ class Interchange:
         """
         Parameters
         ----------
-        config : globus_compute_sdk.Config object
+        config : globus_compute_sdk.UserEndpointConfig object
              Globus Compute config object that describes how compute should
              be provisioned
 

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -181,12 +181,13 @@ def engine_runner(
 ###
 
 
+def randomstring_impl(length=5, alphabet=string.ascii_letters):
+    return "".join(random.choice(alphabet) for _ in range(length))
+
+
 @pytest.fixture
 def randomstring():
-    def func(length=5, alphabet=string.ascii_letters):
-        return "".join(random.choice(alphabet) for _ in range(length))
-
-    return func
+    return randomstring_impl
 
 
 @pytest.fixture

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -17,7 +17,7 @@ from globus_compute_endpoint.cli import (
     app,
 )
 from globus_compute_endpoint.endpoint import endpoint
-from globus_compute_endpoint.endpoint.config import Config
+from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_sdk.sdk.web_client import WebClient
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint."
@@ -65,7 +65,7 @@ def test_start_endpoint_display_name(mocker, fs, display_name):
     )
 
     ep = endpoint.Endpoint()
-    ep_conf = Config()
+    ep_conf = UserEndpointConfig()
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
     ep_dir.mkdir(parents=True, exist_ok=True)
     ep_conf.display_name = display_name
@@ -88,7 +88,7 @@ def test_start_endpoint_data_passthrough(fs):
     )
 
     ep = endpoint.Endpoint()
-    ep_conf = Config()
+    ep_conf = UserEndpointConfig()
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
     ep_dir.mkdir(parents=True, exist_ok=True)
     ep_conf.allowed_functions = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -104,10 +104,9 @@ def test_start_endpoint_data_passthrough(fs):
     req_json = json.loads(req.body)
 
     assert len(req_json["allowed_functions"]) == 2
-    assert req_json["allowed_functions"][1] == ep_conf.allowed_functions[1]
-    assert req_json["authentication_policy"] == ep_conf.authentication_policy
-    assert req_json["subscription_uuid"] == ep_conf.subscription_id
-    assert req_json["public"] is ep_conf.public
+    assert req_json["allowed_functions"][1] == str(ep_conf.allowed_functions[1])
+    assert req_json["authentication_policy"] == str(ep_conf.authentication_policy)
+    assert req_json["subscription_uuid"] == str(ep_conf.subscription_id)
 
 
 @mock.patch(f"{_MOCK_BASE}Endpoint.get_endpoint_id", return_value="abc-uuid")
@@ -238,7 +237,7 @@ def test_endpoint_setup_execution(mocker, tmp_path, randomstring):
 
     endpoint_dir = None
     endpoint_uuid = None
-    endpoint_config = Config(endpoint_setup=command, detach_endpoint=False)
+    endpoint_config = UserEndpointConfig(endpoint_setup=command, detach_endpoint=False)
     log_to_console = False
     no_color = True
     reg_info = {}
@@ -279,7 +278,7 @@ def test_endpoint_teardown_execution(mocker, tmp_path, randomstring):
     command = f"cat {tmp_file}\nexit {exit_code}"
 
     endpoint_dir = tmp_path
-    endpoint_config = Config(endpoint_teardown=command)
+    endpoint_config = UserEndpointConfig(endpoint_teardown=command)
 
     with mock.patch(f"{_MOCK_BASE}log") as mock_log:
         with pytest.raises(SystemExit) as e:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -10,7 +10,7 @@ import globus_compute_endpoint.endpoint
 import pytest
 import requests
 import yaml
-from globus_compute_endpoint.endpoint.endpoint import Config, Endpoint
+from globus_compute_endpoint.endpoint.endpoint import Endpoint, UserEndpointConfig
 from globus_sdk import GlobusAPIError
 
 logger = logging.getLogger("mock_funcx")
@@ -330,10 +330,9 @@ class TestStart:
         # Allow this mock to be used in a with statement
         mock_context.return_value.__enter__.return_value = None
         mock_context.return_value.__exit__.return_value = None
-
         mock_context.return_value.pidfile.path = ""
 
-        config = Config(executors=[], detach_endpoint=False)
+        config = UserEndpointConfig(executors=[], detach_endpoint=False)
 
         manager = Endpoint()
         config_dir = pathlib.Path("/some/path/mock_endpoint")

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -13,13 +13,13 @@ from globus_compute_common.messagepack import pack, unpack
 from globus_compute_common.messagepack.message_types import EPStatusReport, Result
 from globus_compute_endpoint import engines
 from globus_compute_endpoint.cli import get_config
+from globus_compute_endpoint.endpoint.config.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange, log
 from globus_compute_endpoint.endpoint.rabbit_mq import (
     ResultPublisher,
     TaskQueueSubscriber,
 )
-from globus_compute_endpoint.endpoint.utils.config import Config
 from tests.utils import try_assert
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.interchange."
@@ -50,7 +50,7 @@ def mock_ex(mocker, endpoint_uuid):
 
 @pytest.fixture
 def mock_conf(mock_ex):
-    yield Config(executors=[mock_ex])
+    yield UserEndpointConfig(executors=[mock_ex])
 
 
 @pytest.fixture
@@ -140,7 +140,7 @@ def test_endpoint_id_conveyed_to_executor(funcx_dir):
 def test_start_requires_pre_registered(mocker, funcx_dir):
     with pytest.raises(TypeError):
         EndpointInterchange(
-            config=Config(executors=[mocker.Mock()]),
+            config=UserEndpointConfig(executors=[mocker.Mock()]),
             reg_info=None,
             endpoint_id="mock_endpoint_id",
         )

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -1,4 +1,87 @@
+import inspect
+import os
+import pathlib
+import random
+import typing as t
+import uuid
+
+import pytest
+from tests.conftest import randomstring_impl
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "no_mock_pim: In test_endpointmanager_unit, disable autouse fixture"
     )
+
+
+known_user_config_opts = {
+    "display_name": str,
+    "allowed_functions": t.Iterable[uuid.UUID],
+    "authentication_policy": uuid.UUID,
+    "subscription_id": uuid.UUID,
+    "amqp_port": int,
+    "heartbeat_period": int,
+    "debug": True,
+    "heartbeat_threshold": int,
+    "idle_heartbeats_soft": int,
+    "idle_heartbeats_hard": int,
+    "detach_endpoint": False,
+    "endpoint_setup": str,
+    "endpoint_teardown": str,
+    "log_dir": str,
+    "stdout": str,
+    "stderr": str,
+    "local_compute_services": True,
+    "environment": str,
+    "multi_user": False,
+    "executors": None,
+}
+
+known_manager_config_opts = {
+    "display_name": str,
+    "allowed_functions": t.Iterable[uuid.UUID],
+    "authentication_policy": uuid.UUID,
+    "subscription_id": uuid.UUID,
+    "amqp_port": int,
+    "heartbeat_period": int,
+    "debug": True,
+    "public": True,
+    "identity_mapping_config_path": os.PathLike,
+    "force_mu_allow_same_user": True,
+    "mu_child_ep_grace_period_s": float,
+    "local_compute_services": True,
+    "environment": str,
+    "multi_user": True,
+}
+
+
+def get_random_of_datatype_impl(cls):
+    if cls == t.Iterable[uuid.UUID]:
+        return tuple(str(uuid.uuid4()) for _ in range(random.randint(1, 10)))
+    if not inspect.isclass(cls):
+        return cls  # not a type; test knows what it needs so just return it
+    elif issubclass(cls, uuid.UUID):
+        return str(uuid.uuid4())
+    elif issubclass(cls, os.PathLike):
+        # use an invalid path to guarantee test is run under fs fixture
+        p = pathlib.Path("/asadf/asdf/fake/filesystem/dir")
+        p.mkdir(parents=True)
+        p = p / "Some Test File"
+        p.touch()
+        return str(p)
+    elif issubclass(cls, str):
+        return randomstring_impl()
+    elif issubclass(cls, bool):
+        return random.choice((True, False))
+    elif issubclass(cls, int):
+        return random.randint(10_000, 1_000_000)
+    elif issubclass(cls, float):
+        return random.random() * 1_000_000
+
+    raise NotImplementedError(f"Missing test branch for type: {repr(cls)}")
+
+
+@pytest.fixture
+def get_random_of_datatype():
+    return get_random_of_datatype_impl

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -80,7 +80,7 @@ def test_enable_on_boot_no_systemd(fake_ep_dir, mocker):
 
 @pytest.mark.parametrize("mu", (True, False))
 def test_enable_on_boot_detach_endpoint(
-    mocker, fake_ep_dir, systemd_unit_dir, mu: bool, fs: fakefs.FakeFilesystem
+    mocker, fake_ep_dir, systemd_unit_dir, mu: bool
 ):
     mock_app = mock.Mock(spec=UserApp)
     cfg_path = fake_ep_dir / "config.yaml"

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -5,7 +5,7 @@ from multiprocessing.synchronize import Event as EventType
 from unittest import mock
 
 import pytest
-from globus_compute_endpoint.endpoint.config import Config
+from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange
 from globus_compute_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
 
@@ -34,7 +34,7 @@ def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals)
     mocker.patch(f"{_mock_base}time.sleep")
     mocker.patch(f"{_mock_base}multiprocessing")
     ei = EndpointInterchange(
-        config=Config(executors=[mocker.Mock()]),
+        config=UserEndpointConfig(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=num_iterations + 10,
     )
@@ -67,7 +67,7 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     mocker.patch(f"{_mock_base}multiprocessing")
     mock_log = mocker.patch(f"{_mock_base}log")
     ei = EndpointInterchange(
-        config=Config(executors=[mocker.Mock()]),
+        config=UserEndpointConfig(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=reconnect_attempt_limit,
     )
@@ -87,7 +87,7 @@ def test_reset_reconnect_attempt_limit_when_stable(mocker, fs, mock_tqs):
     mocker.patch(f"{_mock_base}threading.Thread")
     mocker.patch(f"{_mock_base}multiprocessing")
     ei = EndpointInterchange(
-        config=Config(executors=[mocker.Mock()]),
+        config=UserEndpointConfig(executors=[mocker.Mock()]),
         endpoint_id=str(uuid.uuid4()),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
     )
@@ -123,7 +123,7 @@ def test_rundir_passed_to_gcengine(mocker, fs):
     mock_gcengine.start = mocker.Mock()
 
     ei = EndpointInterchange(
-        config=Config(executors=[mock_gcengine]),
+        config=UserEndpointConfig(executors=[mock_gcengine]),
         endpoint_id=str(uuid.uuid4()),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
     )

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -11,7 +11,7 @@ import pytest
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import TaskTransition
 from globus_compute_common.tasks import ActorName, TaskState
-from globus_compute_endpoint.endpoint.config import Config
+from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.config.utils import serialize_config
 from globus_compute_endpoint.engines import (
     GlobusComputeEngine,
@@ -146,7 +146,7 @@ def test_gc_engine_system_failure(ez_pack_task, task_uuid, engine_runner):
 def test_serialized_engine_config_has_provider(
     engine_type: t.Type[GlobusComputeEngineBase],
 ):
-    ep_config = Config(executors=[engine_type(address="127.0.0.1")])
+    ep_config = UserEndpointConfig(executors=[engine_type(address="127.0.0.1")])
 
     res = serialize_config(ep_config)
     executor = res["executors"][0].get("executor") or res["executors"][0]


### PR DESCRIPTION
To date, we've been comingling the MEP and UEP configurations in `Config`.  At this time, the two implementations are starting to diverge in their overlap, so bite the bullet and be clear about the differences.  This implementation uses `BaseConfig` for the shared attributes, maintains `Config` for backward compatability, and introduces `UserEndpointConfig` for the user endpoint and `ManagerEndpointConfig` for the endpoint manager configuration.

The core of the changes start in `endpoint/config/config.py`, where `UserEndpointConfig` (for UEPs) and `ManagerEndpointConfig` (for MEPs) are defined. These are backed up by requisite changes to the Pydantic model in `config/model.py`,  Just about every other change is in support of the now-distinct configuration classes.

Notes:
 - test coverage has increased around the configurations
 - the YAML facade shouldn't change at all from the user perspective.  This is an internal organization detail

[sc-37362]

## Type of change

- Code maintenance/cleanup