### PR TITLE
Process EP heartbeats separately from results

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -276,9 +276,9 @@ class EndpointManager:
             cq_info = reg_info["command_queue_info"]
             _ = cq_info["connection_url"], cq_info["queue"]
 
-            rq_info = reg_info["result_queue_info"]
-            _ = rq_info["connection_url"], rq_info["queue"]
-            _ = rq_info["queue_publish_kwargs"]
+            hbq_info = reg_info["heartbeat_queue_info"]
+            _ = hbq_info["connection_url"], hbq_info["queue"]
+            _ = hbq_info["queue_publish_kwargs"]
         except Exception as e:
             log_reg_info = _redact_url_creds(str(reg_info))
             log.debug("%s", log_reg_info)
@@ -318,7 +318,7 @@ class EndpointManager:
             stop_event=self._command_stop_event,
             thread_name="CQS",
         )
-        self._heartbeat_publisher = ResultPublisher(queue_info=rq_info)
+        self._heartbeat_publisher = ResultPublisher(queue_info=hbq_info)
 
     @staticmethod
     def get_metadata(config: ManagerEndpointConfig, conf_dir: pathlib.Path) -> dict:

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_heartbeat_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_heartbeat_q.py
@@ -5,7 +5,10 @@ import pytest
 
 @pytest.mark.parametrize("use_heartbeat", [None, 1])
 def test_no_heartbeat(
-    start_result_q_publisher, rabbitmq_conn_url, create_result_queue_info, use_heartbeat
+    start_heartbeat_q_publisher,
+    rabbitmq_conn_url,
+    create_result_queue_info,
+    use_heartbeat,
 ):
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
@@ -20,19 +23,19 @@ def test_no_heartbeat(
 
     q_info = create_result_queue_info(connection_url=conn_url)
 
-    result_pub = start_result_q_publisher(override_params=q_info)
+    hb_pub = start_heartbeat_q_publisher(override_params=q_info)
 
     # simply ensure no crash between two message sends
-    f = result_pub.publish(b"Hello test_no_heartbeat: 1")
+    f = hb_pub.publish(b"Hello test_no_heartbeat: 1")
     f.result(timeout=5)
-    f = result_pub.publish(b"Hello test_no_heartbeat: 2")
+    f = hb_pub.publish(b"Hello test_no_heartbeat: 2")
     f.result(timeout=5)
 
 
-def test_reconnect_after_disconnect(start_result_q_publisher):
-    rp = start_result_q_publisher()
-    f = rp.publish(b"Hello test_reconnect_after_disconnect: before")
+def test_reconnect_after_disconnect(start_heartbeat_q_publisher):
+    hb_pub = start_heartbeat_q_publisher()
+    f = hb_pub.publish(b"Hello test_reconnect_after_disconnect: before")
     f.result(timeout=5)
-    rp._mq_chan.close()
-    f = rp.publish(b"Hello test_reconnect_after_disconnect: afterward")
+    hb_pub._mq_chan.close()
+    f = hb_pub.publish(b"Hello test_reconnect_after_disconnect: afterward")
     f.result(timeout=5)

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -70,6 +70,12 @@ def register_endpoint_response(endpoint_uuid):
                 "args": queue_kwargs,
                 "routing_key": f"{endpoint_uuid}.results",
             },
+            "heartbeat_queue_info": {
+                "exchange_name": "heartbeats",
+                "connection_url": f"amqp://{creds}{rmq_fqdn}",
+                "args": queue_kwargs,
+                "routing_key": f"{endpoint_uuid}.heartbeats",
+            },
         }
 
         responses.add(
@@ -157,6 +163,7 @@ def mock_reg_info():
         "endpoint_id": str(uuid.uuid4()),
         "task_queue_info": {"connection_url": "amqp://some.domain:1234"},
         "result_queue_info": {"connection_url": "amqp://some.domain"},
+        "heartbeat_queue_info": {"connection_url": "amqp://some.domain"},
     }
 
 
@@ -591,11 +598,13 @@ def test_endpoint_respects_port(mocker, fs, mock_ep_data, port):
 
     tq_url = "amqp://some.domain:1234"
     rq_url = "amqp://some.domain"
