### PR TITLE
Add serialization stretegy restriction to readthedocs

### DIFF
--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -359,6 +359,26 @@ Here's an example configuration:
            max_idletime: 60.0      # Default = 120s
            strategy_period: 120.0  # Default = 5s
 
+Restricting Serialization Strategies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Compute Endpoints can be configured to only deserialize and execute submissions that
+  were serialized with specific serialization strategies. For example, with the
+  following config:
+
+  .. code-block:: yaml
+
+    engine:
+        allowed_serializers:
+            - globus_compute_sdk.serialize.DillCodeSource
+            - globus_compute_sdk.serialize.DillCodeTextInspect
+            - globus_compute_sdk.serialize.JSONData
+        type: ThreadPoolEngine
+
+  any submissions that used the default serialization strategies (``DillCode``,
+  ``DillDataBase64``) would be rejected, and users would be informed to use one of the
+  allowed strategies.
+
 
 Ensuring Execution Environment
 ------------------------------


### PR DESCRIPTION
During the release meeting today, Brigitte thought that the serialization strategy restriction configurability should be part of public release notes, and asked whether the details were in the documentation that could be linked to from the notes, not just in the changelog.

I remembered the examples Chris added in PR #1760 and said yes, we do have readthedocs we can link to, mistakenly (when they were only more a more extensive than usual changelog fragment).

Looking back at the changelog, it seems like they should be in the regular docs as well, so this is just copying it into SDK and Endpoint pages with very minor header text change.

So this is just correcting my mistake post-mortem as it was my memory lapse.