### PR TITLE
Adding type hints for sdk.Executor.shutdown

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -1300,7 +1300,7 @@ class _ResultWatcher(threading.Thread):
                     self._open_futures_empty.set()
         log.debug("%r AMQP thread complete.", self)
 
-    def shutdown(self, wait=True, *, cancel_futures=False):
+    def shutdown(self, wait=True, *, cancel_futures=False) -> None:
         if not self.is_alive():
             return
 


### PR DESCRIPTION
# Description

This PR marks `globus_compute_sdk.Executor.shutdown` as returning `None`. Adding this because @benclifford asked about this and our docs didn't clearly mention it.


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
