### PR TITLE
Add source code serializers that skip dill entirely

### DIFF
--- a/changelog.d/20250227_143258_chris_pure_source_serde.rst
+++ b/changelog.d/20250227_143258_chris_pure_source_serde.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added two new serialization strategies,
+  :class:`~globus_compute_sdk.serialize.PureSourceTextInspect` and
+  :class:`~globus_compute_sdk.serialize.PureSourceDill`, which serialize functions as
+  raw source code strings (avoiding ``dill`` bytecode serialization entirely).

--- a/compute_sdk/globus_compute_sdk/serialize/__init__.py
+++ b/compute_sdk/globus_compute_sdk/serialize/__init__.py
@@ -8,6 +8,8 @@ from globus_compute_sdk.serialize.concretes import (
     DillCodeTextInspect,
     DillDataBase64,
     JSONData,
+    PureSourceDill,
+    PureSourceTextInspect,
 )
 from globus_compute_sdk.serialize.facade import AllowlistWildcard, ComputeSerializer
 
@@ -22,6 +24,8 @@ __all__ = [
     "DillCode",
     "DillCodeSource",
     "DillCodeTextInspect",
+    "PureSourceDill",
+    "PureSourceTextInspect",
     "DillDataBase64",
     "JSONData",
 ]

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -310,6 +310,86 @@ class CombinedCode(SerializationStrategy):
         raise DeserializationError(f"Deserialization failed after {count} tries")
 
 
+class PureSourceTextInspect(SerializationStrategy):
+    """
+    Extracts a function's definition via :func:`inspect.getsource` and sends the
+    resulting string directly over the wire.
+
+    .. list-table:: Supports
+        :header-rows: 1
+        :align: center
+
+        * - Functions defined in Python interpreter
+          - Code from notebooks
+          - Interop between mismatched Python versions
+          - Decorated functions
+        * - ❌
+          - ✅
+          - ⚠️
+          - ❌
+    """
+
+    identifier = "st\n"
+    for_code = True
+
+    _separator = ":"
+
+    def serialize(self, data) -> str:
+        ":meta private:"
+        name = data.__name__
+        body = inspect.getsource(data)
+        x = name + self._separator + body
+        return self.identifier + x
+
+    def deserialize(self, payload: str):
+        ":meta private:"
+        chomped = self.chomp(payload)
+        name, body = chomped.split(self._separator, 1)
+        exec_ns: dict = {}
+        exec(body, exec_ns)
+        return exec_ns[name]
+
+
+class PureSourceDill(SerializationStrategy):
+    """
+    Extracts a function's definition via |dill.getsource|_ and sends the resulting
+    string directly over the wire.
+
+    .. list-table:: Supports
+        :header-rows: 1
+        :align: center
+
+        * - Functions defined in Python interpreter
+          - Code from notebooks
+          - Interop between mismatched Python versions
+          - Decorated functions
+        * - ✅
+          - ❌
+          - ⚠️
+          - ❌
+    """
+
+    identifier = "sd\n"
+    for_code = True
+
+    _separator = ":"
+
+    def serialize(self, data) -> str:
+        ":meta private:"
+        name = data.__name__
+        body = dill.source.getsource(data, lstrip=True)
+        x = name + self._separator + body
+        return self.identifier + x
+
+    def deserialize(self, payload: str):
+        ":meta private:"
+        chomped = self.chomp(payload)
+        name, body = chomped.split(self._separator, 1)
+        exec_ns: dict = {}
+        exec(body, exec_ns)
+        return exec_ns[name]
+
+
 SELECTABLE_STRATEGIES = [
     t.__class__
     for t in SerializationStrategy._CACHE.values()


### PR DESCRIPTION
# Description

Comes from some inter-related thoughts:

* Both of the existing "source code" strategies involve a `dill` bytecode step, suggesting we're introducing unnecessary room for Python version mismatch errors.
* Admins have asked about source code auditing, which is possible but mildly tricky with the existing strategies.
* Pickle is insecure, and some admins would appreciate the ability to prevent any pickle deserialization whatsoever.

These new serialization strategies simply extract the source and send that directly. (They also append that string with the name of the function for ease of deserialization.)

### Food for thought: if this covers all situations that the existing code strategies do while avoiding more Python version mismatch errors, do we deprecate the old ones?

I'd like to see this out in the wild first before making that decision, of course.

## Type of change

- New feature (non-breaking change that adds functionality)
