### PR TITLE
Bump parsl 11 25 and remove reference to removed method

### DIFF
--- a/changelog.d/20241126_104747_LeiGlobus_bump_parsl_11_25.rst
+++ b/changelog.d/20241126_104747_LeiGlobus_bump_parsl_11_25.rst
@@ -1,0 +1,9 @@
+New Functionality
+^^^^^^^^^^^^^^^^
+
+- Added ipv6 support for GlobusComputeEngine by upgrading Parsl
+
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version to `2024.11.25 <https://pypi.org/project/parsl/2024.11.25/>`_.

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
@@ -356,9 +356,7 @@ class Interchange:
             self.provider.channel.script_dir = os.path.join(
                 working_dir, "submit_scripts"
             )
-            self.provider.channel.makedirs(
-                self.provider.channel.script_dir, exist_ok=True
-            )
+            os.makedirs(self.provider.channel.script_dir, mode=0o700, exist_ok=True)
             os.makedirs(self.provider.script_dir, exist_ok=True)
 
         debug_opts = "--debug" if self.worker_debug else ""

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.10.21",
+    "parsl==2024.11.25",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
Bumping parsl mostly works, except that Compute uses a method that's been removed/cleaned up in Parsl:

https://github.com/Parsl/parsl/pull/3689

The original code does a redundant makedirs anyway - if the child is made, the parent is also created.
*edit* However, I left the parent's makedirs() in anyway, because the original child dir creation had a different default permission, just in case.