### PR TITLE
Convert test class to threading

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/result_publisher.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/result_publisher.py
@@ -153,6 +153,7 @@ class ResultPublisher(threading.Thread):
             finally:
                 if self._mq_conn and self._mq_conn.ioloop:
                     self._mq_conn.ioloop.close()
+                self._mq_conn = None
 
         self._stop_event.set()
 
@@ -378,7 +379,6 @@ class ResultPublisher(threading.Thread):
                     self._mq_conn.close()
             elif self._mq_conn.is_closed:
                 self._mq_conn.ioloop.stop()
-                self._mq_conn = None
 
     def publish(self, message: bytes) -> Future[None]:
         """

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import queue
 
 
@@ -10,14 +9,14 @@ def test_simple_roundtrip(
     start_result_q_publisher,
     randomstring,
 ):
-    task_q, result_q = queue.SimpleQueue(), multiprocessing.Queue()
+    task_q, result_q = queue.SimpleQueue(), queue.SimpleQueue()
 
     # Start the publishers *first* as that route creates the queues
     task_pub = start_task_q_publisher()
     result_pub = start_result_q_publisher()
 
     task_sub = start_task_q_subscriber(task_queue=task_q)
-    result_sub = start_result_q_subscriber(queue=result_q)
+    result_sub = start_result_q_subscriber(result_q=result_q)
 
     message = f"Hello test_simple_roundtrip: {randomstring()}".encode()
     task_pub.publish(message)

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_result_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_result_q.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import multiprocessing
+import queue
 import uuid
 
 import pika
@@ -38,7 +38,7 @@ def test_result_queue_basic(start_result_q_publisher):
 def test_message_integrity_across_sizes(
     size, start_result_q_publisher, start_result_q_subscriber, default_endpoint_id
 ):
-    """Publish count messages from endpoint_1
+    """Publish messages from endpoint_1 of different sizes;
     Confirm that the subscriber gets all of them.
     """
     result_pub = start_result_q_publisher()
@@ -47,8 +47,8 @@ def test_message_integrity_across_sizes(
     b_message = json.dumps(message).encode()
     result_pub.publish(b_message)
 
-    results_q = multiprocessing.Queue()
-    start_result_q_subscriber(queue=results_q)
+    results_q = queue.SimpleQueue()
+    start_result_q_subscriber(result_q=results_q)
 
     result_message = results_q.get(timeout=2)
     assert result_message == (result_pub.queue_info["test_routing_key"], b_message)
@@ -72,8 +72,8 @@ def test_publish_multiple_then_subscribe(
     publish_messages(result_pub1, count=10)
     publish_messages(result_pub2, count=10)
 
-    results_q = multiprocessing.Queue()
-    start_result_q_subscriber(queue=results_q)
+    results_q = queue.SimpleQueue()
+    start_result_q_subscriber(result_q=results_q)
 
     all_results = {}
     for _i in range(total_messages):


### PR DESCRIPTION
There's no need to create an external process to run the AMQP test class; in fact, doing so has hidden a couple of subtle pika interaction bugs. Consequently, though the motivating change in this commit is:

    - multiprocessing
    + threading/queue.SimpleQueue

there are also some fixes in `test/.../result_queue_subscriber` around the proper shutdown procedure of the `pika.SelectConnection`: don't stop the loop prematurely, and close all resources.

## Type of change

- Code maintenance/cleanup