+    hbq_url = "amqp://some.domain"
 
     mock_reg_info = {
         "endpoint_id": ep_id,
         "task_queue_info": {"connection_url": tq_url},
         "result_queue_info": {"connection_url": rq_url},
+        "heartbeat_queue_info": {"connection_url": hbq_url},
     }
 
     mock_update_url_port = mocker.patch(f"{_mock_base}update_url_port")

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -41,7 +41,11 @@ def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals)
     mocker.patch(f"{_mock_base}multiprocessing")
     ei = EndpointInterchange(
         config=UserEndpointConfig(executors=[mocker.Mock()]),
-        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        reg_info={
+            "task_queue_info": {},
+            "result_queue_info": {},
+            "heartbeat_queue_info": {},
+        },
         reconnect_attempt_limit=num_iterations + 10,
     )
     ei._main_loop = mock.Mock()
@@ -74,7 +78,11 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     mock_log = mocker.patch(f"{_mock_base}log")
     ei = EndpointInterchange(
         config=UserEndpointConfig(executors=[mocker.Mock()]),
-        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        reg_info={
+            "task_queue_info": {},
+            "result_queue_info": {},
+            "heartbeat_queue_info": {},
+        },
         reconnect_attempt_limit=reconnect_attempt_limit,
     )
     ei._main_loop = mock.Mock(spec=ei._main_loop)
@@ -95,7 +103,11 @@ def test_reset_reconnect_attempt_limit_when_stable(mocker, fs, mock_tqs, mock_pa
     ei = EndpointInterchange(
         config=UserEndpointConfig(executors=[mocker.Mock()]),
         endpoint_id=str(uuid.uuid4()),
-        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        reg_info={
+            "task_queue_info": {},
+            "result_queue_info": {},
+            "heartbeat_queue_info": {},
+        },
     )
     ei._quiesce_event = mock.Mock(spec=EventType)
 
@@ -131,7 +143,11 @@ def test_rundir_passed_to_gcengine(mocker, fs):
     ei = EndpointInterchange(
         config=UserEndpointConfig(executors=[mock_gcengine]),
         endpoint_id=str(uuid.uuid4()),
-        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        reg_info={
+            "task_queue_info": {},
+            "result_queue_info": {},
+            "heartbeat_queue_info": {},
+        },
     )
     ei._quiesce_event = mock.Mock(spec=EventType)
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -153,6 +153,11 @@ def mock_reg_info(ep_uuid) -> str:
             "queue": "",
             "queue_publish_kwargs": {},
         },
+        "heartbeat_queue_info": {
+            "connection_url": "",
+            "queue": "",
+            "queue_publish_kwargs": {},
+        },
     }
 
 
@@ -605,20 +610,20 @@ def test_mismatched_id_gracefully_exits(
     (
         (False, {"command_queue_info": {"connection_url": ""}}),
         (False, {"command_queue_info": {"queue": ""}}),
-        (False, {"result_queue_info": {"connection_url": ""}}),
-        (False, {"result_queue_info": {"queue": ""}}),
+        (False, {"heartbeat_queue_info": {"connection_url": ""}}),
+        (False, {"heartbeat_queue_info": {"queue": ""}}),
         (
             False,
             {
                 "typo-ed_cqi": {"connection_url": "", "queue": ""},
-                "result_queue_info": {"connection_url": "", "queue": ""},
+                "heartbeat_queue_info": {"connection_url": "", "queue": ""},
             },
         ),
         (
             True,
             {
                 "command_queue_info": {"connection_url": "", "queue": ""},
-                "result_queue_info": {
+                "heartbeat_queue_info": {
                     "connection_url": "",
                     "queue": "",
                     "queue_publish_kwargs": {},

--- a/compute_endpoint/tests/unit/test_utils.py
+++ b/compute_endpoint/tests/unit/test_utils.py
@@ -131,6 +131,13 @@ def test_cmd_send_failure_publishes_message(mock_mq_chan, randomstring, err_msg)
                 "routing_key": mock_routing_key,
             },
         },
+        "heartbeat_queue_info": {
+            "connection_url": "abc",
+            "queue_publish_kwargs": {
+                "exchange": mock_exchange_name,
+                "routing_key": mock_routing_key,
+            },
+        },
     }
     send_endpoint_startup_failure_to_amqp(amqp_creds, msg=err_msg)
 


### PR DESCRIPTION
# Description

To ensure endpoint heartbeats are always processed in a timely manner, a dedicated multiprocessing queue and RabbitMQ channel, exchange and queue are now used.

[sc-37952]

## Type of change

- New feature (non-breaking change that adds functionality)
