### PR TITLE
Remove spurious warning

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -196,7 +196,8 @@ class TaskQueueSubscriber(threading.Thread):
         if self._connection_tries == 1:
             # if 1, then we've not been stable for more than 60s (see _event_watcher)
             logger.info(msg_fmt, self, exc)
-            logger.warning(f"{self!r} Unable to sustain connection; retrying ...")
+            if not self._stop_event.is_set():
+                logger.warning(f"{self!r} Unable to sustain connection; retrying ...")
 
         self._consumer_tag = None
         mq_conn.ioloop.stop()


### PR DESCRIPTION
For short runs of the endpoint, perhaps while developing or with a very short idle timeout, the internal `_connection_tries` may not have been reset.  In those cases, only emit the warning if shutting down was not intentional.  (This was already done for the `ResultPublisher` as part of the recent cleaning up of resources drive.)

## Type of change

- Code maintenance/cleanup