### PR TITLE
Restrict serializers

### DIFF
--- a/changelog.d/20250113_150119_chris_restrict_serializers.rst
+++ b/changelog.d/20250113_150119_chris_restrict_serializers.rst
@@ -30,3 +30,20 @@ New Functionality
     #   The only allowed data serializer is JSONData.
     #
     #   (Hint: reserialize the arguments with JSONData and try again.)
+
+- Compute Endpoints can be configured to only deserialize and execute submissions that
+  were serialized with specific serialization strategies. For example, with the
+  following config:
+
+  .. code-block:: yaml
+
+    engine:
+        allowed_serializers:
+            - globus_compute_sdk.serialize.DillCodeSource
+            - globus_compute_sdk.serialize.DillCodeTextInspect
+            - globus_compute_sdk.serialize.JSONData
+        type: ThreadPoolEngine
+
+  any submissions that used the default serialization strategies (``DillCode``,
+  ``DillDataBase64``) would be rejected, and users would be informed to use one of the
+  allowed strategies.

--- a/changelog.d/20250113_150119_chris_restrict_serializers.rst
+++ b/changelog.d/20250113_150119_chris_restrict_serializers.rst
@@ -1,0 +1,32 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The ``ComputeSerializer`` can now be told to only deserialize payloads that were
+  serialized with specific serialization strategies. For example:
+
+  .. code-block:: python
+
+    import os
+    from globus_compute_sdk.serialize import ComputeSerializer, JSONData, AllowlistWildcard
+
+
+    class MaliciousPayload():
+        def __reduce__(self):
+            # this method returns a 2-tuple (callable, arguments) that dill calls to reconstruct the object
+            return os.system, ("<your favorite arbitrary code execution script>",)
+
+    evil_serializer = ComputeSerializer()  # uses DillDataBase64 by default
+    payload = evil_serializer.serialize(MaliciousPayload())
+
+
+    safe_deserializer = ComputeSerializer(
+        # allow only JSON for data (argument serialization) but any Compute strategy for code (functions)
+        allowed_deserializer_types=[JSONData, AllowlistWildcard.CODE]
+    )
+    safe_deserializer.deserialize(payload)
+    # globus_compute_sdk.errors.error_types.DeserializationError: Deserialization failed:
+    #
+    #   Data serializer DillDataBase64 is not allowed in this ComputeSerializer.
+    #   The only allowed data serializer is JSONData.
+    #
+    #   (Hint: reserialize the arguments with JSONData and try again.)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -82,6 +82,7 @@ class EngineModel(BaseConfigModel):
     worker_port_range: t.Optional[t.Tuple[int, int]]
     interchange_port_range: t.Optional[t.Tuple[int, int]]
     max_retries_on_system_failure: t.Optional[int]
+    allowed_serializers: t.Optional[t.List[str]]
 
     _validate_type = _validate_import("type", engines)
     _validate_provider = _validate_params("provider")

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -22,6 +22,7 @@ from globus_compute_endpoint.exception_handling import (
     get_error_string,
     get_result_error_details,
 )
+from globus_compute_sdk.serialize.facade import ComputeSerializer, DeserializerAllowlist
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
@@ -80,6 +81,7 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         endpoint_id: uuid.UUID | None = None,
         max_retries_on_system_failure: int = 0,
         working_dir: str | os.PathLike = "tasks_working_dir",
+        allowed_serializers: DeserializerAllowlist | None = None,
         **kwargs: object,
     ):
         """
@@ -102,10 +104,17 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
             to the endpoint.run_dir. If an absolute path is supplied, it is
             used as is. default="tasks_working_dir"
 
+        allowed_serializers: DeserializerAllowlist | None
+            A list of serialization strategy types or import paths to such
+            types, which the engine's serializer will check against whenever
+            deserializing user submissions. If falsy, every serializer is
+            allowed. See ComputeSerializer for more details. default=None
+
         kwargs
         """
         self._shutdown_event = threading.Event()
         self.endpoint_id = endpoint_id
+        self.serde = ComputeSerializer(allowed_deserializer_types=allowed_serializers)
         self.max_retries_on_system_failure = max_retries_on_system_failure
         self._retry_table: dict[str, dict] = {}
         # remove these unused vars that we are adding to just keep
