### PR TITLE
Add manager EP and SDK versions to status report 

### DIFF
--- a/changelog.d/20250218_125140_30907815+rjmello_bump_parsl.rst
+++ b/changelog.d/20250218_125140_30907815+rjmello_bump_parsl.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency to `2025.2.17 <https://pypi.org/project/parsl/2025.2.17/>`_.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -306,6 +306,15 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         """
         return self.executor.connected_managers()
 
+    def get_connected_managers_packages(self) -> t.Dict[str, t.Dict[str, str]]:
+        """
+        Returns
+        -------
+        Dict mapping each connected manager ID to a dict of installed packages
+        and versions
+        """
+        return self.executor.connected_managers_packages()
+
     def get_total_managers(self, managers: t.List[t.Dict[str, t.Any]]) -> int:
         """
         Parameters
@@ -471,14 +480,17 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         Object containing info on the current status of the endpoint
         """
         managers = self.get_connected_managers()
-
+        managers_packages = self.get_connected_managers_packages()
         manager_info: dict[str, list] = {}
         for m in managers:
             jid = self.executor.blocks_to_job_id[m["block_id"]]
+            packages = managers_packages[m["manager"]]
             m_info = {
                 "worker_count": m["worker_count"],
                 "idle_duration": m["idle_duration"],
                 "parsl_version": m["parsl_version"],
+                "endpoint_version": packages.get("globus-compute-endpoint"),
+                "sdk_version": packages.get("globus-compute-sdk"),
                 "python_version": m["python_version"],
             }
             manager_info.setdefault(jid, []).append(m_info)

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl>=2025.1.6,<=2025.1.20",
+    "parsl==2025.2.17",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
# Description

We utilize the Parsl HTEX `connected_managers_packages()` method to retrieve the installed versions of `globus-compute-endpoint` and `globus-compute-sdk` running on each connected worker manager, then add them to the status report.

[sc-39409](https://app.shortcut.com/globus/story/39409/add-worker-endpoint-version-to-ep-status-and-console-api)

## Type of change

- New feature (non-breaking change that adds functionality)
