### PR TITLE
Modify release script to distinguish git tag errors

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -32,14 +32,18 @@ if ! grep '^globus\-compute\-sdk \& globus\-compute\-endpoint v'"$VERSION"'$' do
 fi
 
 echo "releasing v$VERSION"
-if git tag -s -m "v$VERSION" "$VERSION" ; then
+TAG_STDERR="$(git tag -s -m v$VERSION $VERSION 2>&1 > /dev/null)"
+if [[ $? == 0 ]]; then
   echo "Git tagged $VERSION"
   git push origin "$VERSION"
-else
+elif [[ "$TAG_STDERR" =~ "already exists" ]]; then
   read -p "Tag $VERSION already exists.  Release packages with this tag anyway? [y/n] " -n 1 -r
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     [[ $0 = $BASH_SOURCE ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
   fi
+else
+  echo "Git tag failed: $TAG_STDERR"
+  [[ $0 = $BASH_SOURCE ]] && exit 1
 fi
 
 pushd compute_sdk


### PR DESCRIPTION
When I released 2.32.0 earlier this week, the git tag command in release.sh failed(my gpg key, only used for tags, expired a few weeks earlier), but I missed the error message amongst the release output:

```
...
error: gpg failed to sign the data
error: unable to sign the tag
...
```

The script thinks it's a 'tag already exists' error and asks to confirm, which I answered 'y' without becoming suspicious of why the tag would already be pre-existing.  In the end, the packages were released but the tag wasn't pushed.

Instead, the user should be prompted for 'already exists' situations, but the script should abort for other, unknown issues.

