### PR TITLE
Allow UEPs to restrict functions

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1073,10 +1073,12 @@ class EndpointManager:
                 self._config, template_str, user_config_schema, user_opts, user_runtime
             )
             stdin_data_dict = {
-                "allowed_functions": self._config.allowed_functions,
                 "amqp_creds": kwargs.get("amqp_creds"),
                 "config": user_config,
             }
+            if self._config.allowed_functions is not None:
+                stdin_data_dict["allowed_functions"] = self._config.allowed_functions
+
             stdin_data = json.dumps(stdin_data_dict, separators=(",", ":"))
             exit_code += 1
 


### PR DESCRIPTION
Update recent logic to only force UEPs to a certain function allow list iff the parent MEP has such a list.  If the parent MEP is _not_ otherwise restricted, then let the UEP's configuration decide.  This allows administrators to use Jinja logic to have different users restricted to different functions.

## Type of change

- New feature (non-breaking change that adds functionality)