### PR TITLE
Make test function readily-REPL-available

### DIFF
--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -12,14 +12,14 @@ import globus_compute_sdk as gc
 import globus_sdk
 import pytest
 import responses
-from globus_compute_common import messagepack
 from globus_compute_endpoint import engines
 from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
 from globus_compute_sdk.sdk.web_client import WebClient
 from globus_compute_sdk.serialize import ComputeSerializer
 from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
-from tests.utils import ez_pack_function
+
+from .utils import create_task_packer
 
 
 @pytest.fixture(autouse=True)
@@ -215,15 +215,7 @@ def serde():
 
 @pytest.fixture
 def ez_pack_task(serde, task_uuid, container_uuid):
-    def _pack_it(fn, *a, **k) -> bytes:
-        task_body = ez_pack_function(serde, fn, a, k)
-        return messagepack.pack(
-            messagepack.message_types.Task(
-                task_id=task_uuid, container_id=container_uuid, task_buffer=task_body
-            )
-        )
-
-    return _pack_it
+    return create_task_packer(serde, task_uuid, container_uuid)
 
 
 @pytest.fixture


### PR DESCRIPTION
Having written this function multiple times, then pulled it out of the tests fixtures while poking at the engines before throwing it away N more times, recognize that it's perhaps a REPL-useful utility.  Documentation for the dev inline, while the core is still used by the test fixtures.

## Type of change

- New feature (entirely oriented toward devs hacking on the engines)