### PR TITLE
Replace `WebClient` with `globus-sdk` clients

### DIFF
--- a/changelog.d/20241209_081322_30907815+rjmello_globus_sdk_compute_client_sc_36127.rst
+++ b/changelog.d/20241209_081322_30907815+rjmello_globus_sdk_compute_client_sc_36127.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bump ``globus-sdk`` dependency version to at least ``3.50.0``.

--- a/changelog.d/20241209_143843_30907815+rjmello_globus_sdk_compute_client_sc_36127.rst
+++ b/changelog.d/20241209_143843_30907815+rjmello_globus_sdk_compute_client_sc_36127.rst
@@ -1,0 +1,7 @@
+Deprecated
+^^^^^^^^^^
+
+- The ``WebClient`` class and ``Client.web_client`` attribute have been deprecated.
+  Please use the ``ComputeClient``, ``ComputeClientV2``, and ``ComputeClientV3``
+  classes from the `Globus Python SDK <https://globus-sdk-python.readthedocs.io/en/stable/services/compute.html>`_
+  to interact directly with the Globus Compute API.

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -18,7 +18,7 @@ from globus_compute_endpoint.cli import (
 )
 from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import UserEndpointConfig
-from globus_compute_sdk.sdk.web_client import WebClient
+from globus_compute_sdk.sdk.client import _ComputeWebClient
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint."
 _SVC_ADDY = "http://api.funcx.fqdn"  # something clearly not correct
@@ -38,7 +38,7 @@ def patch_compute_client(mocker):
         login_manager=mock.Mock(),
     )
     gcc.web_service_address = _SVC_ADDY
-    gcc.web_client = WebClient(base_url=_SVC_ADDY)
+    gcc._compute_web_client = _ComputeWebClient(base_url=_SVC_ADDY)
 
     yield mocker.patch(f"{_MOCK_BASE}Client", return_value=gcc)
 

--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -24,6 +24,7 @@ from globus_compute_sdk.sdk._environments import (
     get_amqp_service_host,
     get_web_service_url,
 )
+from globus_compute_sdk.sdk.client import _ComputeWebClient
 from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
 from globus_compute_sdk.sdk.executor import _RESULT_WATCHERS
 from globus_compute_sdk.sdk.hardware_report import hardware_commands_list
@@ -31,7 +32,6 @@ from globus_compute_sdk.sdk.utils import display_name
 from globus_compute_sdk.sdk.utils.sample_function import (
     sdk_tutorial_sample_simple_function,
 )
-from globus_compute_sdk.sdk.web_client import WebClient
 from globus_compute_sdk.serialize.concretes import DillCodeTextInspect
 from rich import get_console
 from rich.console import Console
@@ -122,7 +122,9 @@ def print_service_versions(base_url: str):
     @display_name(f"get_service_versions({base_url})")
     def kernel():
         # Just adds a newline to the version info for better formatting
-        version_info = WebClient(base_url=base_url).get_version(service="all")
+        version_info = _ComputeWebClient(base_url=base_url).v2.get_version(
+            service="all"
+        )
         print(f"{version_info}\n")
 
     return kernel

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -684,7 +684,7 @@ class Executor(concurrent.futures.Executor):
         assert task_group_id is not None  # mypy: we _just_ proved this
 
         # step 1: from server, acquire list of related task ids and make futures
-        r = self.client.web_client.get_taskgroup_tasks(task_group_id)
+        r = self.client._compute_web_client.v2.get_task_group(task_group_id)
         if r["taskgroup_id"] != str(task_group_id):
             msg = (
                 "Server did not respond with requested TaskGroup Tasks.  "
@@ -720,7 +720,7 @@ class Executor(concurrent.futures.Executor):
                         len(id_chunk),
                     )
 
-                res = self.client.web_client.get_batch_status(id_chunk)
+                res = self.client._compute_web_client.v2.get_task_batch(id_chunk)
                 for task_id, task in res.data.get("results", {}).items():
                     if task_id in open_futures:
                         continue

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -17,7 +17,6 @@ from globus_compute_sdk.sdk._environments import get_web_service_url, remove_url
 from globus_compute_sdk.sdk.utils.uuid_like import UUID_LIKE_T
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.version import __version__
-from globus_sdk import GlobusAPIError, GlobusApp, Scope
 
 from .auth.scopes import ComputeScopes
 
