### PR TITLE
Refactor the Endpoint unit tests

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -491,16 +491,17 @@ class Endpoint:
             exit(os.EX_DATAERR)
 
         try:
-            tq_info, rq_info = (
+            tq_info, rq_info, hbq_info = (
                 reg_info["task_queue_info"],
                 reg_info["result_queue_info"],
+                reg_info["heartbeat_queue_info"],
             )
         except KeyError:
             log.error("Invalid credential structure")
             exit(os.EX_DATAERR)
 
         if endpoint_config.amqp_port is not None:
-            for q_info in tq_info, rq_info:
+            for q_info in tq_info, rq_info, hbq_info:
                 q_info["connection_url"] = update_url_port(
                     q_info["connection_url"], endpoint_config.amqp_port
                 )


### PR DESCRIPTION
Main addition is a couple of new fixtures, `mock_gcc` and `mock_get_client`. Using these, replaced a number of boiler-plate setups with a single point of authority.  In the course of this refactor, discovered one oversight bug: the heartbeat AMQP port replacement logic.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup