### PR TITLE
Minor Perlmutter example update.

### DIFF
--- a/docs/endpoints/configs/perlmutter.yaml
+++ b/docs/endpoints/configs/perlmutter.yaml
@@ -19,7 +19,7 @@ engine:
 
         # string to prepend to #SBATCH blocks in the submit
         # script to the scheduler
-        # For GPUs in the debug qos eg: "#SBATCH --constraint=gpu"
+        # For GPUs in the debug qos eg: "#SBATCH --constraint=gpu\n#SBATCH --gpus-per-node=4"
         scheduler_options: {{ OPTIONS }}
 
         # Your NERSC account, eg: "m0000"


### PR DESCRIPTION
# Description

Includes the gpus-per-node flag in the scheduler options comment. This flag is needed for the workers to be able to access the gpus on the node.

## Type of change
- Documentation update
