### PR TITLE
Remove obsolete upgrade command

### DIFF
--- a/changelog.d/20250206_125215_kevin_remove_obsolete_funcx_upgrade_code.rst
+++ b/changelog.d/20250206_125215_kevin_remove_obsolete_funcx_upgrade_code.rst
@@ -1,0 +1,6 @@
+Removed
+^^^^^^^
+
+- Removed obsolete rebrand upgrade command.  The project rebranded from funcX
+  to Globus Compute at :ref:`v2.0.0 <changelog-2.0.0>`, in April, 2023, and this
+  command helped with the upgrade process for previously created endpoints.


### PR DESCRIPTION
This command helped with the upgrade process for endpoints created prior to v2.0.0 (a.k.a, the rebrand to Globus Compute from funcX).  Beyond the sheer amount of time (21 months), the vast majority of folks use the YAML configuration approach rather than manually creating configurations.

## Type of change

- Code maintenance/cleanup