### PR TITLE
Move test task kernel to utils

### DIFF
--- a/compute_endpoint/tests/utils.py
+++ b/compute_endpoint/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import pathlib
 import sys
@@ -106,8 +108,8 @@ def kill_manager():
     os.killpg(manager_pgid, signal.SIGKILL)
 
 
-def div_zero(x: int):
-    return x / 0
+def divide(x: int | float, y: int | float):
+    return x / y
 
 
 def succeed_after_n_runs(dirpath: pathlib.Path, fail_count: int = 1):


### PR DESCRIPTION
Move `divide` to utils, and remove the recently unreferenced `div_zero`.  While here, make the test slightly more honest by using random numbers.

## Type of change

- Code maintenance/cleanup