### PR TITLE
Fix default engine type

### DIFF
--- a/changelog.d/20250207_160227_30907815+rjmello_fix_default_engine.rst
+++ b/changelog.d/20250207_160227_30907815+rjmello_fix_default_engine.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- The default engine is now ``GlobusComputeEngine`` when the engine ``type`` field is not specified.
+  Previously, the default was ``HighThroughputEngine``, which was removed in version ``3.0.0``.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -68,7 +68,7 @@ class ProviderModel(BaseConfigModel):
 
 
 class EngineModel(BaseConfigModel):
-    type: str = "HighThroughputEngine"
+    type: str = "GlobusComputeEngine"
     provider: t.Optional[ProviderModel]
     strategy: t.Optional[str]
     address: t.Optional[t.Union[str, AddressModel]]

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -244,16 +244,3 @@ def serde():
 @pytest.fixture
 def ez_pack_task(serde, task_uuid, container_uuid):
     return create_task_packer(serde, task_uuid, container_uuid)
-
-
-@pytest.fixture
-def htex_warns():
-    with pytest.warns(DeprecationWarning) as pyt_w:
-        yield
-
-    def _warned(msg: str) -> bool:
-        test = "HighThroughputEngine is deprecated" in msg
-        test &= "Please use GlobusComputeEngine instead" in msg
-        return test
-
-    assert any(_warned(str(w)) for w in pyt_w.list)

--- a/smoke_tests/tests/sh/test_endpoint.sh
+++ b/smoke_tests/tests/sh/test_endpoint.sh
@@ -42,7 +42,7 @@ cat > "$conf_dir/config.yaml" <<EOF
 environment: $env
 detach_endpoint: False
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     heartbeat_period: 10
     provider:
         type: LocalProvider


### PR DESCRIPTION
# Description

The default engine is now `GlobusComputeEngine` when the engine `type` is not specified. Previously, the default was `HighThroughputEngine`, which was removed in version `3.0.0`.

## Type of change

- Bug fix (non-breaking change that fixes an issue)