### PR TITLE
Bumping Parsl version req from 2025.1.6 to 2025.1.20

### DIFF
--- a/changelog.d/20250122_104738_yadudoc1729_update_parsl_version_req.rst
+++ b/changelog.d/20250122_104738_yadudoc1729_update_parsl_version_req.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version to `2025.1.20 <https://pypi.org/project/parsl/2025.1.20/>`_.
+  This version bump avoids dependency version mismatch when using Parsl's newly added optional extra
+  `GlobusComputeExecutor <https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.GlobusComputeExecutor.html>`_

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2025.1.6",
+    "parsl>=2025.1.6,<=2025.1.20",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
# Description

There's a version dependency conflict currently between parsl and globus-compute-endpoint, this version bump fixes that.

For a user trying to use Parsl with the new optional extra that allows task submission of Globus Compute, we currently have a version dependency bug: the latest `globus-compute-endpoint==2.24.0` pins parsl to `2025.1.6` while `parsl
>=2025.1.20` is required to use the new functionality.

Reported by @christopherwharrop-noaa

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
