### PR TITLE
Replace TODO with link

### DIFF
--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -74,7 +74,7 @@ monitor status and retrieve results.
 
 .. note::
    Globus Compute places limits on the size of the functions and the rate at which functions can be submitted.
-   Please refer to the limits section for TODO:YADU
+   Please refer to the :doc:`limits` section for details.
 
 
 Retrieving Results


### PR DESCRIPTION
# Description
The documentation has a very visible TODO. I've replaced that with a proposed link to a relevant doc section.

Alternate solutions are possible and welcome; this is the smallest possible fix.

## Type of change
Documentation update

