### PR TITLE
Bumped dill dependency to v0.3.9 for Python 3.11+

### DIFF
--- a/changelog.d/20241205_121009_30907815+rjmello_bum_dill_v0_3_9.rst
+++ b/changelog.d/20241205_121009_30907815+rjmello_bum_dill_v0_3_9.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bumped ``dill`` dependency to version 0.3.9 for Python 3.11+.

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -13,7 +13,7 @@ REQUIRES = [
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy
     'dill==0.3.5.1;python_version<"3.11"',
-    'dill==0.3.6;python_version>="3.11"',
+    'dill==0.3.9;python_version>="3.11"',
     # typing_extensions, so we can use Protocol and other typing features on python3.7
     'typing_extensions>=4.0;python_version<"3.8"',
     # packaging, allowing version parsing


### PR DESCRIPTION
# Description

Bumped ``dill`` dependency to version 0.3.9 for Python 3.11+.

## Type of change

- Code maintenance/cleanup
