### PR TITLE
fix possible issue regarding bytes/str decoding

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/messages.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/messages.py
@@ -104,10 +104,11 @@ class Task(Message):
             #
             # all of this code is going to be eliminated soonish by
             # globus_compute_common.messagepack in part because of issues like this
-            add_ons = (
-                f"TID={self.task_id};CID={self.container_id};"  # type: ignore
-                f"{self.task_buffer}"
-            )
+            if isinstance(self.task_buffer, bytes):
+                buf = self.task_buffer.decode()
+            else:
+                buf = self.task_buffer
+            add_ons = f"TID={self.task_id};CID={self.container_id};{buf}"
             self.raw_buffer = add_ons.encode("utf-8")
 
         return self.type.pack() + self.raw_buffer


### PR DESCRIPTION
This started giving the following mypy error recently.  Not quite sure what changed, but handling str vs. bytes formally is better anyway.  (line a bit long for a one-liner so split it into if/else)

```
globus_compute_endpoint/engines/high_throughput/messages.py:110: error: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
```