### PR TITLE
Add port 443 of amqp host to diagnostics

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -238,8 +238,10 @@ def connection_tests():
 
     return [
         test_conn(web_svc_host, 443),
-        test_conn(amqp_svc_host, 5671),
         test_ssl_conn(web_svc_host, 443),
+        test_conn(amqp_svc_host, 443),
+        test_ssl_conn(amqp_svc_host, 443),
+        test_conn(amqp_svc_host, 5671),
         test_ssl_conn(amqp_svc_host, 5671),
         print_service_versions(web_svc_url),
     ]


### PR DESCRIPTION
Also slightly reorder tests so ordered by hosts and port.

1. web conn (443)
2. web ssl conn (443)
3. amqp conn (443)
4. amqp ssl conn (443)
5. amqp conn (5761)
6. amqp ssl conn (5761)

## Type of change

- Code maintenance/cleanup