@@ -104,20 +103,27 @@ class WebClient(globus_sdk.BaseClient):
     # it does not have any other effects
     service_name: str = "funcx"
     # use the Globus Compute-specific error class
-    error_class = GlobusAPIError
+    error_class = globus_sdk.GlobusAPIError
 
     scopes = ComputeScopes
-    default_scope_requirements = [Scope(ComputeScopes.all)]
+    default_scope_requirements = [globus_sdk.Scope(ComputeScopes.all)]
 
     def __init__(
         self,
         *,
         environment: t.Optional[str] = None,
         base_url: t.Optional[str] = None,
-        app: t.Optional[GlobusApp] = None,
+        app: t.Optional[globus_sdk.GlobusApp] = None,
         app_name: t.Optional[str] = None,
         **kwargs,
     ):
+        warnings.warn(
+            "The 'WebClient' class is deprecated."
+            " Please use globus_sdk.ComputeClient instead.",
+            category=DeprecationWarning,
+            stacklevel=10,
+        )
+
         if base_url is None:
             base_url = get_web_service_url(environment)
         base_url = remove_url_path(base_url)

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.47.0,<4",
+    "globus-sdk>=3.50.0,<4",
     "globus-compute-common==0.5.0",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear

--- a/compute_sdk/tests/integration/test_executor_int.py
+++ b/compute_sdk/tests/integration/test_executor_int.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 from globus_compute_sdk import Client
+from globus_compute_sdk.sdk.client import _ComputeWebClient
 from globus_compute_sdk.sdk.executor import Executor, _ResultWatcher
 from tests.utils import try_assert
 
@@ -17,7 +18,7 @@ def test_resultwatcher_graceful_shutdown():
     service_url = os.environ["COMPUTE_INTEGRATION_TEST_WEB_URL"]
     gcc = Client()
     gcc.web_service_address = service_url
-    gcc.web_client = gcc.login_manager.get_web_client(service_url)
+    gcc._compute_web_client = _ComputeWebClient(service_url, app=gcc.app)
     gce = Executor(client=gcc)
     rw = _ResultWatcher(gce)
     rw._start_consuming = mock.Mock()

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -768,3 +768,11 @@ def test_client_logout_with_login_manager():
     client = gc.Client(do_version_check=False, login_manager=mock_lm)
     client.logout()
     assert mock_lm.logout.called
+
+
+def test_web_client_deprecated():
+    gcc = gc.Client(do_version_check=False)
+    with pytest.warns(DeprecationWarning) as record:
+        assert gcc.web_client, "Client.web_client needed for backward compatibility"
+    msg = "'Client.web_client' attribute is deprecated"
+    assert any(msg in str(r.message) for r in record)

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -33,6 +33,13 @@ def client():
     return WebClient(base_url=_BASE_URL, transport_params={"max_retries": 0})
 
 
+def test_web_client_deprecated():
+    with pytest.warns(DeprecationWarning) as record:
+        WebClient(base_url="blah")
+    msg = "'WebClient' class is deprecated"
+    assert any(msg in str(r.message) for r in record)
+
+
 def test_web_client_can_set_explicit_base_url():
     c1 = WebClient(base_url="https://foo.example.com/")
     c2 = WebClient(base_url="https://bar.example.com/")

--- a/smoke_tests/tests/test_version.py
+++ b/smoke_tests/tests/test_version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 def test_web_service(compute_client, endpoint, compute_test_config):
     """This test checks 1) web-service is online, 2) version of the web-service"""
-    response = compute_client.web_client.get_version()
+    response = compute_client._compute_web_client.v2.get_version(service="all")
 
     assert response.http_status == 200, (
         "Request to version expected status_code=200, "


### PR DESCRIPTION
# Description

- Created the `_ComputeWebClient` class, which integrates `ComputeClientV2` and `ComputeClientV3` from the `globus-sdk` using composition. This work is part of our effort to more closely align with the `globus-sdk`.
- Marked the `WebClient` class and `Client.web_client` attribute as deprecated and replaced their usage with the `_ComputeWebClient` class and `Client._compute_web_client` attribute, respectively.


[sc-36127]

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup
