### PR TITLE
Update Polaris config to use alternate interface for engine communication

### DIFF
--- a/docs/endpoints/configs/polaris.yaml
+++ b/docs/endpoints/configs/polaris.yaml
@@ -9,7 +9,7 @@ engine:
 
   address:
     type: address_by_interface
-    ifname: bond0
+    ifname: hsn0
 
   provider:
     type: PBSProProvider


### PR DESCRIPTION
# Description

As @khk-globus discovered recently, the `bond0` interface on Polaris@ALCF is no longer working for worker to login node communication. This PR updates our documented configs for Polaris to use the `hsn0` interface which we tested to confirm that it works for internal communication.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
