### PR TITLE
Check before test ioloop close

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -151,6 +151,7 @@ class TaskQueueSubscriber(threading.Thread):
             finally:
                 if self._connection and self._connection.ioloop:
                     self._connection.ioloop.close()
+                self._connection = None
 
         self._stop_event.set()
         logger.debug("%s Shutdown complete", self)
@@ -346,7 +347,6 @@ class TaskQueueSubscriber(threading.Thread):
                     self._connection.close()
             elif self._connection.is_closed:
                 self._connection.ioloop.stop()
-                self._connection = None
 
     def _event_watcher(self):
         """Polls the stop_event periodically to trigger a shutdown"""

--- a/compute_endpoint/tests/integration/test_rabbit_mq/task_queue_publisher.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/task_queue_publisher.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import logging
-
 import pika
 import pika.channel
 from globus_compute_endpoint.endpoint.rabbit_mq.base import RabbitPublisherStatus
-
-logger = logging.getLogger(__name__)
 
 
 class TaskQueuePublisher:
@@ -37,7 +33,6 @@ class TaskQueuePublisher:
         self.status = RabbitPublisherStatus.closed
 
     def connect(self):
-        logger.debug("Connecting as server")
         params = pika.URLParameters(self.queue_info["connection_url"])
         self._connection = pika.BlockingConnection(params)
         self._channel = self._connection.channel()
@@ -62,5 +57,8 @@ class TaskQueuePublisher:
 
     def close(self):
         """Close the connection and channels"""
-        self._connection.close()
+        if self._connection and self._connection.is_open:
+            self._connection.close()
+        self._channel = None
+        self._connection = None
         self.status = RabbitPublisherStatus.closed

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
@@ -4,9 +4,9 @@ import queue
 def test_simple_roundtrip(
     flush_results,
     start_task_q_publisher,
+    start_result_q_publisher,
     start_task_q_subscriber,
     start_result_q_subscriber,
-    start_result_q_publisher,
     randomstring,
 ):
     task_q, result_q = queue.SimpleQueue(), queue.SimpleQueue()
@@ -15,8 +15,8 @@ def test_simple_roundtrip(
     task_pub = start_task_q_publisher()
     result_pub = start_result_q_publisher()
 
-    task_sub = start_task_q_subscriber(task_queue=task_q)
-    result_sub = start_result_q_subscriber(result_q=result_q)
+    start_task_q_subscriber(task_queue=task_q)
+    start_result_q_subscriber(result_q=result_q)
 
     message = f"Hello test_simple_roundtrip: {randomstring()}".encode()
     task_pub.publish(message)
@@ -25,9 +25,6 @@ def test_simple_roundtrip(
 
     result_pub.publish(task_message)
     _, result_message = result_q.get(timeout=2)
-
-    task_sub._stop_event.set()
-    result_sub.kill_event.set()
 
     _, expected = (result_pub.queue_info["test_routing_key"], message)
     assert result_message == expected

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
@@ -165,7 +165,7 @@ def test_connection_closed_shuts_down(start_task_q_subscriber):
     try_assert(lambda: tqs._connection, "Ensure we establish a connection")
 
     assert not tqs._stop_event.is_set()
-    tqs._on_connection_closed(tqs._connection, MemoryError())
+    tqs._connection.close()
     try_assert(lambda: tqs._stop_event.is_set())
 
     tqs.join(timeout=3)


### PR DESCRIPTION
- remove an unwarranted test `reconnect()` (makes flow much simpler to verify)
- don't forget to remove reference to connection so it can be GC'd
- remove redundant shutdown requests, given fixtures
- fix test to let ioloop know that connection is closing, allows for a cleaner shutdown in the ioloop internals.

## Type of change

- Code maintenance/cleanup
