### PR TITLE
Remove unnecessary c&p fixture

### DIFF
--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_result_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_result_q.py
@@ -125,9 +125,7 @@ def test_broken_connection(
         rp.stop()
 
 
-def test_disconnect_from_client_side(
-    start_result_q_publisher, start_result_q_subscriber
-):
+def test_disconnect_from_client_side(start_result_q_publisher):
     """Confirm that an exception is raised when the connection is closed
     Ideally we use rabbitmqadmin to close the connection, but that is less reliable here
     since the test env may not be have the util, and


### PR DESCRIPTION
Another unnecessary resource consumed.  Tangentially found a missed `SimpleQueue` refactor item from yesterday, and realize during log trawling that we only care about the log if we're stopping unexpectedly.

## Type of change

- Code maintenance/cleanup