### PR TITLE
document package pushing procedures

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,3 +113,68 @@ git push
 
 6. Create a GitHub release from the tag. See [GitHub documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release)
    for instructions.
+
+### DEB/RPM Packaging Workflow
+
+#### Pre-requisites
+
+Before building the packages:
+
+* ensure that the release itself, either the alpha or prod versions, is published on PyPI.
+* VPN is enabled to access the build page.
+
+#### Build Process
+
+To build the alpha DEB/RPM packages after the alpha PyPI is released, simply put
+the tag name ie. ``v2.29.0a0`` or ``v2.29.0`` into the input textbox of the
+[build page here](https://builds.globus.org/jenkins/job/BuildGlobusComputeAgentPackages/build?delay=0sec).
+then clicking the green **Build** button.
+
+For production builds, check the  ``BUILD_FOR_STABLE`` box.
+
+1. Notes
+    Our alpha builds will go to the ``unstable`` repo, and production packages goes
+     to both the ``testing`` and ``stable`` repos.
+
+    After this build process for production, the testing and stable packages will
+    reside in an internal globus 'holding' repo.  GCS manages the infrastructure
+    so we need to run another Jenkins build to push it to live if GCS is not having
+    a release the same week.  TBD details
+
+    * Example of unstable repo:
+        * https://downloads.globus.org/globus-connect-server/unstable/rpm/el/9/x86_64/
+    * Directory of testing images:
+        * https://builds.globus.org/downloads.globus.org/globus-connect-server/testing/rpm/el/8/x86_64/
+    * Stable repo:
+        * The images will be in the below build directory after we finish our build process, but not public:
+            * https://builds.globus.org/downloads.globus.org/globus-connect-server/stable/rpm/el/8/x86_64/
+        * After GCS push during deploy day (or if we ping them to do so), the public images will be located at:
+            * https://downloads.globus.org/globus-connect-server/stable/rpm/el/9/x86_64/
+      [publishResults.groovy line 85](https://github.com/globusonline/gcs-build-scripts/blob/168617a0ccbb0aee7b3bee04ee67940bbe2a80f6/vars/publishResults.groovy#L85)
+2. (Access on VPN) Click the [build button here](https://builds.globus.org/jenkins/job/BuildGlobusComputeAgentPackages/build?delay=0sec)
+3. Wait 20-30 minutes and confirm that the [build is green](https://builds.globus.org/jenkins/job/BuildGlobusComputeAgentPackages/)
+4. For production release cycles where there is also a GCS release, if we push our packages before they do, skip the following (also not necessary for alpha releases)
+    * If there isn't a concurrent GCS release, or if we build our packages after they finish their deploy, we need to manually run the downloads sync (leave SYNC_V4_REPO ubnchecked):
+    * https://builds.globus.org/jenkins/view/all/job/Synchronize%20GCSv5%20Stable/build?delay=0sec
+
+#### Old Build Instructions
+
+(Previously) As a temporary workaround, we needed to add a few lines to manually set some
+env variables in our [JenkinsFile](https://github.com/globus/globus-compute/blob/743fa1e398fd40a00efb5880c55e3fa6e47392fc/compute_endpoint/packaging/JenkinsFile#L24) before triggering the build, as detailed below.
+
+1. Notes
+    * Example of unstable repo:
+        * https://downloads.globus.org/globus-connect-server/unstable/rpm/el/9/x86_64/
+    * Directory of testing images:
+        * https://builds.globus.org/downloads.globus.org/globus-connect-server/testing/rpm/el/8/x86_64/
+    * Stable repo:
+        * The images will be in the below build directory after we finish our build process, but not public:
+            * https://builds.globus.org/downloads.globus.org/globus-connect-server/stable/rpm/el/8/x86_64/
+        * After GCS push during deploy day (or if we ping them to do so), the public images will be located at:
+            * https://downloads.globus.org/globus-connect-server/stable/rpm/el/9/x86_64/
+      [publishResults.groovy line 85](https://github.com/globusonline/gcs-build-scripts/blob/168617a0ccbb0aee7b3bee04ee67940bbe2a80f6/vars/publishResults.groovy#L85)
+2. (Access on VPN) Click the [build button here](https://builds.globus.org/jenkins/job/BuildGlobusComputeAgentPackages/build?delay=0sec)
+3. Wait 20-30 minutes and confirm that the [build is green](https://builds.globus.org/jenkins/job/BuildGlobusComputeAgentPackages/)
+4. For production release, we will have finished the build before the GCS
+   team, and can notify them that our build is complete.  They then will
+   publish all packages when they finish their builds, which includes ours.


### PR DESCRIPTION
This is the documented procedure to build DEB/RPM packages.  It was part of the build_for_stable branch, now separated so we can merge it into main.