### PR TITLE
Bump versions for V2.34.0 release

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.33.0"
+__version__ = "2.34.0a0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.34.0a0"
+__version__ = "2.34.0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.34.0a0",
+    "globus-compute-sdk==2.34.0",
     "globus-compute-common==0.5.0",
     "globus-identity-mapping==0.4.0",
     # table printing used in list-endpoints

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.33.0",
+    "globus-compute-sdk==2.34.0a0",
     "globus-compute-common==0.5.0",
     "globus-identity-mapping==0.4.0",
     # table printing used in list-endpoints

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.33.0"
+__version__ = "2.34.0a0"
 
 
 def compare_versions(

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.34.0a0"
+__version__ = "2.34.0"
 
 
 def compare_versions(


### PR DESCRIPTION
No public changelog for this release.  Most distinguished commit is add exponential backoff to smoke tests.