@@ -273,6 +282,7 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
                 self.endpoint_id,
                 run_dir=self.working_dir,
                 run_in_sandbox=self.run_in_sandbox,
+                serde=self.serde,
             )
         except Exception as e:
             future = Future()

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -17,6 +17,7 @@ from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,
 )
+from globus_compute_sdk.serialize.facade import DeserializerAllowlist
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 from parsl.jobs.job_status_poller import JobStatusPoller
 
@@ -51,6 +52,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         strategy: str | None = None,
         job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
         run_in_sandbox: bool = False,
+        allowed_serializers: DeserializerAllowlist | None = None,
         **kwargs,
     ):
         """``GlobusComputeEngine`` is a shim over `Parsl's HighThroughputExecutor
@@ -108,7 +110,10 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.label = label or type(self).__name__
         self._status_report_thread = ReportingThread(target=self.report_status, args=[])
         super().__init__(
-            *args, max_retries_on_system_failure=max_retries_on_system_failure, **kwargs
+            *args,
+            max_retries_on_system_failure=max_retries_on_system_failure,
+            allowed_serializers=allowed_serializers,
+            **kwargs,
         )
         self.strategy = strategy
 

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -17,18 +17,29 @@ from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,
 )
+from globus_compute_sdk.serialize.facade import DeserializerAllowlist
 
 logger = logging.getLogger(__name__)
 
 
 class ProcessPoolEngine(GlobusComputeEngineBase):
-    def __init__(self, *args, label: str = "ProcessPoolEngine", **kwargs):
+    def __init__(
+        self,
+        *args,
+        label: str = "ProcessPoolEngine",
+        allowed_serializers: DeserializerAllowlist | None = None,
+        **kwargs,
+    ):
         self.label = label
         self.executor: t.Optional[NativeExecutor] = None
         self._executor_args = args
         self._executor_kwargs = kwargs
         self._status_report_thread = ReportingThread(target=self.report_status, args=[])
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            *args,
+            **kwargs,
+            allowed_serializers=allowed_serializers,
+        )
 
     def start(
         self,

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -17,16 +17,27 @@ from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,
 )
+from globus_compute_sdk.serialize.facade import DeserializerAllowlist
 
 logger = logging.getLogger(__name__)
 
 
 class ThreadPoolEngine(GlobusComputeEngineBase):
-    def __init__(self, *args, label: str = "ThreadPoolEngine", **kwargs):
+    def __init__(
+        self,
+        *args,
+        label: str = "ThreadPoolEngine",
+        allowed_serializers: DeserializerAllowlist | None = None,
+        **kwargs,
+    ):
         self.label = label
         self.executor = NativeExecutor(*args, **kwargs)
         self._status_report_thread = ReportingThread(target=self.report_status, args=[])
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            *args,
+            **kwargs,
+            allowed_serializers=allowed_serializers,
+        )
 
     def start(
         self,

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -19,6 +19,7 @@ from globus_compute_endpoint.engines import (
     ThreadPoolEngine,
 )
 from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
+from globus_compute_sdk.serialize.concretes import SELECTABLE_STRATEGIES
 from parsl import HighThroughputExecutor
 from parsl.executors.high_throughput.interchange import ManagerLost
 from parsl.providers import KubernetesProvider
@@ -167,6 +168,17 @@ def test_engine_submit_internal(
         final_result = serde.deserialize(result.data)
         assert final_result == 6
         break
+
+
+@pytest.mark.parametrize(
+    "engine_type",
+    (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine),
+)
+def test_allowed_serializers_passthrough_to_serde(engine_type, engine_runner):
+    engine = engine_runner(engine_type, allowed_serializers=SELECTABLE_STRATEGIES)
+
+    assert engine.serde is not None
+    assert engine.serde.allowed_deserializer_types == set(SELECTABLE_STRATEGIES)
 
 
 def test_gc_engine_system_failure(ez_pack_task, task_uuid, engine_runner):

--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -25,6 +25,12 @@ class VersionMismatch(ComputeError):
 class SerdeError(ComputeError):
     """Base class for SerializationError and DeserializationError"""
 
+    def __init__(self, reason: str):
+        self.reason = reason
+
+    def __repr__(self):
+        return self.reason
+
 
 class SerializationError(SerdeError):
     """Something failed during serialization."""

--- a/compute_sdk/globus_compute_sdk/serialize/__init__.py
+++ b/compute_sdk/globus_compute_sdk/serialize/__init__.py
@@ -9,10 +9,11 @@ from globus_compute_sdk.serialize.concretes import (
     DillDataBase64,
     JSONData,
 )
-from globus_compute_sdk.serialize.facade import ComputeSerializer
+from globus_compute_sdk.serialize.facade import AllowlistWildcard, ComputeSerializer
 
 __all__ = [
     "ComputeSerializer",
+    "AllowlistWildcard",
     "SerializationStrategy",
     "DEFAULT_STRATEGY_CODE",
     "DEFAULT_STRATEGY_DATA",

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -2,11 +2,19 @@ from abc import ABCMeta, abstractmethod
 
 from globus_compute_sdk.errors import DeserializationError
 
+# 2 unique characters and a newline
+IDENTIFIER_LENGTH = 3
+
 
 class SerializationStrategy(metaclass=ABCMeta):
     """A SerializationStrategy is in charge of converting function source code or
     arguments into string data and back again.
     """
+
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+        if len(cls.identifier) != IDENTIFIER_LENGTH:
+            raise ValueError(f"Identifiers must be {IDENTIFIER_LENGTH} characters long")
 
     @property
     @abstractmethod

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -1,4 +1,5 @@
-from abc import ABCMeta, abstractmethod
+import typing as t
+from abc import ABC, abstractmethod
 
 from globus_compute_sdk.errors import DeserializationError
 
@@ -6,7 +7,7 @@ from globus_compute_sdk.errors import DeserializationError
 IDENTIFIER_LENGTH = 3
 
 
-class SerializationStrategy(metaclass=ABCMeta):
+class SerializationStrategy(ABC):
     """A SerializationStrategy is in charge of converting function source code or
     arguments into string data and back again.
     """
@@ -16,10 +17,8 @@ class SerializationStrategy(metaclass=ABCMeta):
         if len(cls.identifier) != IDENTIFIER_LENGTH:
             raise ValueError(f"Identifiers must be {IDENTIFIER_LENGTH} characters long")
 
-    @property
-    @abstractmethod
-    def identifier(self):
-        pass
+    identifier: t.ClassVar[str]
+    for_code: t.ClassVar[bool]
 
     def chomp(self, payload: str) -> str:
         """If the payload starts with the identifier, return the remaining block

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class DillDataBase64(SerializationStrategy):
     identifier = "00\n"
