### PR TITLE
add high-assurance placeholder option to endpoint configuration

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -62,6 +62,7 @@ class BaseConfig:
         self,
         *,
         multi_user: bool = False,
+        high_assurance: bool = False,
         display_name: str | None = None,
         allowed_functions: t.Iterable[UUID_LIKE_T] | None = None,
         authentication_policy: UUID_LIKE_T | None = None,
@@ -76,6 +77,7 @@ class BaseConfig:
         self.display_name = display_name
         self.debug = debug is True
         self.multi_user = multi_user is True
+        self.high_assurance = high_assurance is True
 
         # Connection info and tuning
         self.amqp_port = amqp_port

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -144,6 +144,7 @@ class BaseEndpointConfigModel(BaseModel):
     heartbeat_period: t.Optional[int]
     environment: t.Optional[str]
     local_compute_services: t.Optional[bool]
+    high_assurance: t.Optional[bool]
     debug: t.Optional[bool]
 
     class Config:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -76,6 +76,7 @@ class Endpoint:
         original_path: pathlib.Path,
         target_path: pathlib.Path,
         multi_user: bool,
+        high_assurance: bool,
         display_name: str | None,
         auth_policy: str | None,
         subscription_id: str | None,
@@ -88,6 +89,9 @@ class Endpoint:
 
         if auth_policy:
             config_dict["authentication_policy"] = auth_policy
+
+        if high_assurance:
+            config_dict["high_assurance"] = high_assurance
 
         if multi_user:
             config_dict["multi_user"] = multi_user
@@ -109,6 +113,7 @@ class Endpoint:
         endpoint_dir: pathlib.Path,
         endpoint_config: pathlib.Path | None = None,
         multi_user=False,
+        high_assurance=False,
         display_name: str | None = None,
         auth_policy: str | None = None,
         subscription_id: str | None = None,
@@ -143,6 +148,7 @@ class Endpoint:
                 endpoint_config,
                 config_target_path,
                 multi_user,
+                high_assurance,
                 display_name,
                 auth_policy,
                 subscription_id,
@@ -187,6 +193,7 @@ class Endpoint:
         conf_dir: pathlib.Path,
         endpoint_config: str | None,
         multi_user: bool = False,
+        high_assurance: bool = False,
         display_name: str | None = None,
         auth_policy: str | None = None,
         subscription_id: str | None = None,
@@ -202,6 +209,7 @@ class Endpoint:
             conf_dir,
             templ_conf_path,
             multi_user,
+            high_assurance,
             display_name,
             auth_policy,
             subscription_id,
@@ -428,6 +436,7 @@ class Endpoint:
                     allowed_functions=endpoint_config.allowed_functions,
                     auth_policy=endpoint_config.authentication_policy,
                     subscription_id=endpoint_config.subscription_id,
+                    high_assurance=endpoint_config.high_assurance,
                 )
 
             except GlobusAPIError as e:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -181,6 +181,7 @@ class EndpointManager:
                     auth_policy=config.authentication_policy,
                     subscription_id=config.subscription_id,
                     public=config.public,
+                    high_assurance=config.high_assurance,
                 )
 
                 # Mostly to appease mypy, but also a useful text if it ever

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -59,24 +59,30 @@ class TestStart:
         with pytest.raises(Exception, match="ConfigExists"):
             manager.configure_endpoint(config_dir, None)
 
+    @pytest.mark.parametrize("ha", [None, True, False])
     @pytest.mark.parametrize("mu", [None, True, False])
-    def test_configure_multi_user_existing_config(self, mu):
+    def test_configure_multi_user_ha_existing_config(self, ha, mu):
         manager = Endpoint()
         config_dir = pathlib.Path("/some/path/mock_endpoint")
         config_file = Endpoint._config_file_path(config_dir)
         config_copy = str(config_dir.parent / "config2.yaml")
 
