### PR TITLE
Include python version in endpoint registration

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import pathlib
+import platform
 import pwd
 import re
 import shutil
@@ -890,6 +891,7 @@ class Endpoint:
     def get_metadata(config: UserEndpointConfig) -> dict:
         metadata: dict = {
             "endpoint_version": __version__,
+            "python_version": platform.python_version(),
             "hostname": socket.getfqdn(),
             # should be more accurate than `getpass.getuser()` in non-login situations
             "local_user": pwd.getpwuid(os.getuid()).pw_name,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import pathlib
+import platform
 import pwd
 import queue
 import re
@@ -342,6 +343,7 @@ class EndpointManager:
         user_config_template, user_config_schema = load_user_config_template(conf_dir)
         return {
             "endpoint_version": __version__,
+            "python_version": platform.python_version(),
             "hostname": socket.getfqdn(),
             "local_user": pwd.getpwuid(os.getuid()).pw_name,
             "config": serialize_config(config),

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -430,6 +430,7 @@ def test_pid_file_check(pid_info, fs):
 def test_endpoint_get_metadata(mocker, engine_cls):
     mock_data = {
         "endpoint_version": "106.7",
+        "python_version": "3.12.7",
         "hostname": "oneohtrix.never",
         "local_user": "daniel",
     }
@@ -438,6 +439,7 @@ def test_endpoint_get_metadata(mocker, engine_cls):
         "globus_compute_endpoint.endpoint.endpoint.__version__",
         mock_data["endpoint_version"],
     )
+    mocker.patch("platform.python_version", return_value=mock_data["python_version"])
 
     mock_fqdn = mocker.patch("globus_compute_endpoint.endpoint.endpoint.socket.getfqdn")
     mock_fqdn.return_value = mock_data["hostname"]

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -550,6 +550,7 @@ def test_sends_data_during_registration(
 
     expected_keys = {
         "endpoint_version",
+        "python_version",
         "hostname",
         "local_user",
         "config",


### PR DESCRIPTION
# Description

We now include the python version in the endpoint registration metadata along with the endpoint version and SDK version.

## Type of change

- New feature (non-breaking change that adds functionality)
