### PR TITLE
Deprecate executors (list of len() == 1)

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -136,15 +136,6 @@ class UserEndpointConfigModel(BaseEndpointConfigModel):
 
     _validate_engine = _validate_params("engine")
 
-    def dict(self, *args, **kwargs):
-        # Slight modification is needed here since we still
-        # store the engine/executor in a list named executors
-        ret = super().dict(*args, **kwargs)
-
-        engine = ret.pop("engine", None)
-        ret["executors"] = [engine] if engine else None
-        return ret
-
 
 class ManagerEndpointConfigModel(BaseEndpointConfigModel):
     public: t.Optional[bool]

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -302,11 +302,13 @@ def serialize_config(config: UserEndpointConfig | ManagerEndpointConfig) -> dict
         ...
         "display_name": "My Endpoint",
         ...
-        "executor": {
-            ...
-            "provider": {
-                ...
-                "type": "LocalProvider"
+        "engine": {
+            "executor": {
+                "provider": {
+                    ...
+                    "type": "LocalProvider"
+                    ...
+                }
                 ...
             }
             ...
@@ -339,6 +341,8 @@ def serialize_config(config: UserEndpointConfig | ManagerEndpointConfig) -> dict
         params = [k for sig in signatures for k in sig.parameters.keys()]
 
         for param in params:
+            if param == "executors":
+                continue
             val = getattr(obj, param, 0)
             if val == 0:
                 continue

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -365,12 +365,8 @@ class Endpoint:
         elif sys.stderr.isatty():
             ostream = sys.stderr
 
-        # This is to ensure that at least 1 executor is defined
-        if not endpoint_config.executors:
-            msg = (
-                "Endpoint configuration has no executors defined.  Endpoint will not"
-                " start."
-            )
+        if not endpoint_config.engine:
+            msg = "Configuration has no engines defined.  Endpoint will not start."
             log.critical(msg)
             raise ValueError(msg)
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/taskqueue.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/taskqueue.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 class TaskQueue:
-    """Outgoing task queue from the executor to the Interchange"""
+    """Outgoing task queue from the engine to the Interchange"""
 
     def __init__(
         self,

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -63,7 +63,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
                 *self._executor_args, **self._executor_kwargs
             )
 
-        assert endpoint_id, "ProcessPoolExecutor requires kwarg:endpoint_id at start"
+        assert endpoint_id, "ProcessPoolEngine requires kwarg:endpoint_id at start"
         self.endpoint_id = endpoint_id
         if results_passthrough:
             self.results_passthrough = results_passthrough

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -60,7 +60,7 @@ def test_start_endpoint_display_name(mocker, fs, display_name):
     )
 
     ep = endpoint.Endpoint()
-    ep_conf = UserEndpointConfig()
+    ep_conf = UserEndpointConfig(engine=mock.Mock())
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
     ep_dir.mkdir(parents=True, exist_ok=True)
     ep_conf.display_name = display_name
@@ -83,7 +83,7 @@ def test_start_endpoint_data_passthrough(fs):
     )
 
     ep = endpoint.Endpoint()
-    ep_conf = UserEndpointConfig()
+    ep_conf = UserEndpointConfig(engine=mock.Mock())
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
     ep_dir.mkdir(parents=True, exist_ok=True)
     ep_conf.allowed_functions = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -132,7 +132,11 @@ def test_endpoint_setup_execution(mocker, tmp_path, randomstring):
 
     endpoint_dir = None
     endpoint_uuid = None
-    endpoint_config = UserEndpointConfig(endpoint_setup=command, detach_endpoint=False)
+    endpoint_config = UserEndpointConfig(
+        endpoint_setup=command,
+        engine=mock.Mock(),
+        detach_endpoint=False,
+    )
     log_to_console = False
     no_color = True
     reg_info = {}

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -322,7 +322,7 @@ class TestStart:
             detach_process=True,
         )
 
