### PR TITLE
Remove no-longer necessary test-skips

### DIFF
--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -136,32 +136,27 @@ def _add_args_for_client_creds_login(api_client_id, api_client_secret, client_ar
     funcx_authorizer = AccessTokenAuthorizer(funcx_token)
     auth_authorizer = AccessTokenAuthorizer(auth_token)
 
-    try:
-        from globus_compute_sdk.sdk.login_manager import LoginManagerProtocol
-    except ImportError:
-        client_args["fx_authorizer"] = funcx_authorizer
-        client_args["openid_authorizer"] = auth_authorizer
-    else:
+    from globus_compute_sdk.sdk.login_manager import LoginManagerProtocol
 
-        class TestsuiteLoginManager:
-            def ensure_logged_in(self) -> None:
-                pass
+    class TestsuiteLoginManager:
+        def ensure_logged_in(self) -> None:
+            pass
 
-            def logout(self) -> None:
-                pass
+        def logout(self) -> None:
+            pass
 
-            def get_auth_client(self) -> AuthClient:
-                return AuthClient(authorizer=auth_authorizer)
+        def get_auth_client(self) -> AuthClient:
+            return AuthClient(authorizer=auth_authorizer)
 
-            def get_web_client(self, *, base_url: str | None = None) -> WebClient:
-                return WebClient(base_url=base_url, authorizer=funcx_authorizer)
+        def get_web_client(self, *, base_url: str | None = None) -> WebClient:
+            return WebClient(base_url=base_url, authorizer=funcx_authorizer)
 
-        login_manager = TestsuiteLoginManager()
+    login_manager = TestsuiteLoginManager()
 
-        # check runtime-checkable protocol
-        assert isinstance(login_manager, LoginManagerProtocol)
+    # check runtime-checkable protocol
+    assert isinstance(login_manager, LoginManagerProtocol)
 
-        client_args["login_manager"] = login_manager
+    client_args["login_manager"] = login_manager
 
 
 @pytest.fixture(scope="session")

--- a/smoke_tests/tests/test_s3_indirect.py
+++ b/smoke_tests/tests/test_s3_indirect.py
@@ -1,11 +1,5 @@
 import pytest
-
-try:
-    from globus_compute_sdk.errors import TaskExecutionFailed
-
-    has_task_exec_error_type = True
-except ImportError:
-    has_task_exec_error_type = False
+from globus_compute_sdk.errors import TaskExecutionFailed
 
 
 def large_result_producer(size: int) -> str:
@@ -25,9 +19,6 @@ def test_allowed_result_sizes(submit_function_and_get_result, endpoint, size):
     assert len(r.result) == size
 
 
-@pytest.mark.skipif(
-    not has_task_exec_error_type, reason="Test requires newer execution exception type"
-)
 def test_result_size_too_large(submit_function_and_get_result, endpoint):
     """
     Globus Compute should raise a MaxResultSizeExceeded exception when results exceeds
@@ -38,8 +29,8 @@ def test_result_size_too_large(submit_function_and_get_result, endpoint):
         submit_function_and_get_result(
             endpoint, func=large_result_producer, func_args=(11 * 1024 * 1024,)
         )
-        # ...so unwrap the exception to verify that it's the right type
-        assert "MaxResultSizeExceeded" in excinfo.value.remote_data
+    # ...so unwrap the exception to verify that it's the right type
+    assert "MaxResultSizeExceeded" in excinfo.value.remote_data
 
 
 @pytest.mark.parametrize("size", [200, 2000, 20000, 200000])


### PR DESCRIPTION
These skips were transitionally necessary, but the underlying imports and expectations are now stabilized.

## Type of change

- Code maintenance/cleanup