### PR TITLE
Deprecate `Client.auth_client` attribute

### DIFF
--- a/changelog.d/20250127_162749_30907815+rjmello.rst
+++ b/changelog.d/20250127_162749_30907815+rjmello.rst
@@ -1,0 +1,4 @@
+Deprecated
+^^^^^^^^^^
+
+- The ``Client.auth_client`` attribute is now deprecated.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -49,6 +49,7 @@ from globus_compute_endpoint.endpoint.utils import (
     send_endpoint_startup_failure_to_amqp,
     update_url_port,
 )
+from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_sdk import GlobusAPIError, NetworkError
 
 if t.TYPE_CHECKING:
@@ -522,8 +523,9 @@ class EndpointManager:
             log.debug("Ascertaining user identity set (%s)", client_options)
 
             gcc = GC.Client(**client_options)
+            ac = ComputeAuthClient(app=gcc.app)
             try:
-                userinfo = gcc.auth_client.userinfo()
+                userinfo = ac.userinfo()
                 ids = userinfo["identity_set"]
                 parent_identities.update(ident["sub"] for ident in ids)
                 log.debug(

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -121,7 +121,7 @@ class WebClient(globus_sdk.BaseClient):
             "The 'WebClient' class is deprecated."
             " Please use globus_sdk.ComputeClient instead.",
             category=DeprecationWarning,
-            stacklevel=10,
+            stacklevel=2,
         )
 
         if base_url is None:

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -748,7 +748,6 @@ def test_client_handles_login_manager():
     mock_lm = mock.Mock(spec=LoginManager)
     client = gc.Client(do_version_check=False, login_manager=mock_lm)
     assert client.login_manager is mock_lm
-    assert mock_lm.get_auth_client.call_count == 1
     assert mock_lm.get_web_client.call_count == 1
     assert mock_lm.get_web_client.call_args[1]["base_url"] == client.web_service_address
 
@@ -775,4 +774,12 @@ def test_web_client_deprecated():
     with pytest.warns(DeprecationWarning) as record:
         assert gcc.web_client, "Client.web_client needed for backward compatibility"
     msg = "'Client.web_client' attribute is deprecated"
+    assert any(msg in str(r.message) for r in record)
+
+
+def test_auth_client_deprecated():
+    gcc = gc.Client(do_version_check=False)
+    with pytest.warns(DeprecationWarning) as record:
+        assert gcc.auth_client, "Client.auth_client needed for backward compatibility"
+    msg = "'Client.auth_client' attribute is deprecated"
     assert any(msg in str(r.message) for r in record)


### PR DESCRIPTION
# Description

This attribute is only used by the `EndpointManager`, which will instead instantiate its own `AuthClient`.

## Type of change

- Code maintenance/cleanup
