### PR TITLE
Add static information to EP Info in heartbeat

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -642,6 +642,7 @@ def _do_start_endpoint(
         )
 
     _no_fn_list_canary = -15  # an arbitrary random integer; invalid as an allow_list
+    ep_info = {}
     reg_info = {}
     config_str: str | None = None
     fn_allow_list: list[str] | None | int = _no_fn_list_canary
@@ -656,6 +657,7 @@ def _do_start_endpoint(
                     f" {type_name} instead"
                 )
 
+            ep_info = stdin_data.get("ep_info", {})
             reg_info = stdin_data.get("amqp_creds", {})
             config_str = stdin_data.get("config", None)
             fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
@@ -720,6 +722,7 @@ def _do_start_endpoint(
                 state.log_to_console,
                 state.no_color,
                 reg_info,
+                ep_info,
                 die_with_parent,
             )
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
@@ -139,9 +139,9 @@ def send_endpoint_startup_failure_to_amqp(amqp_creds: dict, msg: str | None = No
     if msg is None:
         msg = "General or unknown failure starting user endpoint"
 
-    result_q_info = amqp_creds["result_queue_info"]
-    publish_kw = result_q_info["queue_publish_kwargs"]
-    urlp = pika.URLParameters(result_q_info["connection_url"])
+    q_info = amqp_creds["heartbeat_queue_info"]
+    publish_kw = q_info["queue_publish_kwargs"]
+    urlp = pika.URLParameters(q_info["connection_url"])
     status_report = EPStatusReport(
         endpoint_id=amqp_creds["endpoint_id"],
         global_state={"error": msg, "heartbeat_period": 3},

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -73,23 +73,18 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         self._engine_ready = True
 
     def get_status_report(self) -> EPStatusReport:
-        assert self.executor, "The engine has not been started"
         executor_status: t.Dict[str, t.Any] = {
-            "task_id": -2,
-            "info": {
-                "total_cores": multiprocessing.cpu_count(),
-                "total_mem": round(psutil.virtual_memory().available / (2**30), 1),
-                "total_core_hrs": 0,
-                "total_workers": self.executor._max_workers,  # type: ignore
-                "pending_tasks": 0,
-                "outstanding_tasks": 0,
-                "scaling_enabled": False,
-                "max_blocks": 1,
-                "min_blocks": 1,
-                "max_workers_per_node": self.executor._max_workers,  # type: ignore
-                "nodes_per_block": 1,
-                "heartbeat_period": None,
-            },
+            "total_cores": multiprocessing.cpu_count(),
+            "total_mem": round(psutil.virtual_memory().available / (2**30), 1),
+            "total_core_hrs": 0,
+            "total_workers": self.executor._max_workers,  # type: ignore
+            "pending_tasks": 0,
+            "outstanding_tasks": 0,
+            "scaling_enabled": False,
+            "max_blocks": 1,
+            "min_blocks": 1,
+            "max_workers_per_node": self.executor._max_workers,  # type: ignore
+            "nodes_per_block": 1,
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}
 
@@ -106,12 +101,9 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         *args: t.Any,
         **kwargs: t.Any,
     ) -> Future:
-        """We pass all params except the function to executor.submit()"""
+        """``resource_specification`` is not applicable to the ProcessPoolEngine"""
         assert self.executor, "The engine has not been started"
         return self.executor.submit(func, *args, **kwargs)
-
-    def status_polling_interval(self) -> int:
-        return 30
 
     def shutdown(self, /, block=False, **kwargs) -> None:
         if self.executor:

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -63,29 +63,18 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         self._engine_ready = True
 
     def get_status_report(self) -> EPStatusReport:
-        """
-        endpoint_id: uuid.UUID
-        ep_status_report: t.Dict[str, t.Any]
-        task_statuses: t.Dict[str, t.List[TaskTransition]]
-        Returns
-        -------
-        """
         executor_status: t.Dict[str, t.Any] = {
-            "task_id": -2,
-            "info": {
-                "total_cores": multiprocessing.cpu_count(),
-                "total_mem": round(psutil.virtual_memory().available / (2**30), 1),
-                "total_core_hrs": 0,
-                "total_workers": self.executor._max_workers,  # type: ignore
-                "pending_tasks": 0,
-                "outstanding_tasks": 0,
-                "scaling_enabled": False,
-                "max_blocks": 1,
-                "min_blocks": 1,
-                "max_workers_per_node": self.executor._max_workers,  # type: ignore
-                "nodes_per_block": 1,
-                "heartbeat_period": None,
-            },
+            "total_cores": multiprocessing.cpu_count(),
+            "total_mem": round(psutil.virtual_memory().available / (2**30), 1),
+            "total_core_hrs": 0,
+            "total_workers": self.executor._max_workers,  # type: ignore
+            "pending_tasks": 0,
+            "outstanding_tasks": 0,
+            "scaling_enabled": False,
+            "max_blocks": 1,
+            "min_blocks": 1,
+            "max_workers_per_node": self.executor._max_workers,  # type: ignore
+            "nodes_per_block": 1,
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}
 
@@ -102,13 +91,8 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         *args: t.Any,
         **kwargs: t.Any,
     ) -> Future:
