### PR TITLE
Drop support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -78,7 +78,7 @@ jobs:
         options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/20241111_160525_chris_new_pythons.rst
+++ b/changelog.d/20241111_160525_chris_new_pythons.rst
@@ -2,4 +2,4 @@ New Functionality
 ^^^^^^^^^^^^^^^^^
 
 - The ``globus-compute-sdk`` and ``globus-compute-endpoint`` packages now support
-  Python versions 3.12 and 3.13.
+  Python version 3.12.

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{313,312,311,310,39}
+envlist = py{312,311,310,39}
 skip_missing_interpreters = true
 
 [testenv]

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{313,312,311,310,39}
+envlist = py{312,311,310,39}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
# Description

During testing, it was discovered that the following error happens when starting an endpoint on py313. Pulling support for that version until a future release while diagnosing the error.

```
Traceback (most recent call last):
  File "/Users/chris/opt/anaconda3/envs/gce-py313/bin/globus-compute-endpoint", line 8, in <module>
    sys.exit(cli_run())
             ~~~~~~~^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/cli.py", line 984, in cli_run
    app()
    ~~~^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/exception_handling.py", line 80, in wrapper
    return f(*args, **kwargs)
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/cli.py", line 468, in start_endpoint
    _do_start_endpoint(
    ~~~~~~~~~~~~~~~~~~^
        ep_dir=ep_dir,
        ^^^^^^^^^^^^^^
        endpoint_uuid=state.endpoint_uuid,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        die_with_parent=state.die_with_parent,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/cli.py", line 693, in _do_start_endpoint
    get_cli_endpoint(ep_config).start_endpoint(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        ep_dir,
        ^^^^^^^
    ...<5 lines>...
        die_with_parent,
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/endpoint/endpoint.py", line 559, in start_endpoint
    Endpoint.daemon_launch(
    ~~~~~~~~~~~~~~~~~~~~~~^
        endpoint_uuid,
        ^^^^^^^^^^^^^^
    ...<4 lines>...
        parent_pid,
        ^^^^^^^^^^^
    )
    ^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/endpoint/endpoint.py", line 589, in daemon_launch
    interchange.start()
    ~~~~~~~~~~~~~~~~~^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/endpoint/interchange.py", line 218, in start
    self.start_engine()
    ~~~~~~~~~~~~~~~~~^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/endpoint/interchange.py", line 141, in start_engine
    self.executor.start(
    ~~~~~~~~~~~~~~~~~~~^
        results_passthrough=self.results_passthrough,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        endpoint_id=self.endpoint_id,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        run_dir=self.logdir,
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/engines/globus_compute.py", line 268, in start
    self._status_report_thread.start()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/site-packages/globus_compute_endpoint/engines/base.py", line 52, in start
    self._thread.start()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/chris/opt/anaconda3/envs/gce-py313/lib/python3.13/threading.py", line 973, in start
    _start_joinable_thread(self._bootstrap, handle=self._handle,
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                           daemon=self.daemon)
                           ^^^^^^^^^^^^^^^^^^^
RuntimeError: thread already started
```
