### PR TITLE
Replace ipv4 v6 sc 37307

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/taskqueue.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/taskqueue.py
@@ -91,6 +91,8 @@ class TaskQueue:
         if linger is not None:
             self.zmq_socket.setsockopt(zmq.LINGER, linger)
 
+        self.zmq_socket.setsockopt(zmq.IPV6, True)
+
         # all zmq setsockopt calls must be done before bind/connect is called
         if self.mode == "server":
             self.zmq_socket.bind(f"tcp://*:{port}")
@@ -122,6 +124,7 @@ class TaskQueue:
         self.auth = ThreadAuthenticator(self.context)
         self.auth.start()
         self.auth.allow("127.0.0.1")
+        self.auth.allow("::1")
         # Tell the authenticator how to handle CURVE requests
 
         if not self.ironhouse:

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
@@ -134,11 +134,11 @@ class Interchange:
 
         client_address : str
              The ip address at which the parsl client can be reached.
-             Default: "127.0.0.1"
+             Default: "localhost"
 
         interchange_address : str
              The ip address at which the workers will be able to reach the Interchange.
-             Default: "127.0.0.1"
+             Default: "localhost"
 
         client_ports : tuple[int, int, int]
              The ports at which the client can be reached

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/manager.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/manager.py
@@ -80,8 +80,8 @@ class Manager:
 
     def __init__(
         self,
-        task_q_url="tcp://127.0.0.1:50097",
-        result_q_url="tcp://127.0.0.1:50098",
+        task_q_url="tcp://localhost:50097",
+        result_q_url="tcp://localhost:50098",
         max_queue_size=10,
         cores_per_worker=1,
         available_accelerators: list[str] | None = None,
@@ -171,6 +171,7 @@ class Manager:
         # Linger is set to 0, so that the manager can exit even when there might be
         # messages in the pipe
         self.task_incoming.setsockopt(zmq.LINGER, 0)
+        self.task_incoming.setsockopt(zmq.IPV6, True)
         self.task_incoming.connect(task_q_url)
 
         self.logdir = logdir
@@ -179,6 +180,7 @@ class Manager:
         self.result_outgoing = self.context.socket(zmq.DEALER)
         self.result_outgoing.setsockopt(zmq.IDENTITY, uid.encode("utf-8"))
         self.result_outgoing.setsockopt(zmq.LINGER, 0)
+        self.result_outgoing.setsockopt(zmq.IPV6, True)
         self.result_outgoing.connect(result_q_url)
 
         log.info("Manager connected")
@@ -213,7 +215,8 @@ class Manager:
 
         self.funcx_task_socket = self.context.socket(zmq.ROUTER)
         self.funcx_task_socket.set_hwm(0)
-        self.address = "127.0.0.1"
+        self.funcx_task_socket.setsockopt(zmq.IPV6, True)
+        self.address = "localhost"
         self.worker_port = self.funcx_task_socket.bind_to_random_port(
             "tcp://*",
             min_port=self.internal_worker_port_range[0],

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/worker.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/worker.py
@@ -38,7 +38,8 @@ class Worker:
      Worker id string
 
     address : str
-     Address at which the manager might be reached. This is usually 127.0.0.1
+     Address at which the manager might be reached. This is usually the ipv4
+     or ipv6 loopback address 127.0.0.1 or ::1
 
     port : int
      Port at which the manager can be reached
@@ -79,6 +80,7 @@ class Worker:
 
         self.task_socket = self.context.socket(zmq.DEALER)
         self.task_socket.setsockopt(zmq.IDENTITY, self.identity)
+        self.task_socket.setsockopt(zmq.IPV6, True)
 
         log.info(f"Trying to connect to : tcp://{self.address}:{self.port}")
         self.task_socket.connect(f"tcp://{self.address}:{self.port}")

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -139,7 +139,7 @@ def engine_runner(
             k = dict(max_workers=2)
         elif engine_type is engines.GlobusComputeEngine:
             k = dict(
-                address="127.0.0.1",
+                address="::1",
                 heartbeat_period=engine_heartbeat,
                 heartbeat_threshold=2,
                 job_status_kwargs=dict(max_idletime=0, strategy_period=0.1),
@@ -153,7 +153,7 @@ def engine_runner(
                 """
 
             k = dict(
-                address="127.0.0.1",
+                address="::1",
                 heartbeat_period=engine_heartbeat,
                 heartbeat_threshold=1,
                 mpi_launcher="mpiexec",

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -394,10 +394,10 @@ class TestStart:
         mock_interchange.return_value.stop.return_value = None
 
         mock_optionals = {}
-        mock_optionals["interchange_address"] = "127.0.0.1"
+        mock_optionals["interchange_address"] = "::1"
 
         mock_funcx_config = {}
-        mock_funcx_config["endpoint_address"] = "127.0.0.1"
+        mock_funcx_config["endpoint_address"] = "::1"
 
         manager = Endpoint(funcx_dir=os.getcwd())
         manager.name = "test"

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def gc_engine_scaling(tmp_path):
     ep_id = uuid.uuid4()
     engine = GlobusComputeEngine(
-        address="127.0.0.1",
+        address="::1",
         heartbeat_period=1,
         heartbeat_threshold=2,
         provider=LocalProvider(
@@ -37,7 +37,7 @@ def gc_engine_scaling(tmp_path):
 def gc_engine_non_scaling(tmp_path):
     ep_id = uuid.uuid4()
     engine = GlobusComputeEngine(
-        address="127.0.0.1",
+        address="::1",
         heartbeat_period=1,
         heartbeat_threshold=2,
         provider=LocalProvider(

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -100,5 +100,5 @@ def test_repeated_fail(mock_gce, ez_pack_task):
 
 
 def test_default_retries_is_0():
-    engine = GlobusComputeEngine(address="127.0.0.1")
+    engine = GlobusComputeEngine(address="localhost")
     assert engine.max_retries_on_system_failure == 0, "Users must knowingly opt-in"

--- a/compute_endpoint/tests/unit/test_bad_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_bad_endpoint_config.py
@@ -6,7 +6,7 @@ from globus_compute_endpoint.engines import HighThroughputEngine
 _MOCK_BASE = "globus_compute_endpoint.engines.high_throughput.engine."
 
 
-@pytest.mark.parametrize("address", ("localhost", "login1.theta.alcf.anl.gov", "*"))
+@pytest.mark.parametrize("address", ("example", "a.b.c.d.e", "*"))
 def test_invalid_address(address, htex_warns):
     with mock.patch(f"{_MOCK_BASE}log") as mock_log:
         with pytest.raises(ValueError):

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -491,7 +491,7 @@ def test_config_yaml_display_none(run_line, mock_command_ensure, display_name):
     run_line(config_cmd)
 
     conf_dict = dict(yaml.safe_load(conf.read_text()))
-    conf_dict["engine"]["address"] = "127.0.0.1"  # avoid unnecessary DNS lookup
+    conf_dict["engine"]["address"] = "::1"  # avoid unnecessary DNS lookup
     conf = load_config_yaml(yaml.safe_dump(conf_dict))
 
     assert conf.display_name is None, conf.display_name

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -20,7 +20,7 @@ _MOCK_BASE = "globus_compute_endpoint.endpoint.config."
 
 @pytest.fixture
 def config_dict():
-    return {"engine": {"type": "GlobusComputeEngine", "address": "127.0.0.1"}}
+    return {"engine": {"type": "GlobusComputeEngine", "address": "localhost"}}
 
 
 @pytest.fixture
@@ -140,7 +140,9 @@ def test_conditional_engine_strategy(
 ):
     config_dict["engine"]["type"] = engine_type
     config_dict["engine"]["strategy"] = strategy
-    config_dict["engine"]["address"] = "127.0.0.1"
+    config_dict["engine"]["address"] = (
+        "::1" if engine_type != "HighThroughputEngine" else "127.0.0.1"
+    )
 
     if engine_type == "GlobusComputeEngine":
         if isinstance(strategy, str) or strategy is None:
@@ -173,7 +175,7 @@ def test_provider_container_compatibility(
 ):
     config_dict["engine"]["container_uri"] = "docker://ubuntu"
     config_dict["engine"]["provider"] = {"type": provider_type}
-    config_dict["engine"]["address"] = "127.0.0.1"
+    config_dict["engine"]["address"] = "::1"
 
     if compatible:
         UserEndpointConfigModel(**config_dict)

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -530,7 +530,7 @@ def test_endpoint_get_metadata(mocker, engine_cls):
 
     k = {}
     if engine_cls is GlobusComputeEngine:
-        k["address"] = "127.0.0.1"
+        k["address"] = "::1"
     executors = [engine_cls(**k)]
     test_config = UserEndpointConfig(executors=executors)
     test_config.source_content = "foo: bar"
@@ -720,7 +720,7 @@ def test_always_prints_endpoint_id_to_terminal(mocker, mock_ep_data, mock_reg_in
 def test_serialize_config_field_types():
     fns = [str(uuid.uuid4()) for _ in range(5)]
 
-    ep_config = UserEndpointConfig(executors=[GlobusComputeEngine(address="127.0.0.1")])
+    ep_config = UserEndpointConfig(executors=[GlobusComputeEngine(address="::1")])
     ep_config._hidden_attr = "123"
     ep_config.rando_attr = "howdy"
     ep_config.allowed_functions = fns

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -19,7 +19,7 @@ def gce_factory(tmp_path, randomstring) -> t.Callable:
         expect_uri = randomstring(length=random.randint(1, 20))
         expect_opts = randomstring(length=random.randint(1, 20))
         k = {
-            "address": "127.0.0.1",
+            "address": "::1",
             "max_workers_per_node": 1,
             "label": "GCE_TEST",
             "container_uri": expect_uri,
@@ -66,7 +66,7 @@ def test_custom_missing_options(tmp_path):
     with pytest.raises(AssertionError) as pyt_e:
         with mock.patch(f"{_MOCK_BASE}ReportingThread"):
             GlobusComputeEngine(
-                address="127.0.0.1",
+                address="::1",
                 max_workers_per_node=1,
                 label="GCE_TEST",
                 container_type="custom",
@@ -88,4 +88,4 @@ def test_custom(gce_factory, randomstring):
 
 def test_bad_container():
     with pytest.raises(AssertionError):
-        GlobusComputeEngine(address="127.0.0.1", container_type="BAD")
+        GlobusComputeEngine(address="::1", container_type="BAD")

--- a/compute_endpoint/tests/unit/test_reporting_period.py
+++ b/compute_endpoint/tests/unit/test_reporting_period.py
@@ -24,7 +24,7 @@ def test_default_period():
     thread = thread_pool._status_report_thread
     assert thread.reporting_period == 30.0
 
-    gce = GlobusComputeEngine(address="127.0.0.1", heartbeat_period=1)
+    gce = GlobusComputeEngine(address="::1", heartbeat_period=1)
     thread = gce._status_report_thread
     assert thread.reporting_period == 30.0
     assert gce.executor.heartbeat_period == 1

--- a/compute_endpoint/tests/unit/test_worker.py
+++ b/compute_endpoint/tests/unit/test_worker.py
@@ -45,7 +45,7 @@ def test_worker():
         # the worker will receive tasks and send messages on this mock socket
         mock_socket = mock.Mock()
         mock_context.return_value.socket.return_value = mock_socket
-        yield Worker("0", "127.0.0.1", 50001)
+        yield Worker("0", "::1", 50001)
 
 
 def test_register_and_kill(test_worker):

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -23,7 +23,7 @@ def reset_cwd():
 
 @pytest.mark.parametrize(
     "engine",
-    (GlobusComputeEngine(address="127.0.0.1"), ThreadPoolEngine(), ProcessPoolEngine()),
+    (GlobusComputeEngine(address="::1"), ThreadPoolEngine(), ProcessPoolEngine()),
 )
 def test_set_working_dir_default(engine, tmp_path):
     """Verify that working dir is set to tasks dir in the run_dir by default for all
@@ -36,7 +36,7 @@ def test_set_working_dir_default(engine, tmp_path):
 
 @pytest.mark.parametrize(
     "engine",
-    (GlobusComputeEngine(address="127.0.0.1"), ThreadPoolEngine(), ProcessPoolEngine()),
+    (GlobusComputeEngine(address="::1"), ThreadPoolEngine(), ProcessPoolEngine()),
 )
 def test_set_working_dir_called(engine, tmp_path, endpoint_uuid):
     """Verify that set_working_dir is called when engine.start() is called"""
@@ -50,7 +50,7 @@ def test_set_working_dir_called(engine, tmp_path, endpoint_uuid):
 
 @pytest.mark.parametrize(
     "engine",
-    (GlobusComputeEngine(address="127.0.0.1"), ThreadPoolEngine(), ProcessPoolEngine()),
+    (GlobusComputeEngine(address="::1"), ThreadPoolEngine(), ProcessPoolEngine()),
 )
 def test_set_working_dir_relative(engine, tmp_path):
     """Working_dir should be absolute and set relative to the endpoint run_dir"""
@@ -64,7 +64,7 @@ def test_set_working_dir_relative(engine, tmp_path):
 def test_default_working_dir(tmp_path):
     """Test working_dir relative to run_dir"""
     gce = GlobusComputeEngine(
-        address="127.0.0.1",
+        address="::1",
     )
     gce.executor.start = mock.MagicMock(spec=HighThroughputExecutor.start)
     gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
@@ -75,7 +75,7 @@ def test_default_working_dir(tmp_path):
 def test_relative_working_dir(tmp_path):
     """Test working_dir relative to run_dir"""
     gce = GlobusComputeEngine(
-        address="127.0.0.1",
+        address="::1",
         working_dir="relative_path",
     )
     gce.executor.start = mock.MagicMock(spec=HighThroughputExecutor.start)
@@ -87,7 +87,7 @@ def test_relative_working_dir(tmp_path):
 def test_absolute_working_dir(tmp_path):
     """Test absolute path for working_dir"""
     gce = GlobusComputeEngine(
-        address="127.0.0.1",
+        address="::1",
         working_dir="/absolute/path",
     )
     gce.executor.start = mock.MagicMock(spec=HighThroughputExecutor.start)
@@ -99,7 +99,7 @@ def test_absolute_working_dir(tmp_path):
 def test_submit_pass(tmp_path, task_uuid):
     """Test absolute path for working_dir"""
     gce = GlobusComputeEngine(
-        address="127.0.0.1",
+        address="::1",
     )
     gce.executor.start = mock.Mock(spec=HighThroughputExecutor.start)
     gce.executor.submit = mock.Mock(spec=HighThroughputExecutor.submit)

--- a/compute_sdk/tests/unit/test_login_manager.py
+++ b/compute_sdk/tests/unit/test_login_manager.py
@@ -220,7 +220,7 @@ def test_requires_login_decorator(mocker, logman):
 
     class MockClient:
         login_manager = logman
-        web_service_address = "127.0.0.1"
+        web_service_address = "::1"
         upstream_call = requires_login(mock_method)
 
     mock_client = MockClient()

--- a/docs/autobuild.sh
+++ b/docs/autobuild.sh
@@ -49,7 +49,7 @@ make clean html || exit 2
 # quick and dirty display clean up from inaugural run; highlight python
 # 'http.server' message
 echo -en "\033[;H\033[J\033[40;92;1m"
-(cd _build/html/; python3 -m http.server -b 127.0.0.1 $PORT) &
+(cd _build/html/; python3 -m http.server -b localhost $PORT) &
 sleep 1
 echo -en "\033[m"
 


### PR DESCRIPTION
One of the steps in making sure ipv6 is supported is too remove the usage of the ipv4 loopback address `127.0.0.1`, replacing it with `::1` to confirm that things work with ipv6.  (127.0.0.1 has already been working since beginning of history, so doesn't need to be kept in most circumstances.

We also decided that we should not go the extra mile to ensure that ipv6 is compatible with HTEX, as that's being deprecated.  All the 127.0.0.1 should be only in the htex module.

[sc-37307]