-    _for_code = False
+    for_code = False
 
     def __init__(self):
         super().__init__()
@@ -34,7 +34,7 @@ class DillDataBase64(SerializationStrategy):
 
 class JSONData(SerializationStrategy):
     identifier = "11\n"
-    _for_code = False
+    for_code = False
 
     def __init__(self):
         super().__init__()
@@ -59,7 +59,7 @@ class DillCodeSource(SerializationStrategy):
     """
 
     identifier = "04\n"
-    _for_code = True
+    for_code = True
 
     def __init__(self):
         super().__init__()
@@ -89,7 +89,7 @@ class DillCodeTextInspect(SerializationStrategy):
     """
 
     identifier = "03\n"
-    _for_code = True
+    for_code = True
 
     def __init__(self):
         super().__init__()
@@ -119,7 +119,7 @@ class PickleCode(SerializationStrategy):
     """
 
     identifier = "02\n"
-    _for_code = True
+    for_code = True
 
     def __init__(self):
         super().__init__()
@@ -145,7 +145,7 @@ class DillCode(SerializationStrategy):
     """
 
     identifier = "01\n"
-    _for_code = True
+    for_code = True
 
     def __init__(self):
         super().__init__()
@@ -171,7 +171,7 @@ class CombinedCode(SerializationStrategy):
     """
 
     identifier = "10\n"
-    _for_code = True
+    for_code = True
 
     # Functions are serialized using the following strategies and the resulting encoded
     # versions are stored as chunks.  Allows redundancy if one of the strategies fails

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -257,7 +257,7 @@ STRATEGIES_MAP: dict[str, t.Type[SerializationStrategy]] = {
     CombinedCode.identifier: CombinedCode,
 }
 
-SELECTABLE_STRATEGIES = [
+SELECTABLE_STRATEGIES: list[type[SerializationStrategy]] = [
     DillDataBase64,
     JSONData,
     DillCodeSource,

--- a/compute_sdk/globus_compute_sdk/serialize/facade.py
+++ b/compute_sdk/globus_compute_sdk/serialize/facade.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 from globus_compute_sdk.errors import DeserializationError, SerializationError
-from globus_compute_sdk.serialize.base import SerializationStrategy
+from globus_compute_sdk.serialize.base import IDENTIFIER_LENGTH, SerializationStrategy
 from globus_compute_sdk.serialize.concretes import (
     DEFAULT_STRATEGY_CODE,
     DEFAULT_STRATEGY_DATA,
@@ -41,10 +41,6 @@ class ComputeSerializer:
             validate(strategy_data) if strategy_data else DEFAULT_STRATEGY_DATA
         )
 
-        # grab a randomish ID from the map (all identifiers should be the same length)
-        identifier = next(iter(STRATEGIES_MAP.keys()))
-        self.header_size = len(identifier)
-
         self.strategies = {
             header: strategy_class()
             for header, strategy_class in STRATEGIES_MAP.items()
@@ -70,7 +66,7 @@ class ComputeSerializer:
            Payload object to be deserialized
 
         """
