### PR TITLE
Don't leave GCE threads running

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -52,6 +52,7 @@ def mock_gce(tmp_path):
         engine._engine_ready = True
         engine.results_passthrough = queue.Queue()
         yield engine
+        engine.shutdown()
 
 
 def test_success_after_1_fail(mock_gce, serde, ez_pack_task):
@@ -102,3 +103,4 @@ def test_repeated_fail(mock_gce, ez_pack_task):
 def test_default_retries_is_0():
     engine = GlobusComputeEngine(address="localhost")
     assert engine.max_retries_on_system_failure == 0, "Users must knowingly opt-in"
+    engine.shutdown()

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -32,13 +32,7 @@ def fake_ep_dir(fs: fakefs.FakeFilesystem, ep_name) -> pathlib.Path:
 detach_endpoint: false
 display_name: null
 engine:
-    type: GlobusComputeEngine
-    address: 127.0.0.1
-    provider:
-        type: LocalProvider
-        init_blocks: 1
-        min_blocks: 0
-        max_blocks: 1
+    type: ThreadPoolEngine
         """.strip()
     )
     return ep_dir

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -149,7 +149,8 @@ def test_provider_container_compatibility(
     config_dict["engine"]["address"] = "::1"
 
     if compatible:
-        UserEndpointConfigModel(**config_dict)
+        conf = UserEndpointConfigModel(**config_dict)
+        conf.engine.shutdown()
     else:
         with pytest.raises(ValueError) as pyt_e:
             UserEndpointConfigModel(**config_dict)
@@ -212,4 +213,4 @@ def test_engine_model_objects_allow_extra():
             },
         }
     }
-    UserEndpointConfigModel(**config_dict)
+    UserEndpointConfigModel(**config_dict).engine.shutdown()

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -616,6 +616,7 @@ def test_serialize_config_field_types():
     ep_config.environment = Foo("bar")
 
     result = serialize_config(ep_config)
+    ep_config.engine.shutdown()
 
     # Objects with a __dict__ attr are expanded
     assert "type" in result["engine"]["executor"]["provider"]

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -69,13 +69,12 @@ def test_singularity(gce_factory, randomstring):
 
 
 def test_custom_missing_options(tmp_path):
+    gce = GlobusComputeEngine(
+        address="::1", max_workers_per_node=1, label="GCE_TEST", container_type="custom"
+    )
     with pytest.raises(AssertionError) as pyt_e:
-        GlobusComputeEngine(
-            address="::1",
-            max_workers_per_node=1,
-            label="GCE_TEST",
-            container_type="custom",
-        ).start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+        gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    gce.shutdown()
     assert "container_cmd_options is required" in str(pyt_e.value)
 
 


### PR DESCRIPTION
Pay attention to the recent change to start the JSP thread during intialization.  It was clearer organization, but means that we now need to ensure that we also shutdown the thread.  This usually means shutting down the engine, often "hidden" as part of the configuration, even though we didn't start the interchange.

## Type of change

- Code maintenance/cleanup