-        # First, make an entry with multi_user
-        manager.configure_endpoint(config_dir, None, multi_user=True)
+        # First, make an entry with multi_user/ha
+        manager.configure_endpoint(
+            config_dir, None, multi_user=True, high_assurance=False
+        )
         shutil.move(config_file, config_copy)
         shutil.rmtree(config_dir)
 
-        # Then, modify it with new setting
-        manager.configure_endpoint(config_dir, config_copy, multi_user=mu)
+        # Then, modify it with new settings
+        manager.configure_endpoint(
+            config_dir, config_copy, multi_user=mu, high_assurance=ha
+        )
 
         with open(config_file) as f:
             config_dict = yaml.safe_load(f)
         assert "multi_user" in config_dict
+        assert ("high_assurance" in config_dict) is (ha is True)
 
         os.remove(config_copy)
 

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -38,6 +38,7 @@ known_user_config_opts = {
     "local_compute_services": True,
     "environment": str,
     "multi_user": False,
+    "high_assurance": False,
     "executors": None,
 }
 
@@ -57,6 +58,7 @@ known_manager_config_opts = {
     "local_compute_services": True,
     "environment": str,
     "multi_user": True,
+    "high_assurance": True,
 }
 
 

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -199,8 +199,8 @@ def test_userconfig_repr_nondefault_kwargs(
 
     repr_c = repr(UserEndpointConfig(**kwds))
 
-    if kw == "multi_user":
-        assert f"{kw}={repr(val)}" not in repr_c, "Multi user *off* by default"
+    if kw in ["multi_user", "high_assurance"]:
+        assert f"{kw}={repr(val)}" not in repr_c, "Multi-user and HA *off* by default"
     else:
         assert f"{kw}={repr(val)}" in repr_c
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -507,6 +507,7 @@ def test_sends_data_during_registration(
         "endpoint_id",
         "metadata",
         "multi_user",
+        "high_assurance",
         "display_name",
         "allowed_functions",
         "auth_policy",

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -429,6 +429,7 @@ class Client:
         auth_policy: UUID_LIKE_T | None = None,
         subscription_id: UUID_LIKE_T | None = None,
         public: bool | None = None,
+        high_assurance: bool | None = None,
     ):
         """Register an endpoint with the Globus Compute service.
 
@@ -442,6 +443,8 @@ class Client:
             Endpoint metadata
         multi_user : bool | None
             Whether the endpoint supports multiple users
+        high_assurance : bool | None
+            Whether the endpoint should be high assurance capable
         display_name : str | None
             The display name of the endpoint
         allowed_functions: list[str | UUID] | None
@@ -472,6 +475,7 @@ class Client:
             auth_policy=auth_policy,
             subscription_id=subscription_id,
             public=public,
+            high_assurance=high_assurance,
         )
         return r.data
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -194,6 +194,7 @@ class WebClient(globus_sdk.BaseClient):
         subscription_id: t.Optional[UUID_LIKE_T] = None,
         public: t.Optional[bool] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
+        high_assurance: t.Optional[bool] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data: t.Dict[str, t.Any] = {"endpoint_name": endpoint_name}
 
@@ -218,6 +219,8 @@ class WebClient(globus_sdk.BaseClient):
             data["subscription_uuid"] = subscription_id
         if public is not None:
             data["public"] = public
+        if high_assurance is not None:
+            data["high_assurance"] = high_assurance
         if additional_fields is not None:
             data.update(additional_fields)
 


### PR DESCRIPTION
This is the skeleton of adding high-assurance to endpoint configuration.

The option in ``globus-compute-endpoint configure --high-assurance`` is marked as hidden for now.

Like multi-user, the config is only present in the config file if it is True.  The web service treats missing values as False as well.

Obviously no changelog fragment for now.

For a bit more context see [SC https://github.com/globusonline/funcx-services/pull/726](https://app.shortcut.com/globus/story/35308/allow-endpoint-to-be-marked-as-ha)

V3 register adds the high_assurance option if provided, V2 does not support registration with the value set to True.  However GET /v2/endpoint does return the value.