### PR TITLE
Enforce encryption in high assurance endpoints

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -371,6 +371,19 @@ class Endpoint:
             log.critical(msg)
             raise ValueError(msg)
 
+        if endpoint_config.high_assurance:
+            try:
+                endpoint_config.engine.assert_ha_compliant()
+            except Exception as e:
+                log.critical(
+                    "Engine configuration is not High Assurance compliant:\n%s",
+                    str(e),
+                )
+                raise ValueError(
+                    "Engine configuration is not High Assurance compliant."
+                    "  Endpoint will not start."
+                ) from e
+
         pid_check = Endpoint.check_pidfile(endpoint_dir)
         # if the pidfile exists, we should return early because we don't
         # want to attempt to create a new daemon when one is already

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -91,6 +91,18 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         self._engine_ready: bool = False
 
     @abstractmethod
+    def assert_ha_compliant(self):
+        """
+        Signal to endpoint initialization code whether or not this engine, in its
+        current configuration, complies with Globus's High Assurance policies. This
+        must be evaluated on a case-by-case basis. Some example criteria:
+
+        * All manager-worker communication happens within one host machine
+        * Network traffic is encrypted
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def start(
         self,
         *args,

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -158,6 +158,13 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.job_status_poller: JobStatusPoller | None = None
         # N.B. call `.add_executor()` *after* starting executor; see .start()
 
+    def assert_ha_compliant(self):
+        if not self.encrypted:
+            raise ValueError(
+                "High-Assurance GlobusComputeEngines must enable the"
+                " `encrypted` configuration value"
+            )
+
     @property
     def max_workers_per_node(self):
         # Needed for strategies (e.g., SimpleStrategy)

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -37,6 +37,10 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
             allowed_serializers=allowed_serializers,
         )
 
+    def assert_ha_compliant(self):
+        # HA compliant by default
+        pass
+
     def start(
         self,
         *args,

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -35,6 +35,10 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
             allowed_serializers=allowed_serializers,
         )
 
+    def assert_ha_compliant(self):
+        # HA compliant by default
+        pass
+
     def start(
         self,
         *args,


### PR DESCRIPTION
# Description

[[sc-35311]](https://app.shortcut.com/globus/story/35311/ha-endpoints-should-enforce-zmq-encryption)

## Type of change

- New feature (non-breaking change that adds functionality)