### PR TITLE
Implement PAM for MEPs

### DIFF
--- a/changelog.d/20241115_095433_kevin_implement_pam_for_meps.rst
+++ b/changelog.d/20241115_095433_kevin_implement_pam_for_meps.rst
@@ -1,0 +1,27 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Implement optional PAM capabilities for ensuring user accounts meet
+  site-specific criteria before starting user endpoints.  Within the multi user
+  endpoint, PAM defaults to off, but is enabled via the ``pam`` field:
+
+  .. code-block:: yaml
+     :caption: ``config.yaml`` -- Example MEP configuration opting-in to PAM
+
+     multi_user: true
+     pam:
+       enable: true
+
+  As authentication is implemented via Globus Auth and identity mapping, the
+  Globus Compute Endpoint does not implement the authorization or password
+  managment phases of PAM.  It implements account
+  (|pam_acct_mgmt(3)|_) and session (|pam_open_session(3)|) management.
+
+  For more information, consult :ref:`the PAM section <pam>` of the
+  documentation.
+
+  .. |pam_acct_mgmt(3)| replace:: ``pam_acct_mgmt(3)``
+  .. _pam_acct_mgmt(3): https://www.man7.org/linux/man-pages/man3/pam_acct_mgmt.3.html
+  .. |pam_open_session(3)| replace:: ``pam_open_session(3)``
+  .. _pam_open_session(3): https://www.man7.org/linux/man-pages/man3/pam_open_session.3.html
+

--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -4,7 +4,7 @@ import shutil
 import textwrap
 
 from click import ClickException
-from globus_compute_endpoint.endpoint.config import UserEndpointConfig
+from globus_compute_endpoint.endpoint.config.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.config.utils import get_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_sdk import GlobusApp

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/__init__.py
@@ -9,3 +9,4 @@ from .model import (  # noqa: F401
     ManagerEndpointConfigModel,
     UserEndpointConfigModel,
 )
+from .pam import PamConfiguration  # noqa: F401

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -15,6 +15,7 @@ from globus_compute_sdk.sdk.utils.uuid_like import (
 )
 
 from ..utils import is_privileged
+from .pam import PamConfiguration
 
 MINIMUM_HEARTBEAT: float = 5.0
 log = logging.getLogger(__name__)
@@ -327,6 +328,10 @@ class ManagerEndpointConfig(BaseConfig):
         configuration item is required, and a ``ValueError`` will be raised if the path
         does not exist.
 
+    :param pam: Whether to enable authorization of user-endpoints via PAM routines, and
+        optionally specify the PAM service name.  See |PamConfiguration|.  If not
+        specified, PAM authorization defaults to disabled.
+
     :param mu_child_ep_grace_period_s: The web-services send a start-user-endpoint to
         the endpoint manager ahead of tasks for the target user endpoint.  If the
         user-endpoint is already running, these requests are ignored.  To account for
