### PR TITLE
Fix `Client.logout()` method

### DIFF
--- a/changelog.d/20241120_120234_30907815+rjmello_fix_client_logout.rst
+++ b/changelog.d/20241120_120234_30907815+rjmello_fix_client_logout.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- ``Client.logout()`` no longer raises an ``AttributeError``.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -109,6 +109,9 @@ class Client:
 
         self._task_status_table: dict[str, dict] = {}
 
+        self.app: GlobusApp | None = None
+        self.login_manager: LoginManagerProtocol | None = None
+
         if app and login_manager:
             raise ValueError("'app' and 'login_manager' are mutually exclusive.")
         elif login_manager:
@@ -150,7 +153,9 @@ class Client:
 
     def logout(self):
         """Remove credentials from your local system"""
-        self.login_manager.logout()
+        auth_obj = self.app or self.login_manager
+        if auth_obj:
+            auth_obj.logout()
 
     def _log_version_mismatch(self, worker_details: dict | None) -> None:
         """

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -729,3 +729,19 @@ def test_client_handles_login_manager():
     assert mock_lm.get_auth_client.call_count == 1
     assert mock_lm.get_web_client.call_count == 1
     assert mock_lm.get_web_client.call_args[1]["base_url"] == client.web_service_address
+
+
+def test_client_logout_with_app(mocker):
+    mocker.patch(f"{_MOCK_BASE}ComputeAuthClient")
+    mocker.patch(f"{_MOCK_BASE}WebClient")
+    mock_app = mock.Mock(spec=UserApp)
+    client = gc.Client(do_version_check=False, app=mock_app)
+    client.logout()
+    assert mock_app.logout.called
+
+
+def test_client_logout_with_login_manager():
+    mock_lm = mock.Mock(spec=LoginManager)
+    client = gc.Client(do_version_check=False, login_manager=mock_lm)
+    client.logout()
+    assert mock_lm.logout.called


### PR DESCRIPTION
# Description

Ensure `Client.logout()` correctly handles `GlobusApp` and `LoginManager` objects. This method previously only handled the latter.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
