### PR TITLE
Update Parsl to 2025.1.6

### DIFF
--- a/changelog.d/20250109_115759_kevin_update_parsl.rst
+++ b/changelog.d/20250109_115759_kevin_update_parsl.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+- Update Parsl to `2025.1.6 <https://pypi.org/project/parsl/2025.1.6/>`_.  Note
+  that Parsl's Channels were deprecated in Aug, 2024, and now completely
+  removed (see `Parsl Issue #3515
+  <https://github.com/Parsl/parsl/issues/3515>`_); consequently, this will be a
+  breaking change for those using Parsl's Channels.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -13,7 +13,6 @@ from globus_compute_common.pydantic_v1 import (
 from globus_compute_endpoint import engines, strategies
 from globus_compute_endpoint.endpoint.config.pam import PamConfiguration
 from parsl import addresses as parsl_addresses
-from parsl import channels as parsl_channels
 from parsl import launchers as parsl_launchers
 from parsl import providers as parsl_providers
 
@@ -66,19 +65,11 @@ class LauncherModel(BaseConfigModel):
     _validate_type = _validate_import("type", parsl_launchers)
 
 
-class ChannelModel(BaseConfigModel):
-    type: str
-
-    _validate_type = _validate_import("type", parsl_channels)
-
-
 class ProviderModel(BaseConfigModel):
     type: str
-    channel: t.Optional[ChannelModel]
     launcher: t.Optional[LauncherModel]
 
     _validate_type = _validate_import("type", parsl_providers)
-    _validate_channel = _validate_params("channel")
     _validate_launcher = _validate_params("launcher")
 
 

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -253,12 +253,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 f"Containerized launch cmd template: {self.executor.launch_cmd}"
             )
 
-        if (
-            getattr(self.executor.provider, "channel", None)
-            and not self.executor.provider.channel.script_dir
-        ):
-            self.executor.provider.channel.script_dir = script_dir
-
         os.makedirs(self.executor.provider.script_dir, exist_ok=True)
         if results_passthrough:
             # Only update the default queue in GCExecutorBase if

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.11.25",
+    "parsl==2025.1.6",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
I am unable to recreate the recent CI failures (that are so consistent in CI!) locally.  However, there was a major fix recently to be more clean during Parsl shutdown, so I'm hoping this addresses the flakiness.  Let's see what happens!

## Type of change

- Bug fix (non-breaking change that fixes an issue)  (Bug fix for CI, hopefully!)
- Breaking change (fix or feature that would cause existing functionality to not work as expected) (Channels are no more.)