@@ -347,6 +352,7 @@ class ManagerEndpointConfig(BaseConfig):
     .. |BaseConfig| replace:: :class:`BaseConfig <globus_compute_endpoint.endpoint.config.config.BaseConfig>`
     .. |ManagerEndpointConfig| replace:: :class:`ManagerEndpointConfig <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
     .. |UserEndpointConfig| replace:: :class:`UserEndpointConfig <globus_compute_endpoint.endpoint.config.config.UserEndpointConfig>`
+    .. |PamConfiguration| replace:: :class:`PamConfiguration <globus_compute_endpoint.endpoint.config.pam.PamConfiguration>`
 
     .. |setuid(2)| replace:: ``setuid(2)``
     .. _setuid(2): https://www.man7.org/linux/man-pages/man2/setuid.2.html
@@ -357,6 +363,7 @@ class ManagerEndpointConfig(BaseConfig):
         *,
         public: bool = False,
         identity_mapping_config_path: os.PathLike | str | None = None,
+        pam: PamConfiguration | None = None,
         force_mu_allow_same_user: bool = False,
         mu_child_ep_grace_period_s: float = 30.0,
         **kwargs,
@@ -371,6 +378,8 @@ class ManagerEndpointConfig(BaseConfig):
 
         _tmp = identity_mapping_config_path  # work with both mypy and flake8
         self.identity_mapping_config_path = _tmp  # type: ignore[assignment]
+
+        self.pam = pam or PamConfiguration(enable=False)
 
     @property
     def identity_mapping_config_path(self) -> pathlib.Path | None:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -11,6 +11,7 @@ from globus_compute_common.pydantic_v1 import (
     validator,
 )
 from globus_compute_endpoint import engines, strategies
+from globus_compute_endpoint.endpoint.config.pam import PamConfiguration
 from parsl import addresses as parsl_addresses
 from parsl import channels as parsl_channels
 from parsl import launchers as parsl_launchers
@@ -185,6 +186,7 @@ class ManagerEndpointConfigModel(BaseConfigModel):
     identity_mapping_config_path: t.Optional[FilePath]
     force_mu_allow_same_user: t.Optional[bool]
     mu_child_ep_grace_period_s: t.Optional[float]
+    pam: t.Optional[PamConfiguration]
 
     class Config:
         extra = "forbid"

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/pam.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/pam.py
@@ -1,0 +1,26 @@
+from dataclasses import asdict, dataclass
+
+import yaml
+
+
+@dataclass
+class PamConfiguration:
+    """
+    :param enable: Whether to initiate a PAM session for each UEP start request.
+
+    :param service_name: What PAM service name with which to initialize the PAM
+        session.  If a particular MEP has different requirements, define those PAM
+        requirements in ``/etc/pam.d/``, and specify the service name with this field.
+
+        See :ref:`MEP § PAM <pam>` for more information
+    """
+
+    enable: bool = True
+    service_name: str = "globus-compute-endpoint"
+
+
+def _to_yaml(dumper: yaml.SafeDumper, data: PamConfiguration):
+    return dumper.represent_mapping("tag:yaml.org,2002:map", asdict(data))
+
+
+yaml.SafeDumper.add_representer(PamConfiguration, _to_yaml)

--- a/compute_endpoint/globus_compute_endpoint/pam/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/pam/__init__.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import typing as t
+from ctypes import CDLL, CFUNCTYPE, POINTER, Structure, byref, c_char_p, c_int, c_void_p
+from ctypes.util import find_library
+from enum import Enum
+
+pam_lib_name = find_library("pam")
+if pam_lib_name is None:
+    msg = (
+        "Failed to find `pam` shared library\n"
+        "\n  Hints:"
+        "\n    - install libpam.so? (via yum, apt, etc.)"
+        "\n    - ldconfig -p"
+        "\n    - LD_PRELOAD"
+    )
+    raise ImportError(msg)
+
+libpam = CDLL(pam_lib_name)
+
+
+# Constants (interpreted here as Enums) as defined in libpam; see _pam_types.h
+PAM_SUCCESS = 0
+
+
+class PamReturnEnum(Enum):
+    PAM_SUCCESS = PAM_SUCCESS
+
+    PAM_OPEN_ERR = 1  # dlopen() failure when dynamically loading a service module
+    PAM_SYMBOL_ERR = 2
+    PAM_SERVICE_ERR = 3
+    PAM_SYSTEM_ERR = 4
+    PAM_BUF_ERR = 5
+    PAM_PERM_DENIED = 6
+    PAM_AUTH_ERR = 7
+    PAM_CRED_INSUFFICIENT = 8
+    PAM_AUTHINFO_UNAVAIL = 9
+    PAM_USER_UNKNOWN = 10
+    PAM_MAXTRIES = 11
+    PAM_NEW_AUTHTOK_REQD = 12
+    PAM_ACCT_EXPIRED = 13
+    PAM_SESSION_ERR = 14
+    PAM_CRED_UNAVAIL = 15
+    PAM_CRED_EXPIRED = 16
+    PAM_CRED_ERR = 17
+    PAM_NO_MODULE_DATA = 18
+    PAM_CONV_ERR = 19
+    PAM_AUTHTOK_ERR = 20
+    PAM_AUTHTOK_RECOVERY_ERR = 21
+    PAM_AUTHTOK_LOCK_BUSY = 22
+    PAM_AUTHTOK_DISABLE_AGING = 23
+    PAM_TRY_AGAIN = 24
+    PAM_IGNORE = 25
+    PAM_ABORT = 26
+    PAM_AUTHTOK_EXPIRED = 27
+    PAM_MODULE_UNKNOWN = 28
+    PAM_BAD_ITEM = 29
+    PAM_CONV_AGAIN = 30
+    PAM_INCOMPLETE = 31
+
+
+class PamPrompt(Enum):
+    # message styles
+    PAM_PROMPT_ECHO_OFF = 1
+    PAM_PROMPT_ECHO_ON = 2
+    PAM_ERROR_MSG = 3
+    PAM_TEXT_INFO = 4
+
+
+class PamAuthenticate(Enum):
+    PAM_DISALLOW_NULL_AUTHTOK = 0x1
+    PAM_SILENT = 0x8000
+
+
+class PamCred(Enum):
+    PAM_ESTABLISH_CRED = 0x2
+    PAM_DELETE_CRED = 0x4
+    PAM_REINITIALIZE_CRED = 0x8
+    PAM_REFRESH_CRED = 0x10
+    PAM_SILENT = 0x8000
+
+
+class PamAcctMgmt(Enum):
+    PAM_DISALLOW_NULL_AUTHTOK = 0x1
+    PAM_SILENT = 0x8000
+
+
+class PamSession(Enum):
+    PAM_SILENT = 0x8000
+
+
+class PamError(RuntimeError):
+    def __init__(
+        self,
+        pam_handle: PamHandle,
+        pam_error_code: int,
+    ):
+        msg = _pam_strerror(pam_handle, pam_error_code).decode()
+        try:
+            const_name = f" [{PamReturnEnum(pam_error_code).name}]"
+        except ValueError:
+            const_name = ""
+        super().__init__(f"(error code: {pam_error_code}{const_name}) {msg}")
+
+
+class PamMessage(Structure):
+    """Wrapper for `pam_message` struct; see _pam_types.h"""
+
+    _fields_ = (("msg_style", c_int), ("msg", c_char_p))
+
+    def __repr__(self) -> str:
+        c_name = type(self).__name__
+        return f"{c_name}({self.msg_style}, {self.msg!r})"
+
+
+class PamResponse(Structure):
+    """Wrapper for `pam_response` struct; see _pam_types.h"""
+
+    _fields_ = (("resp", c_char_p), ("resp_retcode", c_int))
+
+    def __repr__(self) -> str:
+        c_name = type(self).__name__
+        # emit the `resp_retcode` for completeness, but as of this implementation
+        # note that the C library does not use `resp_retcode`
+        return f"{c_name}({self.resp!r}, {self.resp_retcode})"
+
+
+_conv_fn = CFUNCTYPE(
+    c_int, c_int, POINTER(POINTER(PamMessage)), POINTER(POINTER(PamResponse)), c_void_p
+)
+
+
+@_conv_fn
+def _noop(*a):
+    return 0
+
+
+class PamConversation(Structure):
+    """Wrapper for `pam_conv` struct; see _pam_types.h"""
+
+    _fields_ = (("conv", _conv_fn), ("appdata_ptr", c_void_p))
+
+    def __repr__(self) -> str:
+        # Use angle brackets as this output can't be used to create another instance
+        c_name = type(self).__name__
+        return f"{c_name}<{self.conv}, {self.appdata_ptr}>"
+
+
+PamConversationFunctionType = t.Callable[[int, PamMessage, PamResponse, c_void_p], int]
+
+
+class PamHandle(Structure):
+    """Object-oriented wrapper of pam_handle_t"""
+
+    _fields_ = (("handle", c_void_p),)
+
+    def __init__(
+        self,
+        service_name: str = "",
+        username: str = "",
+        conversation_fn: PamConversationFunctionType | None = None,
+        *,
+        max_username_len: int = 512,
+    ):
+        super().__init__()
+
+        self._started = False
+        self.service_name = service_name
+        self.username = username
+        self.conversation_fn = conversation_fn
+        self.last_rc: int = 0
+        self.max_username_len = max_username_len
+
+    @property
+    def service_name(self) -> str:
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, name: str):
+        if name is None:
+            raise ValueError("service_name must be a string")
+        self._service_name = name
+
+    @property
+    def max_username_len(self) -> int:
+        return self._max_username_len
+
+    @max_username_len.setter
+    def max_username_len(self, val: int):
+        self._max_username_len = max(1, val)
+
+    @property
+    def username(self) -> str:
+        # Protect buggy PAM implementations from themselves
+        return self._username[: self.max_username_len]
+
+    @username.setter
+    def username(self, name: str):
+        if name is None:
+            raise ValueError("username must be a string")
+        self._username = name
+
+    def __enter__(self):
+        sname = self.service_name
+        uname = self.username
+        if not sname:
+            raise ValueError("Missing service name; use `.service_name` or __init__ ")
+        if not uname:
+            raise ValueError("Missing user name; use `.username` or __init__")
+        self.pam_start(sname, uname, self.conversation_fn)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.pam_end()
+
+    def pam_start(
+        self,
+        service_name: str,
+        username: str,
+        conversation_fn: (
+            t.Callable[[int, PamMessage, PamResponse, c_void_p], int] | None
+        ),
+    ):
+        if self._started:
+            raise RuntimeError("Existing session not ended.")
+        conversation_fn = conversation_fn or _noop
+        pamc = PamConversation(_conv_fn(conversation_fn), 0)
+        sname_bytes = service_name.encode()
+        username_bytes = username.encode()
+        self.last_rc = _pam_start(sname_bytes, username_bytes, byref(pamc), byref(self))
+        if self.last_rc != PAM_SUCCESS:
+            raise PamError(self, self.last_rc)
+        self._started = True
+
+    def pam_end(self):
+        if not self._started:
+            return
+        self.last_rc = _pam_end(self, self.last_rc)
+        self._started = False
+        if self.last_rc != PAM_SUCCESS:
+            raise PamError(self, self.last_rc)
+
+    def _flags_only_method(self, pam_fn: t.Callable, flags: Enum | int = 0):
+        """If flags sets more than one bit, pass an int, not an Enum"""
+        _fl: int = flags if isinstance(flags, int) else flags.value
+        self.last_rc = pam_fn(self, _fl)
+        if self.last_rc != PAM_SUCCESS:
+            raise PamError(self, self.last_rc)
+
+    def pam_setcred(self, flags: PamCred | int = 0):
+        """If flags sets more than one bit, pass an int, not a PamCred"""
+        return self._flags_only_method(_pam_setcred, flags)
+
+    def pam_acct_mgmt(self, flags: PamAcctMgmt | int = 0):
+        """If flags sets more than one bit, pass an int, not a PamAcctMgmt"""
+        return self._flags_only_method(_pam_acct_mgmt, flags)
+
+    def pam_open_session(self, flags: PamSession | int = 0):
+        """If flags sets more than one bit, pass an int, not a PamSession"""
+        return self._flags_only_method(_pam_open_session, flags)
+
+    def pam_close_session(self, flags: PamSession | int = 0):
+        """If flags sets more than one bit, pass an int, not a PamSession"""
+        return self._flags_only_method(_pam_close_session, flags)
+
+    def pam_authenticate(self, flags: PamAuthenticate | int = 0):
+        """If flags sets more than one bit, pass an int, not a PamSession"""
+        return self._flags_only_method(_pam_authenticate, flags)
+
+    def credentials_establish(self):
+        return self.pam_setcred(PamCred.PAM_ESTABLISH_CRED)
+
+    def credentials_delete(self):
+        return self.pam_setcred(PamCred.PAM_DELETE_CRED)
+
+    def credentials_refresh(self):
+        return self.pam_setcred(PamCred.PAM_REFRESH_CRED)
+
+    def credentials_reinitialize(self):
+        return self.pam_setcred(PamCred.PAM_REINITIALIZE_CRED)
+
+
+def _pam_fn_unavailable(fn_name: str, exc: Exception):
+    def wrapped(*_a, **_k):
+        raise AttributeError(f"{fn_name} not available in loaded PAM library") from exc
+
+    return wrapped
+
+
+# Not try-except wrapped: required PAM-accessible functions or "just go home."
+_pam_start = libpam.pam_start
+_pam_start.restype = c_int
+_pam_start.argtypes = (c_char_p, c_char_p, POINTER(PamConversation), POINTER(PamHandle))
+
+_pam_end = libpam.pam_end
+_pam_end.restype = c_int
+_pam_end.argtypes = (PamHandle, c_int)
+
+_pam_strerror = libpam.pam_strerror
+_pam_strerror.restype = c_char_p
+_pam_strerror.argtypes = (PamHandle, c_int)
+
+
+# Other PAM-accessible functions may or may not be required for individual applications,
+# so only error out *when they're invoked.*  If a function is not exported by the found
+# PAM C-library but the calling application never uses it, it won't be a problem.
+try:
+    _pam_authenticate = libpam.pam_authenticate
+    _pam_authenticate.restype = c_int
+    _pam_authenticate.argtypes = (PamHandle, c_int)
+except Exception as e:
+    _pam_authenticate = _pam_fn_unavailable("pam_authenticate", e)
+
+try:
+    _pam_setcred = libpam.pam_setcred
+    _pam_setcred.restype = c_int
+    _pam_setcred.argtypes = (PamHandle, c_int)
+except Exception as e:
+    _pam_setcred = _pam_fn_unavailable("pam_setcred", e)
+
+try:
+    _pam_acct_mgmt = libpam.pam_acct_mgmt
+    _pam_acct_mgmt.restype = c_int
+    _pam_acct_mgmt.argtypes = (PamHandle, c_int)
+except Exception as e:
+    _pam_acct_mgmt = _pam_fn_unavailable("pam_acct_mgmt", e)
+
+try:
+    _pam_open_session = libpam.pam_open_session
+    _pam_open_session.restype = c_int
+    _pam_open_session.argtypes = (PamHandle, c_int)
+
+    _pam_close_session = libpam.pam_close_session
+    _pam_close_session.restype = c_int
+    _pam_close_session.argtypes = (PamHandle, c_int)
+except Exception as e:
+    _pam_open_session = _pam_fn_unavailable("pam_open_session", e)
+    _pam_close_session = _pam_fn_unavailable("pam_close_session", e)

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -7,6 +7,7 @@ import typing as t
 import uuid
 
 import pytest
+from globus_compute_endpoint.endpoint.config import PamConfiguration
 from globus_compute_endpoint.engines.helper import execute_task
 from tests.conftest import randomstring_impl
 
@@ -50,6 +51,7 @@ known_manager_config_opts = {
     "debug": True,
     "public": True,
     "identity_mapping_config_path": os.PathLike,
+    "pam": PamConfiguration,
     "force_mu_allow_same_user": True,
     "mu_child_ep_grace_period_s": float,
     "local_compute_services": True,
@@ -80,6 +82,8 @@ def get_random_of_datatype_impl(cls):
         return random.randint(10_000, 1_000_000)
     elif issubclass(cls, float):
         return random.random() * 1_000_000
+    elif issubclass(cls, PamConfiguration):
+        return PamConfiguration(True, "some-service-name")
 
     raise NotImplementedError(f"Missing test branch for type: {repr(cls)}")
 

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -7,6 +7,7 @@ from globus_compute_common.pydantic_v1 import ValidationError
 from globus_compute_endpoint.endpoint.config import (
     ManagerEndpointConfig,
     ManagerEndpointConfigModel,
+    PamConfiguration,
     UserEndpointConfig,
     UserEndpointConfigModel,
 )
@@ -190,8 +191,9 @@ def test_configs_repr_default_kwargs():
         assert (
             repr(UserEndpointConfig()) == f"UserEndpointConfig(executors=({gce_repr},))"
         ), "adds default"
+    defs = f"multi_user=True, pam={PamConfiguration(enable=False)!r}"
     assert (
-        repr(ManagerEndpointConfig()) == "ManagerEndpointConfig(multi_user=True)"
+        repr(ManagerEndpointConfig()) == f"ManagerEndpointConfig({defs})"
     ), "mu is on base"
 
 

--- a/compute_endpoint/tests/unit/test_pam.py
+++ b/compute_endpoint/tests/unit/test_pam.py
@@ -1,0 +1,154 @@
+import random
+from unittest import mock
+
+import pytest
+from globus_compute_endpoint import pam
+from globus_compute_endpoint.pam import PamCred, PamError, PamHandle, PamReturnEnum
+
+_MOCK_BASE = "globus_compute_endpoint.pam."
+
+
+@pytest.fixture
+def pamh():
+    return PamHandle("some service", "some username")
+
+
+def test_pamerror_includes_enum_name(pamh):
+    with pamh:
+        for errenum in PamReturnEnum:
+            e = PamError(pamh, errenum.value)
+            assert f"[{errenum.name}]" in str(e), (errenum, "Expect enum name in error")
+
+
+@pytest.mark.parametrize("name_len", (None, -5, 0, 11, 513))
+def test_pamh_username_limits_length(randomstring, name_len):
+    if name_len is None:
+        pamh = PamHandle("some service")
+        assert pamh.max_username_len == 512, "Expect sensible default; match sshd"
+    else:
+        pamh = PamHandle("some service", max_username_len=name_len)
+
+    assert pamh.max_username_len > 0
+
+    pamh.username = randomstring(pamh.max_username_len + 1)
+    assert (
+        len(pamh.username) == pamh.max_username_len
+    ), "Like ssh, protect buggy PAM implementations from themselves"
+
+
+def test_pamh_start_does_not_clobber_existing_session(pamh):
+    pamh._started = True
+    with pytest.raises(RuntimeError):
+        pamh.pam_start(pamh.service_name, pamh.username, None)
+
+
+def test_pamh_start_raises_on_non_success(pamh):
+    errenum: PamReturnEnum = random.choice(tuple(PamReturnEnum)[1:])  # no SUCCESS!
+    with mock.patch(f"{_MOCK_BASE}_pam_start") as mock_start:
+        mock_start.return_value = errenum.value
+        with pytest.raises(PamError):
+            pamh.pam_start(pamh.service_name, pamh.username, None)
+    assert not pamh._started
+
+
+def test_pamh_start_success(pamh):
+    with mock.patch(f"{_MOCK_BASE}_pam_start") as mock_start:
+        mock_start.return_value = 0
+        pamh.pam_start(pamh.service_name, pamh.username, None)
+
+    a, _k = mock_start.call_args
+    assert isinstance(a[0], bytes), "Expect Python str encoded to *bytes*"
+    assert isinstance(a[1], bytes), "Expect Python str encoded to *bytes*"
+    assert pamh._started, "Expected to mark session is open"
+
+
+def test_pamh_context_verifies_service_name(pamh):
+    pamh.service_name = ""
+    with pytest.raises(ValueError) as pyt_e:
+        with pamh:
+            pass
+    e_str = str(pyt_e.value)
+    assert "Missing service name" in e_str, "Expect human description of problem"
+    assert "use `.service_name`" in e_str, "Expect suggestion in message"
+    assert "__init__" in e_str, "Expect suggestion in message"
+
+
+def test_pamh_context_verifies_username(pamh):
+    pamh.username = ""
+    with pytest.raises(ValueError) as pyt_e:
+        with pamh:
+            pass
+    e_str = str(pyt_e.value)
+    assert "Missing user name" in e_str, "Expect human description of problem"
+    assert "use `.username`" in e_str, "Expect suggestion in message"
+    assert "__init__" in e_str, "Expect suggestion in message"
+
+
+def test_pamh_context_starts_session(pamh):
+    with mock.patch.object(pamh, "pam_start") as mock_start:
+        with pamh as test_pamh:
+            assert pamh is test_pamh
+
+    assert mock_start.called
+    a, _k = mock_start.call_args
+    assert (a[0], a[1]) == (pamh.service_name, pamh.username), "Expect useful defaults"
+
+
+def test_pamh_context_ends_session(pamh):
+    with mock.patch.object(pamh, "pam_end") as mock_end:
+        with pamh:
+            assert pamh._started
+    assert mock_end.called
+
+
+def test_pamh_context(pamh):
+    assert pamh._started is False
+    with pamh:
+        assert pamh._started
+    assert pamh._started is False
+
+
+def test_pamh_flag_only_methods_raises(pamh):
+    errenum: PamReturnEnum = random.choice(tuple(PamReturnEnum)[1:])  # no SUCCESS!
+
+    def return_nonzero(*a, **k):
+        return errenum.value
+
+    with pytest.raises(PamError) as pyt_e:
+        pamh._flags_only_method(return_nonzero)
+
+    assert pamh.last_rc == errenum.value
+    assert errenum.name in str(pyt_e.value)
+
+
+@pytest.mark.parametrize(
+    "fn_name", ("setcred", "acct_mgmt", "open_session", "close_session", "authenticate")
+)
+def test_pamh_flags_only_passthrough(pamh, fn_name):
+    pamh_fn_name = f"pam_{fn_name}"
+    pam_lib_fn = getattr(pam, f"_{pamh_fn_name}")
+    flags = random.randint(0, 0xFFFF)
+    with mock.patch.object(pamh, "_flags_only_method") as mock_fl:
+        getattr(pamh, pamh_fn_name)(flags)
+
+    assert mock_fl.called
+    a, _k = mock_fl.call_args
+    assert a[0] is pam_lib_fn, "Correct PAM callable supplied"
+    assert a[1] == flags
+
+
+@pytest.mark.parametrize(
+    "fn_name,flag",
+    (
+        ("credentials_establish", PamCred.PAM_ESTABLISH_CRED),
+        ("credentials_delete", PamCred.PAM_DELETE_CRED),
+        ("credentials_refresh", PamCred.PAM_REFRESH_CRED),
+        ("credentials_reinitialize", PamCred.PAM_REINITIALIZE_CRED),
+    ),
+)
+def test_pamh_creds(pamh, fn_name, flag):
+    with mock.patch.object(pamh, "pam_setcred") as mock_set:
+        getattr(pamh, fn_name)()
+    assert mock_set.called, "Convenience method wrapper calls pam_setcred"
+    a, _k = mock_set.call_args
+    assert a[0] is flag

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -173,7 +173,7 @@ regex before searching, so the actual regular expression used would be
 ``^(.*)@example.com$``.  Finally, if a match is found, the first saved group is the
 output (i.e., ``{0}``).  If the ``username`` field contained ``mickey97@example.com``,
 then this configuration would return ``mickey97``, and the MEP would then use
-`getpwnam(3)`_ to look up ``mickey97``.  But if the username field(s) did not end with
+|getpwnam(3)|_ to look up ``mickey97``.  But if the username field(s) did not end with
 ``@example.com``, then it would not match and the start-UEP request would fail.
 
 .. code-block:: json
@@ -661,6 +661,150 @@ Installing the MEP as a service is the same :ref:`procedure as with a regular en
 install a systemd unit file.
 
 
