### PR TITLE
Deprecate LoginManager and AuthorizerLoginManager

### DIFF
--- a/changelog.d/20250205_151005_30907815+rjmello_deprecate_login_manager.rst
+++ b/changelog.d/20250205_151005_30907815+rjmello_deprecate_login_manager.rst
@@ -1,0 +1,6 @@
+Deprecated
+^^^^^^^^^^
+
+- The ``LoginManager`` and ``AuthorizerLoginManager`` classes are now deprecated. Use
+  `GlobusApp <https://globus-compute.readthedocs.io/en/stable/sdk.html#globusapps>`_
+  objects from the Globus SDK instead.

--- a/changelog.d/20250205_151005_30907815+rjmello_deprecate_login_manager.rst
+++ b/changelog.d/20250205_151005_30907815+rjmello_deprecate_login_manager.rst
@@ -4,3 +4,5 @@ Deprecated
 - The ``LoginManager`` and ``AuthorizerLoginManager`` classes are now deprecated. Use
   `GlobusApp <https://globus-compute.readthedocs.io/en/stable/sdk.html#globusapps>`_
   objects from the Globus SDK instead.
+
+- The ``Client.login_manager`` attribute is now deprecated.

--- a/changelog.d/20250205_151005_30907815+rjmello_deprecate_login_manager.rst
+++ b/changelog.d/20250205_151005_30907815+rjmello_deprecate_login_manager.rst
@@ -1,3 +1,10 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added an optional ``authorizer`` parameter to the ``Client`` initializer to support
+  using a ``GlobusAuthorizer`` for authentication. This parameter is mutually exclusive
+  with ``app``.
+
 Deprecated
 ^^^^^^^^^^
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -73,6 +73,7 @@ class Client:
         data_serialization_strategy: SerializationStrategy | None = None,
         login_manager: LoginManagerProtocol | None = None,
         app: globus_sdk.GlobusApp | None = None,