-        """We basically pass all params except the resource_specification
-        over to executor.submit
-        """
+        """``resource_specification`` is not applicable to the ThreadPoolEngine"""
         return self.executor.submit(func, *args, **kwargs)
-
-    def status_polling_interval(self) -> int:
-        return 30
 
     def scale_out(self, blocks: int) -> list[str]:
         return []

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -71,7 +71,7 @@ def test_start_endpoint_display_name(mocker, fs, display_name):
     ep_conf.display_name = display_name
 
     with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
+        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={}, ep_info={})
     assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
 
     req = pyt_exc.value.__cause__._underlying_response.request
@@ -97,7 +97,7 @@ def test_start_endpoint_data_passthrough(fs):
     ep_conf.public = True
 
     with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
+        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={}, ep_info={})
     assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
 
     req = pyt_exc.value.__cause__._underlying_response.request
@@ -241,6 +241,7 @@ def test_endpoint_setup_execution(mocker, tmp_path, randomstring):
     log_to_console = False
     no_color = True
     reg_info = {}
+    ep_info = {}
 
     ep = endpoint.Endpoint()
     with mock.patch(f"{_MOCK_BASE}log") as mock_log:
@@ -252,6 +253,7 @@ def test_endpoint_setup_execution(mocker, tmp_path, randomstring):
                 log_to_console,
                 no_color,
                 reg_info,
+                ep_info,
             )
 
     assert e.value.code == os.EX_CONFIG

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -347,7 +347,13 @@ class TestStart:
             log_to_console = False
             no_color = True
             manager.start_endpoint(
-                config_dir, None, config, log_to_console, no_color, reg_info={}
+                config_dir,
+                None,
+                config,
+                log_to_console,
+                no_color,
+                reg_info={},
+                ep_info={},
             )
 
     @pytest.mark.skip("This test doesn't make much sense")

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -52,6 +52,7 @@ def run_interchange_process(
             config=config,
             endpoint_id=endpoint_uuid,
             reg_info=reg_info,
+            ep_info={},
             endpoint_dir=endpoint_dir,
             logdir=endpoint_dir,
         )

--- a/compute_endpoint/tests/unit/engine/test_globuscompute.py
+++ b/compute_endpoint/tests/unit/engine/test_globuscompute.py
@@ -1,0 +1,92 @@
+import random
+import sys
+import uuid
+from unittest import mock
+
+import parsl
+import pytest
+from globus_compute_endpoint.engines import GlobusComputeEngine
+
+_MOCK_BASE = "globus_compute_endpoint.engines.globus_compute."
+this_py_version = "{}.{}.{}".format(*sys.version_info)
+
+
+@pytest.fixture(autouse=True)
+def mock_jsp():
+    with mock.patch(f"{_MOCK_BASE}JobStatusPoller", spec=True) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_blocks():
+    return [str(i) for i in range(random.randint(1, 20))]
+
+
+@pytest.fixture
+def mock_managers(mock_blocks, randomstring):
+    return [
+        {
+            "manager": randomstring(),
+            "block_id": bid,
+            "worker_count": random.randint(1, 32),
+            "tasks": random.randint(0, 100),
+            "idle_duration": max(0.0, random.random() * 100.0 - 10.0),
+            "active": random.random() < 0.5,
+            "parsl_version": parsl.__version__,
+            "python_version": this_py_version,
+            "draining": False,
+        }
+        for bid in mock_blocks
+    ]
+
+
+@pytest.fixture
+def htex(mock_blocks, mock_managers):
+    _htex = parsl.HighThroughputExecutor(address="::1")
+
+    _htex.blocks_to_job_id.update((bid, str(int(bid) + 100)) for bid in mock_blocks)
+    _htex.job_ids_to_block.update(
+        (jid, bid) for bid, jid in _htex.blocks_to_job_id.items()
+    )
+    _htex.connected_managers = mock.Mock(spec=_htex.connected_managers)
+    _htex.connected_managers.return_value = mock_managers
+
+    yield _htex
+
+
+def test_status_report_content(htex, mock_managers):
+    ep_id = uuid.uuid4()
+    gce = GlobusComputeEngine(endpoint_id=ep_id, executor=htex)
+    sr = gce.get_status_report()
+    num_managers = len(mock_managers)
+    num_active_managers = sum(m["active"] for m in mock_managers)
+    num_live_workers = sum(m["worker_count"] for m in mock_managers)
+    num_idle_workers = sum(
+        max(0, m["worker_count"] - m["tasks"]) for m in mock_managers
+    )
+    assert sr.endpoint_id == ep_id
+    assert num_managers == sr.global_state["managers"]
+    assert num_active_managers == sr.global_state["active_managers"]
+    assert num_live_workers == sr.global_state["total_workers"]
+    assert num_idle_workers == sr.global_state["idle_workers"]
+
+    assert "pending_tasks" in sr.global_state
+    assert "outstanding_tasks" in sr.global_state
+    assert "scaling_enabled" in sr.global_state
+    assert "mem_per_worker" in sr.global_state
+    assert "cores_per_worker" in sr.global_state
+    assert "prefetch_capacity" in sr.global_state
+    assert "max_blocks" in sr.global_state
+    assert "min_blocks" in sr.global_state
+    assert "max_workers_per_node" in sr.global_state
+    assert "nodes_per_block" in sr.global_state
+
+    assert len(sr.global_state["node_info"]) == num_managers
+
+    for mock_m in mock_managers:
+        jid = htex.blocks_to_job_id[mock_m["block_id"]]
+        m = sr.global_state["node_info"][jid][0]  # for now, test assumes one worker
+        assert m["parsl_version"] == mock_m["parsl_version"]
+        assert m["python_version"] == mock_m["python_version"]
+        assert m["idle_duration"] == mock_m["idle_duration"]
+        assert m["worker_count"] == mock_m["worker_count"]

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -1,15 +1,25 @@
-import logging
-import random
-import uuid
-from multiprocessing.synchronize import Event as EventType
+from concurrent.futures import Future
 from unittest import mock
 
 import pytest
+from globus_compute_common.messagepack.message_types import EPStatusReport
 from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange
-from globus_compute_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
+from globus_compute_endpoint.endpoint.rabbit_mq import (
+    ResultPublisher,
+    TaskQueueSubscriber,
+)
+from globus_compute_endpoint.engines import GlobusComputeEngine
 
 _mock_base = "globus_compute_endpoint.endpoint.interchange."
+
+
+def empty_reg_info() -> dict:
+    return {
+        "task_queue_info": {},
+        "result_queue_info": {},
+        "heartbeat_queue_info": {},
+    }
 
 
 @pytest.fixture
@@ -20,14 +30,53 @@ def mock_tqs():
 
 
 @pytest.fixture
+def mock_rp():
+    m = mock.Mock(spec=ResultPublisher)
+    with mock.patch(f"{_mock_base}ResultPublisher", return_value=m):
+        yield m
+
+
+@pytest.fixture
 def mock_pack():
     with mock.patch(f"{_mock_base}pack") as m:
         yield m
 
 
-def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals):
-    num_iterations = random.randint(1, 10)
-    excepts_left = num_iterations
+@pytest.fixture
+def mock_gce():
+    return mock.Mock(spec=GlobusComputeEngine)
+
+
+@pytest.fixture
+def mock_ep_info(randomstring):
+    return {
+        "some": randomstring(),
+        "canary": randomstring(),
+        randomstring(): "info",
+    }
+
+
+@pytest.fixture
+def ei(endpoint_uuid, mock_gce, mock_quiesce, mock_ep_info):
+    _ei = EndpointInterchange(
+        config=UserEndpointConfig(executors=[mock_gce]),
+        endpoint_id=endpoint_uuid,
+        reg_info=empty_reg_info(),
+        ep_info=mock_ep_info,
+    )
+    _ei._quiesce_event = mock_quiesce
+    _ei.executor.get_status_report.return_value = EPStatusReport(
+        endpoint_id=_ei.endpoint_id, global_state={}, task_statuses=[]
+    )
+
+    yield _ei
+
+    _ei.stop()
+
+
+@pytest.mark.parametrize("num", list(range(1, 11)))
+def test_main_exception_always_quiesces(fs, ei, randomstring, reset_signals, num):
+    excepts_left = num
     exc_text = f"Woot {randomstring()}"
     exc = Exception(exc_text)
 
@@ -37,56 +86,32 @@ def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals)
         ei.time_to_quit = excepts_left <= 0
         raise exc
 
-    mocker.patch(f"{_mock_base}time.sleep")
-    mocker.patch(f"{_mock_base}multiprocessing")
-    ei = EndpointInterchange(
-        config=UserEndpointConfig(executors=[mocker.Mock()]),
-        reg_info={
-            "task_queue_info": {},
-            "result_queue_info": {},
-            "heartbeat_queue_info": {},
-        },
-        reconnect_attempt_limit=num_iterations + 10,
-    )
-    ei._main_loop = mock.Mock()
+    ei.reconnect_attempt_limit = num + 10
+    ei._main_loop = mock.Mock(spec=ei._main_loop)
     ei._main_loop.side_effect = _mock_start_threads
-    with mock.patch(f"{_mock_base}log") as mock_log:
-        ei.start()
-    assert mock_log.error.call_count == num_iterations
+    with mock.patch(f"{_mock_base}time.sleep"):
+        with mock.patch(f"{_mock_base}log") as mock_log:
+            ei.start()
+    assert mock_log.error.call_count == num
     a, _k = mock_log.error.call_args
     assert exc_text in a[0], "Expect exception text shared in logs"
 
     assert ei._quiesce_event.set.called
-    assert ei._quiesce_event.set.call_count == num_iterations
-    assert ei._main_loop.call_count == num_iterations
+    assert ei._quiesce_event.set.call_count == num
+    assert ei._main_loop.call_count == num
 
 
-@pytest.mark.parametrize("reconnect_attempt_limit", [-1, 0, 1, 2, 3, 5, 10])
-def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_signals):
-    expected_reconnect_limit = max(1, reconnect_attempt_limit)  # checking boundary
+@pytest.mark.parametrize("attempt_limit", list(range(1, 11)))
+def test_reconnect_attempt_limit(fs, ei, attempt_limit, reset_signals):
+    expected_reconnect_limit = max(1, attempt_limit)  # checking boundary
     num_iterations = expected_reconnect_limit * 2 + 5  # overkill "just to be sure"
     excepts_left = num_iterations
 
-    def _mock_start_threads(*a, **k):
-        nonlocal excepts_left
-        excepts_left -= 1
-        ei.time_to_quit = excepts_left <= 0
-        raise Exception()
-
-    mocker.patch(f"{_mock_base}time.sleep")
-    mocker.patch(f"{_mock_base}multiprocessing")
-    mock_log = mocker.patch(f"{_mock_base}log")
-    ei = EndpointInterchange(
-        config=UserEndpointConfig(executors=[mocker.Mock()]),
-        reg_info={
-            "task_queue_info": {},
-            "result_queue_info": {},
-            "heartbeat_queue_info": {},
-        },
-        reconnect_attempt_limit=reconnect_attempt_limit,
-    )
+    ei.reconnect_attempt_limit = attempt_limit
     ei._main_loop = mock.Mock(spec=ei._main_loop)
-    ei.start()
+    with mock.patch(f"{_mock_base}time.sleep"):
+        with mock.patch(f"{_mock_base}log") as mock_log:
+            ei.start()
 
     assert ei._main_loop.call_count == expected_reconnect_limit
 
@@ -96,20 +121,9 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     assert excepts_left > 0, "expect reconnect limit to stop loop, not test backup"
 
 
-def test_reset_reconnect_attempt_limit_when_stable(mocker, fs, mock_tqs, mock_pack):
+def test_reset_reconnect_attempt_limit_when_stable(mocker, fs, ei, mock_tqs, mock_pack):
     mocker.patch(f"{_mock_base}ResultPublisher")
     mocker.patch(f"{_mock_base}threading.Thread")
-    mocker.patch(f"{_mock_base}multiprocessing")
-    ei = EndpointInterchange(
-        config=UserEndpointConfig(executors=[mocker.Mock()]),
-        endpoint_id=str(uuid.uuid4()),
-        reg_info={
-            "task_queue_info": {},
-            "result_queue_info": {},
-            "heartbeat_queue_info": {},
-        },
-    )
-    ei._quiesce_event = mock.Mock(spec=EventType)
 
     ei._quiesce_event.wait.side_effect = (False, True)  # iterate once
     ei._reconnect_fail_counter = 1  # simulate that we've failed once
@@ -131,31 +145,46 @@ def test_reset_reconnect_attempt_limit_when_stable(mocker, fs, mock_tqs, mock_pa
     assert ei._quiesce_event.wait.call_count == 3, "Verify loop iterations"
 
 
-def test_rundir_passed_to_gcengine(mocker, fs):
+def test_rundir_passed_to_gcengine(mocker, fs, ei):
     "Test EndpointInterchange passing run_dir to GCE on start"
 
     mocker.patch(f"{_mock_base}ResultPublisher")
     mocker.patch(f"{_mock_base}threading.Thread")
-    mocker.patch(f"{_mock_base}multiprocessing")
     mock_gcengine = mocker.Mock()
     mock_gcengine.start = mocker.Mock()
 
-    ei = EndpointInterchange(
-        config=UserEndpointConfig(executors=[mock_gcengine]),
-        endpoint_id=str(uuid.uuid4()),
-        reg_info={
-            "task_queue_info": {},
-            "result_queue_info": {},
-            "heartbeat_queue_info": {},
-        },
-    )
-    ei._quiesce_event = mock.Mock(spec=EventType)
-
-    logging.warning(f"{ei.executor=}")
     ei.start_engine()
 
-    mock_gcengine.start.assert_called_with(
+    ei.executor.start.assert_called_with(
         results_passthrough=ei.results_passthrough,
         endpoint_id=ei.endpoint_id,
         run_dir=ei.logdir,
     )
+
+
+def test_heartbeat_includes_static_info(ei, mock_rp, mock_tqs, mock_pack, mock_ep_info):
+    call_count = 0
+    num_hbs_until_quit = 2
+
+    def two_hbs_then_quit(*a, **k):
+        nonlocal call_count, num_hbs_until_quit
+        call_count += 1
+        if call_count >= num_hbs_until_quit:
+            ei.stop()
+        f = Future()
+        f.set_result(None)
+        return f
+
+    mock_rp.publish.side_effect = two_hbs_then_quit
+
+    with mock.patch(f"{_mock_base}threading.Thread"):
+        assert not ei.time_to_quit, "Verify test setup"
+        ei._main_loop()
+
+    # Note that this is the "hooked up" test.  The content of `get_status_report`
+    # is verified by the engine-specific unit tests.
+    assert (
+        ei.executor.get_status_report.call_count == num_hbs_until_quit + 1
+    ), f"Should be {num_hbs_until_quit} heartbeats and a final sign off"
+    for a, k in mock_pack.call_args_list:
+        assert all(a[0].global_state[k] == v for k, v in mock_ep_info.items())


### PR DESCRIPTION
Accept `ep_info` from stdin, if provided, and treat as a static set of data that will not change for the life of the process.  In the case where nothing is provided, generate default values (e.g., `os.getpid()`, etc.).  Use this data structure to augment the EPStatusReport structure that the heartbeat sends.

Add notion of `active`, a boolean, to heartbeat.  This will aid the WS in determining the online status of an endpoint.

Add first test of fields of status report (`global_state`).  Currently, only the fields of the GlobusComputeEngine status report are tested.  I opted to wait to implement tests for the ProcessPool and ThreadPool engines at this time.

[sc-37953]

## Type of change

- New feature (non-breaking change that adds functionality)