### PR TITLE
Add total tasks count to GCEngine status report

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -479,6 +479,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             "idle_workers": self.get_total_idle_workers(managers=managers),
             "pending_tasks": self.get_total_tasks_pending(managers=managers),
             "outstanding_tasks": self.get_total_tasks_outstanding()["RAW"],
+            "total_tasks": self.executor._task_counter,
             "scaling_enabled": self.scaling_enabled,
             "mem_per_worker": self.executor.mem_per_worker,
             "cores_per_worker": self.executor.cores_per_worker,

--- a/compute_endpoint/tests/unit/engine/test_globuscompute.py
+++ b/compute_endpoint/tests/unit/engine/test_globuscompute.py
@@ -84,6 +84,7 @@ def test_status_report_content(htex, mock_managers):
 
     assert "pending_tasks" in sr.global_state
     assert "outstanding_tasks" in sr.global_state
+    assert "total_tasks" in sr.global_state
     assert "scaling_enabled" in sr.global_state
     assert "mem_per_worker" in sr.global_state
     assert "cores_per_worker" in sr.global_state


### PR DESCRIPTION
# Description

This indicates the total number of tasks that the `GlobusComputeEngine` has submitted to its underlying `HighThroughputExecutor`.

## Type of change

- New feature (non-breaking change that adds functionality)