+        authorizer: globus_sdk.authorizers.GlobusAuthorizer | None = None,
         **kwargs,
     ):
         """
@@ -101,14 +102,19 @@ class Client:
 
         login_manager: LoginManagerProtocol [Deprecated]
             Allows login logic to be overridden for specific use cases. If None,
-            a ``GlobusApp`` will be used. Mutually exclusive with ``app``.
+            a ``GlobusApp`` will be used. Mutually exclusive with ``app`` and
+            ``authorizer``.
 
-            This argument is deprecated; please use ``app`` or ``authorizer`` instead.
+            This argument is deprecated; use ``app`` or ``authorizer`` instead.
 
         app: GlobusApp
             A ``GlobusApp`` that will handle authorization and storing and validating
             tokens. If None, a standard ``GlobusApp`` will be used. Mutually exclusive
-            with ``login_manager``.
+            with ``authorizer`` and ``login_manager``.
+
+        authorizer: GlobusAuthorizer
+            A ``GlobusAuthorizer`` that will generate authorization headers. Mutually
+            exclusive with ``app`` and ``login_manager``.
         """
         for arg_name in kwargs:
             msg = (
@@ -124,12 +130,20 @@ class Client:
         self._task_status_table: dict[str, dict] = {}
 
         self.app: globus_sdk.GlobusApp | None = None
+        self.authorizer: globus_sdk.authorizers.GlobusAuthorizer | None = None
         self._login_manager: LoginManagerProtocol | None = None
         self._web_client: WebClient | None = None
         self._auth_client: globus_sdk.AuthClient | None = None
 
-        if app and login_manager:
-            raise ValueError("'app' and 'login_manager' are mutually exclusive.")
+        if sum(bool(x) for x in (app, authorizer, login_manager)) > 1:
+            raise ValueError(
+                "'app', 'authorizer' and 'login_manager' are mutually exclusive."
+            )
+        elif authorizer:
+            self.authorizer = authorizer
+            self._compute_web_client = _ComputeWebClient(
+                base_url=self.web_service_address, authorizer=self.authorizer
+            )
         elif login_manager:
             self.login_manager = login_manager
             self._compute_web_client = _ComputeWebClient(
@@ -154,8 +168,9 @@ class Client:
     @property
     def login_manager(self):
         warnings.warn(
-            "The 'Client.login_manager' attribute is deprecated.",
-            DeprecationWarning,
+            "The 'Client.login_manager' attribute is deprecated;"
+            " use 'Client.app' or 'Client.authorizer' instead.",
+            UserWarning,
             stacklevel=2,
         )
         return self._login_manager
@@ -225,6 +240,13 @@ class Client:
 
     def logout(self):
         """Remove credentials from your local system"""
+        if self.authorizer:
+            logger.warning(
+                "Logout is not supported when Client is initialized with"
+                f" a GlobusAuthorizer (self.authorizer={self.authorizer})."
+            )
+            return
+
         auth_obj = self.app or self.login_manager
         if auth_obj:
             auth_obj.logout()

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -99,9 +99,11 @@ class Client:
             Strategy to use when serializing function arguments. If None,
             globus_compute_sdk.serialize.DEFAULT_STRATEGY_DATA will be used.
 
-        login_manager: LoginManagerProtocol
+        login_manager: LoginManagerProtocol [Deprecated]
             Allows login logic to be overridden for specific use cases. If None,
             a ``GlobusApp`` will be used. Mutually exclusive with ``app``.
+
+            This argument is deprecated; please use ``app`` or ``authorizer`` instead.
 
         app: GlobusApp
             A ``GlobusApp`` that will handle authorization and storing and validating
@@ -122,7 +124,7 @@ class Client:
         self._task_status_table: dict[str, dict] = {}
 
         self.app: globus_sdk.GlobusApp | None = None
-        self.login_manager: LoginManagerProtocol | None = None
+        self._login_manager: LoginManagerProtocol | None = None
         self._web_client: WebClient | None = None
         self._auth_client: globus_sdk.AuthClient | None = None
 
@@ -148,6 +150,19 @@ class Client:
 
         if do_version_check:
             self.version_check()
+
+    @property
+    def login_manager(self):
+        warnings.warn(
+            "The 'Client.login_manager' attribute is deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._login_manager
+
+    @login_manager.setter
+    def login_manager(self, val: LoginManagerProtocol):
+        self._login_manager = val
 
     @property
     def auth_client(self):

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
@@ -24,9 +24,9 @@ class AuthorizerLoginManager(LoginManagerProtocol):
 
     def __init__(self, authorizers: dict[str, globus_sdk.RefreshTokenAuthorizer]):
         warnings.warn(
-            "The `AuthorizerLoginManager` is deprecated. Please use `GlobusApp` objects"
-            "from the Globus SDK instead:"
-            " https://globus-compute.readthedocs.io/en/stable/sdk.html#globusapps",
+            "The `AuthorizerLoginManager` is deprecated. Please use an"
+            " `AccessTokenAuthorizer` object from the Globus SDK instead:"
+            " https://globus-compute.readthedocs.io/en/stable/sdk.html#using-an-existing-token",  # noqa: E501
             category=UserWarning,
             stacklevel=2,
         )

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 
 import globus_sdk
 from globus_compute_sdk.sdk.login_manager.manager import LoginManager
@@ -22,6 +23,13 @@ class AuthorizerLoginManager(LoginManagerProtocol):
     """
 
     def __init__(self, authorizers: dict[str, globus_sdk.RefreshTokenAuthorizer]):
+        warnings.warn(
+            "The `AuthorizerLoginManager` is deprecated. Please use `GlobusApp` objects"
+            "from the Globus SDK instead:"
+            " https://globus-compute.readthedocs.io/en/stable/sdk.html#globusapps",
+            category=UserWarning,
+            stacklevel=2,
+        )
         self.authorizers = authorizers
 
     def get_auth_client(self) -> globus_sdk.AuthClient:

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/manager.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import threading
 import typing as t
+import warnings
 
 import globus_sdk
 from globus_sdk.scopes import AuthScopes
@@ -40,6 +41,13 @@ class LoginManager:
     }
 
     def __init__(self, *, environment: str | None = None) -> None:
+        warnings.warn(
+            "The `LoginManager` is deprecated. Please use `GlobusApp` objects"
+            " from the Globus SDK instead:"
+            " https://globus-compute.readthedocs.io/en/stable/sdk.html#globusapps",
+            category=UserWarning,
+            stacklevel=2,
+        )
         self._token_storage = get_token_storage_adapter(environment=environment)
         self._access_lock = threading.Lock()
 

--- a/compute_sdk/tests/unit/test_authorizer_login_manager.py
+++ b/compute_sdk/tests/unit/test_authorizer_login_manager.py
@@ -32,6 +32,13 @@ def logman(mocker, tmp_path):
     return AuthorizerLoginManager({})
 
 
+def test_authorizer_login_manager_deprecated():
+    with pytest.warns(UserWarning) as record:
+        AuthorizerLoginManager({})
+    msg = "The `AuthorizerLoginManager` is deprecated"
+    assert any(msg in str(r.message) for r in record)
+
+
 def test_auth_client_requires_authorizer_openid_scope(mocker):
     alm = AuthorizerLoginManager({})
     with pytest.raises(KeyError) as pyt_exc:

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -783,3 +783,14 @@ def test_auth_client_deprecated():
         assert gcc.auth_client, "Client.auth_client needed for backward compatibility"
     msg = "'Client.auth_client' attribute is deprecated"
     assert any(msg in str(r.message) for r in record)
+
+
+def test_login_manager_deprecated():
+    mock_lm = mock.Mock(spec=LoginManager)
+    gcc = gc.Client(do_version_check=False, login_manager=mock_lm)
+    with pytest.warns(UserWarning) as record:
+        assert (
+            gcc.login_manager
+        ), "Client.login_manager needed for backward compatibility"
+    msg = "'Client.login_manager' attribute is deprecated"
+    assert any(msg in str(r.message) for r in record)

--- a/compute_sdk/tests/unit/test_login_manager.py
+++ b/compute_sdk/tests/unit/test_login_manager.py
@@ -36,6 +36,13 @@ def logman(mocker, tmp_path):
     return LoginManager()
 
 
+def test_login_manager_deprecated():
+    with pytest.warns(UserWarning) as record:
+        LoginManager()
+    msg = "The `LoginManager` is deprecated"
+    assert any(msg in str(r.message) for r in record)
+
+
 def test_is_client_login():
     env = {CID_KEY: "some_id", CSC_KEY: "some_secret"}
     with mock.patch.dict(os.environ, env):

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -264,59 +264,31 @@ This also applies when starting a Globus Compute endpoint.
 .. note:: Globus Compute clients and endpoints will use the client credentials if they are set, so it is important to ensure the client submitting requests has access to an endpoint.
 
 
-.. _login manager:
+.. _existing-token:
 
-Using a Existing Tokens
+Using an Existing Token
 -----------------------
 
-To programmatically create a Client from tokens and remove the need to perform a Native App login flow you can use the *AuthorizerLoginManager*.
-The AuthorizerLoginManager is responsible for serving tokens to the Client as needed and can be instantiated using existing tokens.
+To create a |Client|_ from an existing access token and skip the interactive login flow, you can pass an |AccessTokenAuthorizer|_
+via the ``authorizer`` parameter:
 
-The AuthorizerLoginManager can be used to simply return static tokens and enable programmatic use of the Client.
+.. code-block:: python
+
+  import globus_sdk
+  from globus_compute_sdk import Executor, Client
+
+  authorizer = globus_sdk.AccessTokenAuthorizer(access_token="...")
+  gcc = Client(authorizer=authorizer)
+  gce = Executor(endpoint_id="...", client=gcc)
 
 .. note::
-    Accessing the Globus Compute API requires the Globus Auth scope:
-
-    .. code-block:: text
-
-      https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all
-
-    This is also programmatically available as the ``FUNCX_SCOPE`` attribute on
-    the ``Client`` class:
+    Accessing the Globus Compute API requires the Globus Compute scope:
 
     .. code-block:: python
 
-      >>> from globus_compute_sdk import Client
-      >>> Client.FUNCX_SCOPE
+      >>> from globus_sdk.scopes import ComputeScopes
+      >>> ComputeScopes.all
       'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all'
-
-More details on the Globus Compute login manager prototcol are available `here. <https://github.com/globus/globus-compute/blob/main/compute_sdk/globus_compute_sdk/sdk/login_manager/protocol.py>`_
-
-
-.. code:: python
-
-  import globus_sdk
-  from globus_sdk.scopes import AuthScopes
-
-  from globus_compute_sdk import Executor, Client
-  from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager
-  from globus_compute_sdk.sdk.login_manager.manager import ComputeScopeBuilder
-
-  ComputeScopes = ComputeScopeBuilder()
-
-  # Create Authorizers from the Compute and Auth tokens
-  compute_auth = globus_sdk.AccessTokenAuthorizer(tokens[ComputeScopes.resource_server]['access_token'])
-  openid_auth = globus_sdk.AccessTokenAuthorizer(tokens[AuthScopes.openid]['access_token'])
-
-  # Create a Compute Client from these authorizers
-  compute_login_manager = AuthorizerLoginManager(
-      authorizers={ComputeScopes.resource_server: compute_auth,
-                   AuthScopes.resource_server: openid_auth}
-  )
-  compute_login_manager.ensure_logged_in()
-
-  gc = Client(login_manager=compute_login_manager)
-  gce = Executor(endpoint_id=tutorial_endpoint, client=gc)
 
 
 .. _specifying-serde-strategy:
@@ -409,6 +381,8 @@ and serializes a fresh copy each time it is invoked.
 
 .. |rarr| unicode:: 0x2192
 
+.. |AccessTokenAuthorizer| replace:: ``AccessTokenAuthorizer``
+.. _AccessTokenAuthorizer: https://globus-sdk-python.readthedocs.io/en/stable/authorization/globus_authorizers.html#globus_sdk.AccessTokenAuthorizer
 .. |Client| replace:: ``Client``
 .. _Client: reference/client.html
 .. |Executor| replace:: ``Executor``


### PR DESCRIPTION
# Description

- Deprecated the `LoginManager` and `AuthorizerLoginManager` classes.
- Deprecated the `Client.login_manager` attribute.
- Added an `authorizer` parameter to the `Client` initializer to enable using a `GlobusAuthorizer` for authentication.
- The SDK docs on using an existing access token now instruct users to pass in a `globus_sdk.AccessTokenAuthorizer` to the `Client` initializer instead of using the deprecated `AuthorizerLoginManager`.

[sc-38908]

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup
