### PR TITLE
Require engine.start before engine allows task submission

### DIFF
--- a/changelog.d/20241114_143416_yadudoc1729_require_engine_start.rst
+++ b/changelog.d/20241114_143416_yadudoc1729_require_engine_start.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added a new runtime check to ``globus_compute_endpoint.engines`` that will raise a `RuntimeError`
+  if a task is submitted before ``engine.start()`` was called.

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -121,6 +121,7 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         self.results_passthrough: queue.Queue[dict[str, bytes | str | None]] = (
             queue.Queue()
         )
+        self._engine_ready: bool = False
 
     @abstractmethod
     def start(
@@ -235,6 +236,11 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         """Subclass should use the internal execution system to implement this"""
         raise NotImplementedError()
 
+    def _ensure_ready(self):
+        """Raises a RuntimeError if engine is not started"""
+        if not self._engine_ready:
+            raise RuntimeError("Engine not started and cannot execute tasks")
+
     def submit(
         self,
         task_id: str,
@@ -251,6 +257,7 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         -------
         future
         """
+        self._ensure_ready()
 
         if task_id not in self._retry_table:
             self._retry_table[task_id] = {

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -269,6 +269,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         # Add executor to poller *after* executor has started
         self.job_status_poller = JobStatusPoller(**self._job_status_kwargs)
         self.job_status_poller.add_executors([self.executor])
+        self._engine_ready = True
 
     def _submit(
         self,

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -64,6 +64,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         self.set_working_dir(run_dir=run_dir)
 
         self._status_report_thread.start()
+        self._engine_ready = True
 
     def get_status_report(self) -> EPStatusReport:
         assert self.executor, "The engine has not been started"

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -54,6 +54,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         self.set_working_dir(run_dir=run_dir)
         # mypy think the thread can be none
         self._status_report_thread.start()
+        self._engine_ready = True
 
     def get_status_report(self) -> EPStatusReport:
         """

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -49,6 +49,7 @@ def mock_gce(tmp_path):
             working_dir=scripts_dir,
             provider=LocalProvider(min_blocks=0, max_blocks=0, init_blocks=0),
         )
+        engine._engine_ready = True
         engine.results_passthrough = queue.Queue()
         yield engine
 


### PR DESCRIPTION
# Description

This PR adds a flag to `GlobusComputeEngineBase` to ensure that engine is started before task submission is allowed. Engine will raise an `AssertionError` if a task is submitted before it was started.
These checks are mainly for tests that miss engine misconfiguration. 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
