### PR TITLE
Find all matched identities, not just first

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -652,7 +652,14 @@ class EndpointManager:
 
             else:
                 try:
-                    local_username = self.identity_mapper.map_identity(identity_set)
+                    idmaps = self.identity_mapper.map_identities(identity_set)
+                    for mapped in idmaps:
+                        if mapped:
+                            first_found: dict = mapped[0]
+                            ident, usernames = next(iter(first_found.items()))
+                            local_username = usernames[0]
+                            break
+
                     if not local_username:
                         raise LookupError()
                 except LookupError as e:

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -319,7 +319,9 @@ def successful_exec_from_mocked_root(
     queue_item = (1, mock_props, json.dumps(command_payload).encode())
 
     em.identity_mapper = mock.Mock()
-    em.identity_mapper.map_identity.return_value = "typicalglobusname@somehost.org"
+    em.identity_mapper.map_identities.return_value = [
+        [{"ident": ["typicalglobusname@somehost.org"]}]
+    ]
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
     em._command_queue.get.side_effect = [queue_item, queue.Empty()]
@@ -1443,7 +1445,7 @@ def test_gracefully_handles_identity_mapping_error(
     exc_text = "Test engineered: " + randomstring()
     queue_item = (1, mock_props, json.dumps(pld).encode())
 
-    em.identity_mapper.map_identity.side_effect = MemoryError(exc_text)
+    em.identity_mapper.map_identities.side_effect = MemoryError(exc_text)
     em.send_failure_notice = mock.Mock(spec=em.send_failure_notice)
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
@@ -1476,7 +1478,7 @@ def test_handles_unknown_or_invalid_command_gracefully(
 
     mocker.patch(f"{_MOCK_BASE}pwd")
     em.identity_mapper = mock.Mock()
-    em.identity_mapper.map_identity.return_value = "a"
+    em.identity_mapper.map_identities.return_value = [[{"someuuid": ["a"]}]]
 
     pld = {
         "globus_username": randomstring(),
@@ -1518,7 +1520,7 @@ def test_handles_local_user_not_found_gracefully(
 
     invalid_user_name = "username_that_is_not_on_localhost6_" + randomstring()
     em.identity_mapper = mock.Mock()
-    em.identity_mapper.map_identity.return_value = invalid_user_name
+    em.identity_mapper.map_identities.return_value = [[{"uuid": [invalid_user_name]}]]
     mock_pwd.getpwnam.side_effect = KeyError(invalid_user_name)
 
     pld = {
@@ -1567,7 +1569,7 @@ def test_handles_failed_command(
     queue_item = (1, mock_props, json.dumps(pld).encode())
 
     em.identity_mapper = mock.Mock()
-    em.identity_mapper.map_identity.return_value = "a"
+    em.identity_mapper.map_identities.return_value = [[{"uuid": ["a"]}]]
     em.send_failure_notice = mock.Mock(spec=em.send_failure_notice)
     em._command_queue = mock.Mock()
     em._command_stop_event.set()


### PR DESCRIPTION
Following the GCS move to deprecate the singular `.map_identity()` in the Globus Identity Mapping tool, go ahead and do similar here.  This is actually convenient timing as this work is also a precursor to sc-37953 to send endpoint meta information to the web-services, and doing this segment now clears up a couple of future PRs.

[sc-37953]

## Type of change

- New feature (non-breaking change that adds functionality)