-    def test_start_without_executors(self, mocker):
+    def test_start_without_engine(self, mocker):
         mock_client = mocker.patch(f"{_MOCK_BASE}Client")
         mock_client.return_value.register_endpoint.return_value = {
             "endpoint_id": "abcde12345",
@@ -337,13 +337,13 @@ class TestStart:
         mock_context.return_value.__exit__.return_value = None
         mock_context.return_value.pidfile.path = ""
 
-        config = UserEndpointConfig(executors=[], detach_endpoint=False)
+        config = UserEndpointConfig(detach_endpoint=False)
 
         manager = Endpoint()
         config_dir = pathlib.Path("/some/path/mock_endpoint")
 
         manager.configure_endpoint(config_dir, None)
-        with pytest.raises(ValueError, match="has no executors defined"):
+        with pytest.raises(ValueError, match="has no engines defined"):
             log_to_console = False
             no_color = True
             manager.start_endpoint(

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -40,6 +40,7 @@ known_user_config_opts = {
     "multi_user": False,
     "high_assurance": False,
     "executors": None,
+    "engine": None,
 }
 
 known_manager_config_opts = {

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -12,7 +12,6 @@ from globus_compute_endpoint.endpoint.config import (
     UserEndpointConfigModel,
 )
 from globus_compute_endpoint.endpoint.config.model import EngineModel
-from globus_compute_endpoint.engines import GlobusComputeEngine
 from tests.unit.conftest import known_manager_config_opts, known_user_config_opts
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.config."
@@ -158,13 +157,7 @@ def test_provider_container_compatibility(
 
 
 def test_configs_repr_default_kwargs():
-    gce_path = "globus_compute_endpoint.engines.globus_compute.GlobusComputeEngine."
-    with mock.patch(f"{gce_path}__init__", return_value=None):
-        # mock == don't make a default executor
-        gce_repr = repr(GlobusComputeEngine())
-        assert (
-            repr(UserEndpointConfig()) == f"UserEndpointConfig(executors=({gce_repr},))"
-        ), "adds default"
+    assert repr(UserEndpointConfig()) == "UserEndpointConfig()"
     defs = f"multi_user=True, pam={PamConfiguration(enable=False)!r}"
     assert (
         repr(ManagerEndpointConfig()) == f"ManagerEndpointConfig({defs})"
@@ -175,11 +168,11 @@ def test_configs_repr_default_kwargs():
 def test_userconfig_repr_nondefault_kwargs(
     randomstring, kw, cls, get_random_of_datatype
 ):
+    if kw in ("engine", "executors"):
+        return
+
     val = get_random_of_datatype(cls)
-    kwds = {"executors": ()}  # Don't create an engine, please
-    if kw == "executors":
-        val = ()
-    kwds[kw] = val
+    kwds = {kw: val}
 
     repr_c = repr(UserEndpointConfig(**kwds))
 

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -59,13 +59,13 @@ def mock_ep_info(randomstring):
 @pytest.fixture
 def ei(endpoint_uuid, mock_gce, mock_quiesce, mock_ep_info):
     _ei = EndpointInterchange(
-        config=UserEndpointConfig(executors=[mock_gce]),
+        config=UserEndpointConfig(engine=mock_gce),
         endpoint_id=endpoint_uuid,
         reg_info=empty_reg_info(),
         ep_info=mock_ep_info,
     )
     _ei._quiesce_event = mock_quiesce
-    _ei.executor.get_status_report.return_value = EPStatusReport(
+    _ei.engine.get_status_report.return_value = EPStatusReport(
         endpoint_id=_ei.endpoint_id, global_state={}, task_statuses=[]
     )
 
@@ -155,7 +155,7 @@ def test_rundir_passed_to_gcengine(mocker, fs, ei):
 
     ei.start_engine()
 
-    ei.executor.start.assert_called_with(
+    ei.engine.start.assert_called_with(
         results_passthrough=ei.results_passthrough,
         endpoint_id=ei.endpoint_id,
         run_dir=ei.logdir,
@@ -184,7 +184,7 @@ def test_heartbeat_includes_static_info(ei, mock_rp, mock_tqs, mock_pack, mock_e
     # Note that this is the "hooked up" test.  The content of `get_status_report`
     # is verified by the engine-specific unit tests.
     assert (
-        ei.executor.get_status_report.call_count == num_hbs_until_quit + 1
+        ei.engine.get_status_report.call_count == num_hbs_until_quit + 1
     ), f"Should be {num_hbs_until_quit} heartbeats and a final sign off"
     for a, k in mock_pack.call_args_list:
         assert all(a[0].global_state[k] == v for k, v in mock_ep_info.items())

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -198,7 +198,7 @@ def test_serialized_engine_config_has_provider():
     ep_config = UserEndpointConfig(executors=[GlobusComputeEngine(address=loopback)])
 
     res = serialize_config(ep_config)
-    executor = res["executors"][0].get("executor") or res["executors"][0]
+    executor = res["engine"]["executor"]
 
     assert executor.get("provider")
 

--- a/docs/endpoints/config_reference.rst
+++ b/docs/endpoints/config_reference.rst
@@ -18,6 +18,8 @@ Compute endpoints currently come in two flavors: one for processing tasks and on
 *managing* multiple task-processing endpoints.  We discuss the former first, backed by
 |UserEndpointConfig|, as it is typically the first entry into Compute for most people.
 
+.. _uep_conf:
+
 User Endpoint Configuration
 ---------------------------
 


### PR DESCRIPTION
Engines entered the mix in Summer, 2023; update configuration to use `.engine` instead of the list of length 1 vestigial thought-process.  Deprecate use of `.executors` at the UserWarning level for visibility.

This should largely be a noop as far as users are concerned, because we've been translating `config.yaml`'s `engine` since day one.

## Type of change

- Code maintenance/cleanup