### PR TITLE
Add support for Pythons 3.12 and 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -78,7 +78,7 @@ jobs:
         options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/20241111_160525_chris_new_pythons.rst
+++ b/changelog.d/20241111_160525_chris_new_pythons.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The ``globus-compute-sdk`` and ``globus-compute-endpoint`` packages now support
+  Python versions 3.12 and 3.13.

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.30.1"
+__version__ = "2.30.2a1"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -7,8 +7,8 @@ REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
     "globus-compute-sdk==2.30.1",
-    "globus-compute-common==0.4.1",
-    "globus-identity-mapping==0.3.0",
+    "globus-compute-common==0.5.0",
+    "globus-identity-mapping==0.4.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.30.1",
+    "globus-compute-sdk==2.30.2a1",
     "globus-compute-common==0.5.0",
     "globus-identity-mapping==0.4.0",
     # table printing used in list-endpoints

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,310,39}
+envlist = py{313,312,311,310,39}
 skip_missing_interpreters = true
 
 [testenv]

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -73,8 +73,9 @@ class DillCodeSource(SerializationStrategy):
     def deserialize(self, payload: str):
         chomped = self.chomp(payload)
         name, body = dill.loads(codecs.decode(chomped.encode(), "base64"))
-        exec(body)
-        return locals()[name]
+        exec_ns: dict = {}
+        exec(body, exec_ns)
+        return exec_ns[name]
 
 
 class DillCodeTextInspect(SerializationStrategy):
@@ -102,8 +103,9 @@ class DillCodeTextInspect(SerializationStrategy):
     def deserialize(self, payload: str):
         chomped = self.chomp(payload)
         name, body = dill.loads(codecs.decode(chomped.encode(), "base64"))
-        exec(body)
-        return locals()[name]
+        exec_ns: dict = {}
+        exec(body, exec_ns)
+        return exec_ns[name]
 
 
 class PickleCode(SerializationStrategy):

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.30.1"
+__version__ = "2.30.2a1"
 
 
 def compare_versions(

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
     "globus-sdk>=3.46.0,<4",
-    "globus-compute-common==0.4.1",
+    "globus-compute-common==0.5.0",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,310,39}
+envlist = py{313,312,311,310,39}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
# Description

* Fix deserialization code to use a dedicated namespace instead of `locals`, due to new strictness from 3.13
* Bump GIM and `globus-compute-common` to versions that officially support 3.12 and 3.13
  * https://github.com/globusonline/globus-identity-mapping/pull/25
  * https://github.com/globus/globus-compute-common/pull/135
* Update test matrices in `tox.ini`s and `ci.yaml`

[[sc-37235]](https://app.shortcut.com/globus/story/37235/add-support-for-recent-python-versions-to-compute-sdk-endpoint)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
