### PR TITLE
Fix some typos

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -242,7 +242,7 @@ def _shell_escape_filter(val):
 
 def load_user_config_template(endpoint_dir: pathlib.Path) -> tuple[str, dict | None]:
     # Reminder: this method _reads from the filesystem_, so will need appropriate
-    # priviliges.  Per sc-28360, separate out from the rendering so that we can
+    # privileges.  Per sc-28360, separate out from the rendering so that we can
     # load the file data into a string before dropping privileges.
     from globus_compute_endpoint.endpoint.endpoint import Endpoint
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -250,7 +250,7 @@ class Endpoint:
         # taking the basename, ensuring it's not Unix hidden (initial dot [.]), and
         # has no whitespace.  The path name is used deep within Parsl, which uses
         # raw shell to perform some actions ... and is not robust about it at all.
-        # The path of least resistence, then, is to restrict this EP name upfront.
+        # The path of least resistance, then, is to restrict this EP name upfront.
         # Examples:
         #
         # Good: "nice_normal_name"
@@ -265,8 +265,8 @@ class Endpoint:
         # Bad: "/absolute_path"
         # Bad: "contains...\r\v\t\n...other_whitespace"
         # Bad: "we_\\_do_not_accept_escapes"
-        # Bad: "we_don't_accept_single_qoutes"
-        # Bad: 'we_do_not_accept_"double_qoutes"'
+        # Bad: "we_don't_accept_single_quotes"
+        # Bad: 'we_do_not_accept_"double_quotes"'
         err_msg = "Invalid endpoint name: "
         pathname_re = re.compile(r"[\\/\s'\"]")
         if not path_name:
@@ -663,7 +663,7 @@ class Endpoint:
         pid = int(pid_path.read_text().strip())
         try:
             log.debug(f"Signaling process: {pid}")
-            # For all the processes, including the deamon and its descendants,
+            # For all the processes, including the daemon and its descendants,
             # send SIGTERM, wait for 10s, and then SIGKILL any still alive.
             grace_period_s = 10
             parent = psutil.Process(pid)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -549,7 +549,7 @@ class EndpointManager:
                 ids = userinfo["identity_set"]
                 parent_identities.update(ident["sub"] for ident in ids)
                 log.debug(
-                    "User-endpoint start requests are valid from identites: %s",
+                    "User-endpoint start requests are valid from identities: %s",
                     parent_identities,
                 )
                 del gcc, client_options, ids

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -174,7 +174,7 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         Callback to post result to the passthrough queue
         Parameters
         ----------
-        future: Future for which the callback is triggerd
+        future: Future for which the callback is triggered
         """
 
         exec_beg = TaskTransition(  # Reminder: used by *closure*, below

--- a/compute_endpoint/tests/integration/test_rabbit_mq/result_queue_subscriber.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/result_queue_subscriber.py
@@ -115,7 +115,7 @@ class ResultQueueSubscriber(threading.Thread):
     def _on_channel_closed(self, channel, exception):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an EXCHANGE_NAME or queue with
+        violates the protocol, such as redeclare an EXCHANGE_NAME or queue with
         different parameters. In this case, we'll close the connection
         to shutdown the object.
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -357,7 +357,7 @@ class Client:
         .. |REPL| replace:: :abbr:`REPL (Read-Eval-Print Loop)`
         .. _REPL: https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop
 
-        :param task_id: a task identifer, as returned a submission to the web-service
+        :param task_id: a task identifier, as returned a submission to the web-service
         :return: a dictionary containing the task status and result information
         :raises: If task failed, the task exception (reconstituted from remote source)
         """
@@ -433,7 +433,7 @@ class Client:
                     results[task_id] = self._update_task_table(task, task_id)
                 except Exception:
                     logger.exception(
-                        "Failure while unpacking results fom get_batch_result"
+                        "Failure while unpacking results from get_batch_result"
                     )
 
         return results

