### PR TITLE
(Re-)Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -78,7 +78,7 @@ jobs:
         options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/20250205_154700_chris_re_python_313.rst
+++ b/changelog.d/20250205_154700_chris_re_python_313.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The ``globus-compute-sdk`` and ``globus-compute-endpoint`` packages now support
+  Python version 3.13.

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{312,311,310,39}
+envlist = py{313,312,311,310,39}
 skip_missing_interpreters = true
 
 [testenv]

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{312,311,310,39}
+envlist = py{313,312,311,310,39}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
# Description

Was finally able to test on ARM hardware after Kevin's thread rework in #1779, and everything looks good in Py3.13 land. This just adds 3.13 back to test matrices.

[[sc-37235]](https://app.shortcut.com/globus/story/37235/add-support-for-recent-python-versions-to-compute-sdk-endpoint)

## Type of change

- New feature (non-breaking change that adds functionality)
