### PR TITLE
Serialization strategy list/map cleanup

### DIFF
--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -13,10 +13,16 @@ class SerializationStrategy(ABC):
     arguments into string data and back again.
     """
 
+    _CACHE: t.ClassVar[t.Dict[str, "SerializationStrategy"]] = {}
+
     def __init_subclass__(cls):
         super().__init_subclass__()
         if len(cls.identifier) != IDENTIFIER_LENGTH:
             raise ValueError(f"Identifiers must be {IDENTIFIER_LENGTH} characters long")
+        if cls.identifier[-1] != "\n":
+            raise ValueError("Identifiers must end with a newline character")
+
+        SerializationStrategy._CACHE[cls.identifier] = cls()
 
     #: The unique, 3-character string that identifies this strategy. The first two
     #: characters are the effective identifier; the third must always be the newline
@@ -28,6 +34,10 @@ class SerializationStrategy(ABC):
     #: Note that a single ``SerializationStrategy`` cannot support both callables and
     #: non-callables.
     for_code: t.ClassVar[bool]
+
+    @classmethod
+    def get_cached(cls, identifier: str) -> t.Optional["SerializationStrategy"]:
+        return cls._CACHE.get(identifier)
 
     @abstractmethod
     def serialize(self, data: t.Any) -> str:

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -152,6 +152,8 @@ class PickleCode(SerializationStrategy):
     :meta private:
     """
 
+    _DEPRECATED = True
+
     identifier = "02\n"  #:
     for_code = True  #:
 
@@ -308,23 +310,10 @@ class CombinedCode(SerializationStrategy):
         raise DeserializationError(f"Deserialization failed after {count} tries")
 
 
-STRATEGIES_MAP: dict[str, t.Type[SerializationStrategy]] = {
-    DillDataBase64.identifier: DillDataBase64,
-    JSONData.identifier: JSONData,
-    DillCodeSource.identifier: DillCodeSource,
-    DillCode.identifier: DillCode,
-    DillCodeTextInspect.identifier: DillCodeTextInspect,
-    PickleCode.identifier: PickleCode,
-    CombinedCode.identifier: CombinedCode,
-}
-
-SELECTABLE_STRATEGIES: list[type[SerializationStrategy]] = [
-    DillDataBase64,
-    JSONData,
-    DillCodeSource,
-    DillCode,
-    DillCodeTextInspect,
-    CombinedCode,
+SELECTABLE_STRATEGIES = [
+    t.__class__
+    for t in SerializationStrategy._CACHE.values()
+    if not getattr(t, "_DEPRECATED", False)
 ]
 
 #: The *code* serialization strategy used by :class:`ComputeSerializer`

--- a/compute_sdk/globus_compute_sdk/serialize/facade.py
+++ b/compute_sdk/globus_compute_sdk/serialize/facade.py
@@ -17,7 +17,6 @@ from globus_compute_sdk.serialize.concretes import (
     DEFAULT_STRATEGY_CODE,
     DEFAULT_STRATEGY_DATA,
     SELECTABLE_STRATEGIES,
-    STRATEGIES_MAP,
 )
 
 logger = logging.getLogger(__name__)
@@ -160,11 +159,6 @@ class ComputeSerializer:
 
         self.allowed_deserializer_types = parse_allowlist(allowed_deserializer_types)
 
-        self.strategies = {
-            header: strategy_class()
-            for header, strategy_class in STRATEGIES_MAP.items()
-        }
-
     def serialize(self, data: t.Any) -> str:
         """
         Converts Python data to a string representation, using this serializer's
@@ -203,7 +197,7 @@ class ComputeSerializer:
             with an allowed strategy.
         """
         header = payload[:IDENTIFIER_LENGTH]
-        strategy = self.strategies.get(header)
+        strategy = SerializationStrategy.get_cached(header)
 
         if not strategy:
             raise DeserializationError(f"Invalid header: {header} in data payload")


### PR DESCRIPTION
# Description

Create serialization strategy cache automatically on class init. Also derive selectable strategy list from properties on the class, rather than creating it ad-hoc later.

## Type of change

- Code maintenance/cleanup