--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -480,7 +480,7 @@ def run_all_diags_wrapper(
             out_bytes = "".join(diagnostic_output).encode()
             f_out.write(out_bytes)
 
-        print(f"Compressed diagnostic output successfully writen to {zip_filename}")
+        print(f"Compressed diagnostic output successfully written to {zip_filename}")
 
 
 def do_diagnostic_base(diagnostic_args):

--- a/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
@@ -52,7 +52,7 @@ def get_env_details() -> t.Dict[str, t.Any]:
 def check_version(task_details: dict | None, check_py_micro: bool = True) -> str | None:
     """
     This method adds an optional string to some Exceptions below to
-    warn of differing environments as a possible cause.  It is pre-pended
+    warn of differing environments as a possible cause.  It is prepended
 
     :param task_details:    Task details from worker environment
     :param check_py_minor:  Whether Python micro version mismatches should

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -329,8 +329,8 @@ def test_diagnostic_gzip(
         assert len(captured_stdout) == 2
 
     assert captured_stdout[-2].startswith(
-        "Compressed diagnostic output successfully written "
-        "to globus_compute_diagnostic_"
+        "Compressed diagnostic output successfully written"
+        " to globus_compute_diagnostic_"
     )
     # Ends with line break
     assert not captured_stdout[-1]

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -329,7 +329,8 @@ def test_diagnostic_gzip(
         assert len(captured_stdout) == 2
 
     assert captured_stdout[-2].startswith(
-        "Compressed diagnostic output successfully writen to globus_compute_diagnostic_"
+        "Compressed diagnostic output successfully written "
+        "to globus_compute_diagnostic_"
     )
     # Ends with line break
     assert not captured_stdout[-1]

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -935,7 +935,7 @@ def test_reload_sets_failed_tasks(gce: Executor):
     assert all("doh!" in str(fut.exception()) for fut in futs)
 
 
-def test_reload_handles_deseralization_error_gracefully(gce: Executor):
+def test_reload_handles_deserialization_error_gracefully(gce: Executor):
     gcc = gce.client
     gcc.fx_serializer = ComputeSerializer()
 

--- a/compute_sdk/tests/unit/test_version_parse.py
+++ b/compute_sdk/tests/unit/test_version_parse.py
@@ -13,7 +13,7 @@ from globus_compute_sdk.version import compare_versions
         ("1.2.3-dev", "1.2.3", True),
         ("1.2.3a1", "1.2.3-dev", True),
         ("1.2.3-dev", "1.2.3b2", True),
-        # dev versions take a back-seat to mistmatched MAJOR.MINOR.PATCH
+        # dev versions take a back-seat to mismatched MAJOR.MINOR.PATCH
         ("1.2.3", "1.2.4-dev", False),  # dev vs non-pre
     ],
 )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -161,7 +161,7 @@ New Functionality
 
   As authentication is implemented via Globus Auth and identity mapping, the
   Globus Compute Endpoint does not implement the authorization or password
-  managment phases of PAM.  It implements account
+  management phases of PAM.  It implements account
   (|pam_acct_mgmt(3)|_) and session (|pam_open_session(3)|) management.
 
   For more information, consult :ref:`the PAM section <pam>` of the
@@ -1423,7 +1423,7 @@ Deprecated
 - The ``HighThroughputExecutor`` is now marked for deprecation.
   Importing and using this class will raise a warning.
   Upgrade to the ``globus_compute_endpoint.engines.GlobusComputeEngine`` which
-  supercedes the ``HighThroughputExecutor``.
+  supersedes the ``HighThroughputExecutor``.
 
   Please note that the |GlobusComputeEngine| has the following limitations:
 
@@ -1672,7 +1672,7 @@ Bug Fixes
 Security
 ^^^^^^^^
 
-- Previously, the main configuraton directory (typically ``~/.funcx/``) would
+- Previously, the main configuration directory (typically ``~/.funcx/``) would
   be created honoring the users umask, typically resulting in
   world-readability.  In a typical administration, this may be mitigated by
   stronger permissions on the user's home directory, but still isn't robust.
@@ -2177,7 +2177,7 @@ Changed
 
 - Endpoint logs have been reduced in verbosity. A number of noisy log lines have been
   lowered to TRACE level. [PREFIXES] have been removed from many messages as they
-  contain information more reliably availale in log metadata.
+  contain information more reliably available in log metadata.
 
 - `FuncXExecutor <https://funcx.readthedocs.io/en/latest/executor.html>`_
   now uses batched submission by default.  This typically significantly
@@ -2248,7 +2248,7 @@ New Functionality
 
 - Capture, log, and report execution time information. The time a function takes to execute is now logged in worker debug logs and reported to the funcX service.
 
-- Added Helm options to specify Kuberenetes workerDebug, imagePullSecret and maxIdleTime values.
+- Added Helm options to specify Kubernetes workerDebug, imagePullSecret and maxIdleTime values.
 
 Changed
 ^^^^^^^

--- a/docs/endpoints/configs/polaris.yaml
+++ b/docs/endpoints/configs/polaris.yaml
@@ -16,7 +16,7 @@ engine:
 
     launcher:
       type: MpiExecLauncher
-      # Ensures 1 manger per node, work on all 64 cores
+      # Ensures 1 manager per node, work on all 64 cores
       bind_cmd: --cpu-bind
       overrides: --depth=64 --ppn 1
 

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -471,7 +471,7 @@ Every template also has access to the following variables:
   submitting the task request, such as Python version. See |UserRuntime| for a complete
   list of available information.
 
-These are reserved words and their values cannot be overidden by the user or admin,
+These are reserved words and their values cannot be overridden by the user or admin,
 and an error is thrown if a user tries to send it as a user option:
 
 .. code-block:: python
@@ -1265,7 +1265,7 @@ Administrator Quickstart
       ========== Endpoint Manager begins: 1ed568ab-79ec-4f7c-be78-a704439b2266
               >>> Multi-User Endpoint ID: 1ed568ab-79ec-4f7c-be78-a704439b2266 <<<
 
-   Additionally, for even noiser output, there is ``--debug``.
+   Additionally, for even noisier output, there is ``--debug``.
 
 #. When ready to install as an on-boot service, install it with a ``systemd`` unit file:
 

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -358,7 +358,7 @@ Endpoint when using the SDK to submit new functions.
 
 The serialization/deserialization mechanics in Python and the pickle/dill
 libraries are implemented at the bytecode level and have evolved extensively
-over time.  There is no backward/forward compatability guarantee between
+over time.  There is no backward/forward compatibility guarantee between
 versions.  Thus a function serialized in an older version of Python or dill
 may not deserialize correctly in later versions, and the opposite is even more
 problematic.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -126,7 +126,7 @@ arbitrary arguments and returned parameters. Globus Compute will
 serialize any ``*args`` and ``**kwargs`` when executing a function and
 it will serialize any return parameters or exceptions.
 
-Note: Globus Compute uses standard Python serilaization libraries (i.e.,
+Note: Globus Compute uses standard Python serialization libraries (i.e.,
 Dill). It also limits the size of input arguments and returned
 parameters to 10 MB. For larger input or output data we suggest using
 Globus.
@@ -235,7 +235,7 @@ square with side length :math:`2r`, the area of the circle is
 :math:`\pi r^2` and the area of the square is :math:`(2r)^2`. Thus, if
 :math:`N` uniformly-distributed points are dropped at random locations
 within the square, approximately :math:`N\pi/4` will be inside the
-circle and therfore we can estimate the value of :math:`\pi`.
+circle and therefore we can estimate the value of :math:`\pi`.
 
 .. code:: python
 


### PR DESCRIPTION
# Description

The typos were caught when reading the documentation [[link to typo that caught my eye](https://globus-compute.readthedocs.io/en/latest/tutorial.html#:~:text=standard%20python%20serilaization%20libraries)], and subsequently by running codespell and typos against the docs and code directories.

Note that a line in `test_diagnostic.py` had to be reflowed because flake8 complained about the line length after adding a 't' to "writen".

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
