### PR TITLE
Ensure that each test closes all file descriptors

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -1005,7 +1005,9 @@ def disable_on_boot_cmd(ep_dir: pathlib.Path):
 def cli_run():
     """Entry point for setuptools to point to"""
     app()
+    setup_logging()  # reset
 
 
 if __name__ == "__main__":
     app()
+    setup_logging()  # reset

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -30,6 +30,7 @@ from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.engines import ThreadPoolEngine
+from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.auth.globus_app import UserApp
 from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
@@ -138,6 +139,7 @@ def run_line(cli_runner):
         if stdin is None:
             stdin = "{}"  # silence some logs; incurred by invoke's sys.stdin choice
         result = cli_runner.invoke(app, args, input=stdin)
+        setup_logging()
         if assert_exit_code is not None:
             assert result.exit_code == assert_exit_code, (result.stdout, result.stderr)
         return result
@@ -202,6 +204,7 @@ def test_get_globus_app_with_scopes(mocker: MockFixture):
     for scope_list in app.scope_requirements.values():
         for scope in scope_list:
             scopes.append(str(scope))
+    app.config.token_storage.close()  # is a SQLiteStorage object
 
     assert len(scopes) > 0
     assert all(str(s) in scopes for s in WebClient.default_scope_requirements)

--- a/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
@@ -13,7 +13,8 @@ DEFAULT_CLIENT_ID = "4cf29807-cf21-49ec-9443-ff9a3fb9f81c"
 def get_globus_app(environment: str | None = None) -> GlobusApp:
     app_name = platform.node()
     client_id, client_secret = get_client_creds()
-    config = GlobusAppConfig(token_storage=get_token_storage(environment=environment))
+    token_storage = get_token_storage(environment=environment)
+    config = GlobusAppConfig(token_storage=token_storage)
 
     if client_id and client_secret:
         return ClientApp(
@@ -24,6 +25,7 @@ def get_globus_app(environment: str | None = None) -> GlobusApp:
         )
 
     elif client_secret:
+        token_storage.close()
         raise ValueError(
             "Both GLOBUS_COMPUTE_CLIENT_ID and GLOBUS_COMPUTE_CLIENT_SECRET must "
             "be set to use a client identity. Either set both environment "


### PR DESCRIPTION
The big add here is the autouse fixture to verify that the before and after file descriptors are in sync after each test has finished.  The other hunks are all in service of ensuring the new fixture does not assert.

## Type of change

- Code maintenance/cleanup