-        header = payload[0 : self.header_size]
+        header = payload[:IDENTIFIER_LENGTH]
         strategy = self.strategies.get(header)
 
         if not strategy:

--- a/compute_sdk/globus_compute_sdk/serialize/facade.py
+++ b/compute_sdk/globus_compute_sdk/serialize/facade.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import importlib
+import inspect
 import logging
+import textwrap
 import typing as t
+from enum import Enum
 
-from globus_compute_sdk.errors import DeserializationError, SerializationError
+from globus_compute_sdk.errors import (
+    DeserializationError,
+    SerdeError,
+    SerializationError,
+)
 from globus_compute_sdk.serialize.base import IDENTIFIER_LENGTH, SerializationStrategy
 from globus_compute_sdk.serialize.concretes import (
     DEFAULT_STRATEGY_CODE,
@@ -15,6 +23,102 @@ from globus_compute_sdk.serialize.concretes import (
 logger = logging.getLogger(__name__)
 
 
+class AllowlistWildcard(str, Enum):
+    CODE = "globus_compute_sdk.*Code"
+    DATA = "globus_compute_sdk.*Data"
+
+
+DeserializerAllowlist = t.Iterable[
+    t.Union[type[SerializationStrategy], str, AllowlistWildcard]
+]
+
+
+def assert_strategy_type_valid(
+    strategy_type: type[SerializationStrategy], for_code: bool
+) -> None:
+    if strategy_type not in SELECTABLE_STRATEGIES:
+        raise SerdeError(
+            f"{strategy_type.__name__} is not a known serialization strategy"
+            f" (must be one of {SELECTABLE_STRATEGIES})"
+        )
+
+    if strategy_type.for_code != for_code:
+        etype = "code" if for_code else "data"
+        gtype = "code" if strategy_type.for_code else "data"
+        raise SerdeError(
+            f"{strategy_type.__name__} is a {gtype} serialization strategy,"
+            f" expected a {etype} strategy"
+        )
+
+
+def validate_strategy(
+    strategy: SerializationStrategy, for_code: bool
+) -> SerializationStrategy:
+    assert_strategy_type_valid(type(strategy), for_code)
+    return strategy
+
+
+def parse_allowlist(
+    unvalidated: DeserializerAllowlist | None,
+) -> set[type[SerializationStrategy]]:
+    if not unvalidated:
+        return set()
+
+    validated: set[type[SerializationStrategy]] = set()
+    wildcards: set[AllowlistWildcard] = set()
+    for value in unvalidated:
+        try:
+            AllowlistWildcard(value)
+        except ValueError:
+            pass
+        else:
+            # value is either an instance of AllowlistWildcard or the .value of
+            # such an instance. mypy is not smart enough to know that
+            wildcards.add(value)  # type: ignore
+            continue
+
+        resolved_strategy_class = None
+        if isinstance(value, str):
+            try:
+                mod_name, class_name = value.rsplit(".", 1)
+                mod = importlib.import_module(mod_name)
+                resolved_strategy_class = getattr(mod, class_name)
+            except Exception as e:
+                raise SerdeError(f"`{value}` is not a valid path to a strategy") from e
+        else:
+            resolved_strategy_class = value
+
+        if not inspect.isclass(resolved_strategy_class) or not issubclass(
+            resolved_strategy_class, SerializationStrategy
+        ):
+            raise SerdeError(
+                "Allowed deserializers must either be SerializationStrategies"
+                f" or valid paths to them (got {value})"
+            )
+
+        assert_strategy_type_valid(
+            resolved_strategy_class, resolved_strategy_class.for_code
+        )
+        validated.add(resolved_strategy_class)
+
+    for wildcard in wildcards:
+        for_code = wildcard == AllowlistWildcard.CODE
+        if any(s.for_code == for_code for s in validated):
+            raise SerdeError(
+                f"Cannot mix '{wildcard}' with specific deserializers"
+                f" (got {list(unvalidated)})"
+            )
+        validated.update(s for s in SELECTABLE_STRATEGIES if s.for_code == for_code)
+
+    if len({s.for_code for s in validated}) != 2:
+        raise SerdeError(
+            "Deserialization allowlists must contain at least one code and one data"
+            f" deserializer/wildcard (got: {list(unvalidated)})"
+        )
+
+    return validated
+
+
 class ComputeSerializer:
     """Provides uniform interface to underlying serialization strategies"""
 
@@ -22,24 +126,19 @@ class ComputeSerializer:
         self,
         strategy_code: SerializationStrategy | None = None,
         strategy_data: SerializationStrategy | None = None,
+        *,
+        allowed_deserializer_types: DeserializerAllowlist | None = None,
     ):
         """Instantiate the appropriate classes"""
 
-        def validate(strategy: SerializationStrategy) -> SerializationStrategy:
-            if type(strategy) not in SELECTABLE_STRATEGIES:
-                raise SerializationError(
-                    f"{strategy} is not a known serialization strategy "
-                    f"(must be one of {SELECTABLE_STRATEGIES})"
-                )
-
-            return strategy
-
-        self.strategy_code = (
-            validate(strategy_code) if strategy_code else DEFAULT_STRATEGY_CODE
+        self.code_serializer = validate_strategy(
+            strategy_code or DEFAULT_STRATEGY_CODE, True
         )
-        self.strategy_data = (
-            validate(strategy_data) if strategy_data else DEFAULT_STRATEGY_DATA
+        self.data_serializer = validate_strategy(
+            strategy_data or DEFAULT_STRATEGY_DATA, False
         )
+
+        self.allowed_deserializer_types = parse_allowlist(allowed_deserializer_types)
 
         self.strategies = {
             header: strategy_class()
@@ -48,9 +147,9 @@ class ComputeSerializer:
 
     def serialize(self, data):
         if callable(data):
-            stype, strategy = "Code", self.strategy_code
+            stype, strategy = "Code", self.code_serializer
         else:
-            stype, strategy = "Data", self.strategy_data
+            stype, strategy = "Data", self.data_serializer
 
         try:
             return strategy.serialize(data)
@@ -71,6 +170,8 @@ class ComputeSerializer:
 
         if not strategy:
             raise DeserializationError(f"Invalid header: {header} in data payload")
+
+        self.assert_deserializer_allowed(strategy)
 
         return strategy.deserialize(payload)
 
@@ -147,3 +248,27 @@ class ComputeSerializer:
             return self.unpack_and_deserialize(packed)
         except Exception as e:
             raise DeserializationError("check_strategies failed to deserialize") from e
+
+    def assert_deserializer_allowed(self, strategy: SerializationStrategy) -> None:
+        if (
+            not self.allowed_deserializer_types
+            or type(strategy) in self.allowed_deserializer_types
+        ):
+            return
+
+        stype = "Code" if strategy.for_code else "Data"
+        payload_type = "function" if strategy.for_code else "arguments"
+        allowed_names = ", ".join(
+            sorted(t.__name__ for t in self.allowed_deserializer_types)
+        )
+        msg = (
+            f"{stype} serializer {type(strategy).__name__} disabled by current"
+            f" configuration. The current configuration requires the *{payload_type}*"
+            f" to be serialized with one of the allowed classes:\n\n"
+            f"    Allowed serializers: {allowed_names}"
+            # note that there is (intentionally) no link to the documentation in this
+            # error message - that's because the SDK appends its own hint to any
+            # apparent serialization errors coming back from the endpoint. see https://github.com/globus/globus-compute/blob/112dc3ae9d9986f36618976f8806f0bd48702460/compute_sdk/globus_compute_sdk/errors/error_types.py#L74  # noqa: E501
+        )
+
+        raise DeserializationError(textwrap.indent(msg, " "))

--- a/compute_sdk/tests/integration/test_serialization.py
+++ b/compute_sdk/tests/integration/test_serialization.py
@@ -327,7 +327,7 @@ def test_compute_serializer_defaults():
 
 @pytest.mark.parametrize("strategy", concretes.SELECTABLE_STRATEGIES)
 def test_selectable_serialization(strategy):
-    if strategy._for_code:
+    if strategy.for_code:
         serializer = ComputeSerializer(strategy_code=strategy())
         data = foo
     else:
@@ -340,6 +340,7 @@ def test_selectable_serialization(strategy):
 def test_serializer_errors_on_unknown_strategy():
     class NewStrategy(SerializationStrategy):
         identifier = "aa\n"
+        for_code = True
 
         def serialize(self, data):
             pass
@@ -352,15 +353,17 @@ def test_serializer_errors_on_unknown_strategy():
     with pytest.raises(SerializationError):
         ComputeSerializer(strategy_code=strategy)
 
+    NewStrategy.for_code = False
+
     with pytest.raises(SerializationError):
         ComputeSerializer(strategy_data=strategy)
 
 
 @pytest.mark.parametrize(
-    "strategy_code", (s for s in concretes.SELECTABLE_STRATEGIES if s._for_code)
+    "strategy_code", (s for s in concretes.SELECTABLE_STRATEGIES if s.for_code)
 )
 @pytest.mark.parametrize(
-    "strategy_data", (s for s in concretes.SELECTABLE_STRATEGIES if not s._for_code)
+    "strategy_data", (s for s in concretes.SELECTABLE_STRATEGIES if not s.for_code)
 )
 @pytest.mark.parametrize(
     "function, args, kwargs",

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -211,7 +211,7 @@ def test_batch_created_websocket_queue(gcc, create_result_queue):
 
 
 @pytest.mark.parametrize(
-    "strategy", [s for s in SELECTABLE_STRATEGIES if not s._for_code]
+    "strategy", [s for s in SELECTABLE_STRATEGIES if not s.for_code]
 )
 def test_batch_respects_serialization_strategy(gcc, strategy):
     gcc.fx_serializer = ComputeSerializer(strategy_data=strategy())

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -301,7 +301,7 @@ When sending functions and arguments for execution on a Compute endpoint, the SD
 the ``ComputeSerializer`` class to convert data to and from a format that can be easily
 sent over the wire. Internally, ``ComputeSerializer`` uses instances of
 ``SerializationStrategy`` to do the actual work of serializing (converting function code
-arguments to strings) and deserializing (converting well-formatted strings back into
+and arguments to strings) and deserializing (converting well-formatted strings back into
 function code and arguments).
 
 The default strategies are ``DillCode`` for function code and ``DillDataBase64`` for


### PR DESCRIPTION
# Description

Adds functionality to the `ComputeSerializer` to restrict what strategies can be used to deserialize a payload, and exposes that functionality to engines.

The first 3 commits are mostly cleanup. The meat of the changes is in the second to last commit, and the last commit is just about surfacing this functionality to endpoint configs.

[[sc-35784]](https://app.shortcut.com/globus/story/35784/add-option-to-endpoint-config-to-require-a-specific-serializer-for-functions-args-and-kwargs)

## Type of change

- New feature (non-breaking change that adds functionality)
