### PR TITLE
Bugfix: start JobStatusPoller at engine start

### DIFF
--- a/changelog.d/20250213_000051_kevin_delay_start_jsp_thread.rst
+++ b/changelog.d/20250213_000051_kevin_delay_start_jsp_thread.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fix bug introduced in :ref:`v3.1.0 <changelog-3.1.0>` that prevented the
+  |GlobusComputeEngine| from processing tasks if the endpoint was daemonized
+  (see: |detach_endpoint| configuration option)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2800,6 +2800,7 @@ New Functionality
 .. |ShellFunction| replace:: :class:`ShellFunction <globus_compute_sdk.sdk.shell_function.ShellFunction>`
 .. |UserRuntime| replace:: :class:`UserRuntime <globus_compute_sdk.sdk.batch.UserRuntime>`
 
+.. |detach_endpoint| replace:: :class:`detach_endpoint <globus_compute_endpoint.endpoint.config.config.UserEndpointConfig>`
 .. |GlobusComputeEngine| replace:: :class:`GlobusComputeEngine <globus_compute_endpoint.engines.globus_compute.GlobusComputeEngine>`
 .. |GlobusMPIEngine| replace:: :class:`GlobusMPIEngine <globus_compute_endpoint.engines.globus_mpi.GlobusMPIEngine>`
 


### PR DESCRIPTION
The recent refactor to move the JobStatusPoller thread initialization to the `GlobusComputeEngine.__init__` method missed that endpoints are often daemonized.  Daemonization only allows the fork()ing thread to survive.

Fix: Move the JSP thread creation back to the GCE's `.start()` method, since this method is invoked *after* the daemonization.  This time, cement the expectation with a test.

Reference:

    - #1779 (as part of [sc-37953])
    - 393b41002f417a05be878ece2e010fef11259ae2

## Type of change

- Bug fix (non-breaking change that fixes an issue)