### PR TITLE
MEP passes identity information to UEP

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -568,17 +568,18 @@ class Endpoint:
                 no_color=no_color,
             )
 
-            if not ep_info:
-                ep_info = {
-                    "posix_pid": os.getpid(),
-                    "posix_uid": os.getuid(),
-                    "posix_gid": os.getgid(),
-                    "posix_username": pwd.getpwuid(os.getuid()).pw_name,
-                    "config.yaml": endpoint_config.source_content,
-                }
             now_tz = datetime.now().astimezone()
-            ep_info["start_iso"] = now_tz.isoformat()
-            ep_info["start_unix"] = now_tz.timestamp()
+            ep_info.update(
+                posix_username=pwd.getpwuid(os.getuid()).pw_name,
+                posix_uid=os.getuid(),
+                posix_gid=os.getgid(),
+                posix_groups=os.getgroups(),
+                posix_pid=os.getpid(),
+                posix_sid=os.getsid(os.getpid()),
+                config_raw=endpoint_config.source_content,
+                start_iso=now_tz.isoformat(),
+                start_unix=now_tz.timestamp(),
+            )
 
             Endpoint.daemon_launch(
                 endpoint_uuid,

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -153,7 +153,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         job_status_kwargs.setdefault("strategy", strategy)
         job_status_kwargs.setdefault("strategy_period", 5.0)
         self.job_status_poller = JobStatusPoller(**job_status_kwargs)
-        # N.B. save `.add_executor()` until after starting executor; see .start()
+        # N.B. call `.add_executor()` *after* starting executor; see .start()
 
     @property
     def max_workers_per_node(self):
@@ -453,6 +453,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         Object containing info on the current status of the endpoint
         """
         managers = self.get_connected_managers()
+
         manager_info: dict[str, list] = {}
         for m in managers:
             jid = self.executor.blocks_to_job_id[m["block_id"]]
@@ -463,9 +464,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 "python_version": m["python_version"],
             }
             manager_info.setdefault(jid, []).append(m_info)
-        for jid in list(manager_info):
-            if not manager_info[jid]:
-                del manager_info[jid]
+
         executor_status: t.Dict[str, t.Any] = {
             "managers": self.get_total_managers(managers=managers),  # aka: nodes
             "active_managers": self.get_total_active_managers(managers=managers),


### PR DESCRIPTION
The SEP/UEP recently learned about a static set of information about the EP process to send along with the heartbeat.  It can also get information from its `stdin` via the usual (JSON dictionary) mechanism.  This commit now teaches the MEP to pass along identity information about which identity matched, that will be included in the heartbeat.

While here, fine-tune the auto-population of the `ep_info` datastructure to always add the information.  There is no need to ferry the data around from the pre-exec context when the OS freely manages this data already.

[sc-37953]

## Type of change

- New feature (non-breaking change that adds functionality)