+.. _pam:
+
+Pluggable Authentication Modules (PAM)
+======================================
+
+`Pluggable Authentication Modules`_ (PAM) allows administrators to configure
+site-specific authentication schemes with arbitrary requirements.  For example, where
+one site might require users to use `MFA`_, another site could disallow use of the
+system for some users at certain times of the day.  Rather than rewrite or modify
+software to accommodate each site's needs, administrators can simply change their site
+configuration.
+
+As a brief intro to PAM, the architecture is designed with four phases:
+
+- authentication
+- account management
+- session management
+- password management
+
+The MEP implements *account* and *session management*.  If enabled, then the child
+process will create a PAM session, check the account (|pam_acct_mgmt(3)|_), and then
+open a session (|pam_open_session(3)|_).  If these two steps succeed, then the MEP will
+continue to drop privileges and become the UEP.  But in these two steps is where the
+administrator can implement custom configuration.
+
+PAM is configured in two parts.  For the MEP, use the ``pam`` field:
+
+.. code-block:: yaml
+   :caption: ``config.yaml`` to show PAM
+   :emphasize-lines: 3,4
+
+   multi_user: true
+   identity_mapping_config_path: .../some/idmap.json
+   pam:
+     enable: true
+
+This configuration will choose the default PAM service name,
+``globus-compute-endpoint`` (see |PamConfiguration|).  The service name is the name of
+the PAM configuration file in ``/etc/pam.d/``.  Use ``service_name`` to tell the MEP
+to authorize users against a different PAM configuration:
+
+.. code-block:: yaml
+   :caption: ``config.yaml`` with a custom PAM service name
+   :emphasize-lines: 7
+
+   multi_user: true
+   identity_mapping_config_path: .../some/idmap.json
+   pam:
+     enable: true
+
+     # the PAM routines will look for `/etc/pam.d/gce-mep123-specific-requirements`
+     service_name: gce-mep123-specific-requirements
+
+For clarity, note that the service name is simply passed to |pam_start(3)|_, to tell
+PAM which service configuration to apply.
+
+.. important::
+
+  If PAM is not enabled, then before starting user endpoints, the child process drops
+  all capabilities and sets the no-new-privileges flag with the kernel.  (See
+  |prctl(2)|_ and reference ``PR_SET_NO_NEW_PRIVS``).  In particular, this will
+  preclude use of SETUID executables, which can break some schedulers.  If your site
+  requires use of SETUID executables, then PAM must be enabled.
+
+Though configuring PAM itself is outside the scope of this document (e.g., see
+|PAM_SAG|_), we briefly discuss a couple of modules to share a taste of what PAM can
+do.  For example, if the administrator were to implement a configuration of:
+
+.. code-block:: text
+   :caption: ``/etc/pam.d/globus-compute-endpoint``
+
+   account   requisite     pam_shells.so
+   session   required      pam_limits.so
+
+then, per |pam_shells(8)|_, any UEP for a user whose shell is not listed in
+``/etc/shells`` will not start and the logs will have a line like:
+
+.. code-block:: text
+
+   ... (error code: 7 [PAM_AUTH_ERR]) Authentication failure
+
+On the other end, the user's SDK would receive a message like:
+
+.. code-block:: text
+
+   Request payload failed validation: Unable to start user endpoint process for jessica [exit code: 71; (PermissionError) see your system administrator]
+
+Similarly, for users who are administratively allowed (i.e., have a valid shell), the
+|pam_limits(8)|_ module will install the admin-configured process limits.
+
+.. hint::
+
+   The Globus Compute Endpoint software implements the account management and session
+   phases of PAM.  As authentication is enacted via Globua Auth and
+   :ref:`Identity Mapping <identity-mapping>`, it does not use PAM's authentication
+   (|pam_authenticate(3)|_) phase, nor does it attempt to manage the user's password.
+   Functionally, this means that only PAM configuration lines that begin with
+   ``account`` and ``session`` will be utilized.
+
+Look to PAM for a number of tasks (which we tease here, but are similarly out of scope
+of this documentation):
+
+- Setting UEP process capabilities (|pam_cap(8)|_)
+- Setting UEP process limits (|pam_limits(8)|_)
+- Setting environment variables (|pam_env(8)|_)
+- Enforcing ``/var/run/nologin`` (|pam_nologin(8)|_)
+- Updating ``/var/log/lastlog`` (|pam_lastlog(8)|_)
+- Create user home directory on demand (|pam_mkhomedir(8)|_)
+
+(If the available PAM modules do not fit the bill, it is also possible to write a
+custom module!  But sadly, that is also out of scope of this documentation; please see
+|PAM_MWG|_.)
+
+.. _MFA: https://en.wikipedia.org/wiki/Multi-factor_authentication
+.. |PAM_SAG| replace:: The Linux-PAM System Administrators' Guide
+.. _PAM_SAG: https://www.chiark.greenend.org.uk/doc/libpam-doc/html/Linux-PAM_SAG.html
+.. |PAM_MWG| replace:: The Linux-PAM Module Writers' Guide
+.. _PAM_MWG: https://www.chiark.greenend.org.uk/doc/libpam-doc/html/Linux-PAM_MWG.html
+.. |pam_acct_mgmt(3)| replace:: ``pam_acct_mgmt(3)``
+.. _pam_acct_mgmt(3): https://www.man7.org/linux/man-pages/man3/pam_acct_mgmt.3.html
+.. |pam_open_session(3)| replace:: ``pam_open_session(3)``
+.. _pam_open_session(3): https://www.man7.org/linux/man-pages/man3/pam_open_session.3.html
+.. |pam_authenticate(3)| replace:: ``pam_authenticate(3)``
+.. _pam_authenticate(3): https://www.man7.org/linux/man-pages/man3/pam_authenticate.3.html
+.. |pam_start(3)| replace:: ``pam_start(3)``
+.. _pam_start(3): https://www.man7.org/linux/man-pages/man3/pam_start.3.html
+.. |pam_shells(8)| replace:: ``pam_shells(8)``
+.. _pam_shells(8): https://www.man7.org/linux/man-pages/man8/pam_shells.8.html
+.. |pam_limits(8)| replace:: ``pam_limits(8)``
+.. _pam_limits(8): https://www.man7.org/linux/man-pages/man8/pam_limits.8.html
+.. |pam_cap(8)| replace:: ``pam_cap(8)``
+.. _pam_cap(8): https://www.man7.org/linux/man-pages/man8/pam_cap.8.html
+.. |pam_env(8)| replace:: ``pam_env(8)``
+.. _pam_env(8): https://www.man7.org/linux/man-pages/man8/pam_env.8.html
+.. |pam_nologin(8)| replace:: ``pam_nologin(8)``
+.. _pam_nologin(8): https://www.man7.org/linux/man-pages/man8/pam_nologin.8.html
+.. |pam_lastlog(8)| replace:: ``pam_lastlog(8)``
+.. _pam_lastlog(8): https://www.man7.org/linux/man-pages/man8/pam_lastlog.8.html
+.. |pam_mkhomedir(8)| replace:: ``pam_mkhomedir(8)``
+.. _pam_mkhomedir(8): https://www.man7.org/linux/man-pages/man8/pam_mkhomedir.8.html
+
+.. |prctl(2)| replace:: ``prctl(2)``
+.. _prctl(2): https://www.man7.org/linux/man-pages/man2/prctl.2.html
+
 .. _auth-policies:
 
 Authentication Policies
