### PR TITLE
Remove code that checks if the user is in a TTY

### DIFF
--- a/changelog.d/20241114_172127_chris_remove_tty_checks.rst
+++ b/changelog.d/20241114_172127_chris_remove_tty_checks.rst
@@ -1,0 +1,12 @@
+Changed
+^^^^^^^
+
+- Bumped dependency on ``globus-sdk-python`` to at least `version 3.47.0 <https://github.com/globus/globus-sdk-python/releases/tag/3.47.0>`_.
+  This version includes changes to detect ``EOFErrors`` when logging in with the command
+  line, obviating the need for existing ``globus-compute-sdk`` code that checks if a
+  user is in an interactive terminal before logging in. The old Compute code raised a
+  ``RuntimeError`` in that scenario; the new code raises a
+  ``globus_sdk.login_flows.CommandLineLoginFlowEOFError`` if Python's ``input``
+  function raises an ``EOFError`` - which, in Compute, can happen if a previously
+  command-line-authenticated endpoint tries to re-authenticate but no longer has access
+  to a STDIN.

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.46.0,<4",
+    "globus-sdk>=3.47.0,<4",
     "globus-compute-common==0.5.0",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear


### PR DESCRIPTION
# Description

`globus-sdk==3.47.0` handles this class of errors for us by informing users on what to do when `input` receives `EOFError` during login flows.

[[sc-37236]](https://app.shortcut.com/globus/story/37236/move-interactive-terminal-check-on-login-code-to-globus-sdk)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