@@ -730,8 +874,10 @@ make the necessary changes to ``config.yaml``:
    $ globus-compute-endpoint configure my-mep --multi-user --auth-policy 2340174a-1a0e-46d8-a958-7c3ddf2c834a
 
 
-Function Whitelisting
-=====================
+.. _function-allowlist:
+
+Function Allow Listing
+======================
 
 To require that UEPs only invoke certain functions, specify the ``allowed_functions``
 top-level configuration item:
@@ -837,7 +983,7 @@ The workflow for a task sent to a MEP roughly follows these steps:
 #. The MEP maps the Globus Auth identity in the start-UEP-request to a local (POSIX)
    username.
 
-#. The MEP ascertains the host-specific UID based on a `getpwnam(3)`_ call with the
+#. The MEP ascertains the host-specific UID based on a |getpwnam(3)|_ call with the
    local username from the previous step.
 
 #. The MEP starts a UEP as the UID from the previous step.
@@ -1028,7 +1174,7 @@ Administrator Quickstart
 #. Setup the identity mapping configuration |nbsp| --- |nbsp| this depends on your
    site's specific requirements and may take some trial and error.  The key point is to
    be able to take a Globus Auth Identity set, and map it to a local username *on this
-   resource* |nbsp| --- |nbsp| this resulting username will be passed to `getpwnam(3)`_
+   resource* |nbsp| --- |nbsp| this resulting username will be passed to |getpwnam(3)|_
    to ascertain a UID for the user.  This file is linked in ``config.yaml`` (from the
    previous step's output), and, per initial configuration, is set to
    ``example_identity_mapping_config.json``.  While the configuration is syntactically
@@ -1119,6 +1265,7 @@ Administrator Quickstart
 .. _Authentication Policies documentation: https://docs.globus.org/api/auth/developer-guide/#authentication_policy_fields
 .. |globus-identity-mapping| replace:: ``globus-identity-mapping``
 .. _globus-identity-mapping: https://pypi.org/project/globus-identity-mapping/
+.. |getpwnam(3)| replace:: ``getpwnam(3)``
 .. _getpwnam(3): https://www.man7.org/linux/man-pages/man3/getpwnam.3.html
 .. _Jinja template: https://jinja.palletsprojects.com/en/3.1.x/
 .. _Globus Connect Server Identity Mapping Guide: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/#mapping_recipes
@@ -1126,7 +1273,10 @@ Administrator Quickstart
 .. |UserRuntime| replace:: :class:`UserRuntime <globus_compute_sdk.sdk.batch.UserRuntime>`
 .. _JSON schema: https://json-schema.org/
 
+.. |PamConfiguration| replace:: :class:`PamConfiguration <globus_compute_endpoint.endpoint.config.pam.PamConfiguration>`
+
 .. _virtualenv: https://pypi.org/project/virtualenv/
 .. _pipx: https://pypa.github.io/pipx/
 .. _conda: https://docs.conda.io/en/latest/
 .. _dill: https://pypi.org/project/dill/
+.. _Pluggable Authentication Modules: https://en.wikipedia.org/wiki/Linux_PAM


### PR DESCRIPTION
PAM (Pluggable Authentication Modules) is an opt-in configuration item for `ManagerEndpointConfig`.  As documented in this PR, it is enabled via the `pam` configuration item, and defaults to false/not enabled if not specified:

```yaml
multi_user: true
pam:
  enable: true
```

I was unable to find a suitable Python PAM implementation for our needs, so ended up creating a PAM wrapper.  In particular, all of the PAM implementations I found seemed to only implement the `pam_authenticate()` method, but we need the `pam_acct_mgmt()` and `pam_*_session()` functions.  Until I'm educated otherwise then, our internal library appears to be more fully featured than other Python PAM implementations&nbsp;&mdash;&nbsp;we may pull it out and offer it as an independent project at some point.

[sc-36027]

## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update