### PR TITLE
Enable custom user config template and schema paths

### DIFF
--- a/changelog.d/20250304_000638_30907815+rjmello_template_dir_sc_39429.rst
+++ b/changelog.d/20250304_000638_30907815+rjmello_template_dir_sc_39429.rst
@@ -1,0 +1,11 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Multi-user endpoint administrators can now specify custom user configuration
+  template and schema paths with the ``user_config_template_path`` and
+  ``user_config_schema_path`` configuration options.
+
+  .. code-block:: yaml
+     multi_user: true
+     user_config_template_path: /path/to/my_template.yaml.j2
+     user_config_schema_path: /path/to/my_schema.json

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -353,6 +353,12 @@ class ManagerEndpointConfig(BaseConfig):
            Do not use this flag as a means of security.  It controls *visibility* in
            the web user interface.  It does **not control access** to the endpoint.
 
+    :param user_config_template_path: Path to the user configuration template file for
+        this endpoint. If not specified, the default template path will be used.
+
+    :param user_config_schema_path: Path to the user configuration schema file for this
+        endpoint. If not specified, the default schema path will be used.
+
     :param identity_mapping_config_path: Path to the identity mapping configuration for
         this endpoint.  If the process is not privileged, a warning will be emitted to
         the logs and this item will be ignored; conversely, if privileged, this
@@ -393,6 +399,8 @@ class ManagerEndpointConfig(BaseConfig):
         self,
         *,
         public: bool = False,
+        user_config_template_path: os.PathLike | str | None = None,
+        user_config_schema_path: os.PathLike | str | None = None,
         identity_mapping_config_path: os.PathLike | str | None = None,
         pam: PamConfiguration | None = None,
         force_mu_allow_same_user: bool = False,
@@ -407,10 +415,32 @@ class ManagerEndpointConfig(BaseConfig):
         self.force_mu_allow_same_user = force_mu_allow_same_user is True
         self.mu_child_ep_grace_period_s = mu_child_ep_grace_period_s
 
+        _tmp = user_config_template_path  # work with both mypy and flake8
+        self.user_config_template_path = _tmp  # type: ignore[assignment]
+
+        _tmp = user_config_schema_path  # work with both mypy and flake8
+        self.user_config_schema_path = _tmp  # type: ignore[assignment]
+
         _tmp = identity_mapping_config_path  # work with both mypy and flake8
         self.identity_mapping_config_path = _tmp  # type: ignore[assignment]
 
         self.pam = pam or PamConfiguration(enable=False)
+
+    @property
+    def user_config_template_path(self) -> pathlib.Path | None:
+        return self._user_config_template_path
+
+    @user_config_template_path.setter
+    def user_config_template_path(self, val: os.PathLike | str | None):
+        self._user_config_template_path = pathlib.Path(val) if val else None
+
+    @property
+    def user_config_schema_path(self) -> pathlib.Path | None:
+        return self._user_config_schema_path
+
+    @user_config_schema_path.setter
+    def user_config_schema_path(self, val: os.PathLike | str | None):
+        self._user_config_schema_path = pathlib.Path(val) if val else None
 
     @property
     def identity_mapping_config_path(self) -> pathlib.Path | None:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -139,6 +139,8 @@ class UserEndpointConfigModel(BaseEndpointConfigModel):
 
 class ManagerEndpointConfigModel(BaseEndpointConfigModel):
     public: t.Optional[bool]
+    user_config_template_path: t.Optional[FilePath]
+    user_config_schema_path: t.Optional[FilePath]
     identity_mapping_config_path: t.Optional[FilePath]
     force_mu_allow_same_user: t.Optional[bool]
     mu_child_ep_grace_period_s: t.Optional[float]

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -52,6 +52,8 @@ known_manager_config_opts = {
     "heartbeat_period": int,
     "debug": True,
     "public": True,
+    "user_config_template_path": os.PathLike,
+    "user_config_schema_path": os.PathLike,
     "identity_mapping_config_path": os.PathLike,
     "pam": PamConfiguration,
     "force_mu_allow_same_user": True,
@@ -73,7 +75,7 @@ def get_random_of_datatype_impl(cls):
     elif issubclass(cls, os.PathLike):
         # use an invalid path to guarantee test is run under fs fixture
         p = pathlib.Path("/asadf/asdf/fake/filesystem/dir")
-        p.mkdir(parents=True)
+        p.mkdir(parents=True, exist_ok=True)
         p = p / "Some Test File"
         p.touch()
         return str(p)

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -19,12 +19,7 @@ import pytest
 import requests
 from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import UserEndpointConfig
-from globus_compute_endpoint.endpoint.config.utils import (
-    get_config,
-    load_user_config_template,
-    render_config_user_template,
-    serialize_config,
-)
+from globus_compute_endpoint.endpoint.config.utils import serialize_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.engines import (
     GlobusComputeEngine,
@@ -542,16 +537,6 @@ def test_mu_endpoint_user_ep_yamls_world_readable(tmp_path):
         assert p.exists()
         assert p.stat().st_mode & 0o444 == 0o444, "Minimum world readable"
     assert ep_dir.stat().st_mode & 0o111 == 0o111, "Minimum world executable"
-
-
-def test_mu_endpoint_user_ep_sensible_default(tmp_path):
-    ep_dir = tmp_path / "new_endpoint_dir"
-    Endpoint.init_endpoint_dir(ep_dir, multi_user=True)
-    parent_cfg = get_config(ep_dir)
-
-    tmpl_str, schema = load_user_config_template(ep_dir)
-    # Doesn't crash; loads yaml, jinja template has defaults
-    render_config_user_template(parent_cfg, tmpl_str, schema, {})
 
 
 def test_always_prints_endpoint_id_to_terminal(

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -523,6 +523,37 @@ def test_handles_provided_endpoint_id_with_json(
     assert k["endpoint_id"] == ep_uuid
 
 
+@pytest.mark.parametrize("custom_template_path", (True, False))
+@pytest.mark.parametrize("custom_schema_path", (True, False))
+def test_sets_user_config_template_and_schema_path(
+    mock_client: t.Tuple[uuid.UUID, mock.Mock],
+    conf_dir: pathlib.Path,
+    mock_conf: ManagerEndpointConfig,
+    custom_template_path: bool,
+    custom_schema_path: bool,
+):
+    ep_uuid, _ = mock_client
+
+    template_path = Endpoint.user_config_template_path(conf_dir)
+    if custom_template_path:
+        template_path = conf_dir / "my_template.yaml.j2"
+
+    schema_path = Endpoint.user_config_schema_path(conf_dir)
+    if custom_schema_path:
+        schema_path = conf_dir / "my_schema.json"
+
+    template_path.write_text("multi_user: true")
+    schema_path.write_text("{}")
+
+    mock_conf.user_config_template_path = template_path
+    mock_conf.user_config_schema_path = schema_path
+
+    em = EndpointManager(conf_dir, ep_uuid, mock_conf)
+
+    assert em.user_config_template_path == template_path
+    assert em.user_config_schema_path == schema_path
+
+
 @pytest.mark.parametrize("public", (True, False))
 def test_sends_data_during_registration(
     conf_dir, mock_conf: ManagerEndpointConfig, mock_client, public: bool

--- a/docs/endpoints/config_reference.rst
+++ b/docs/endpoints/config_reference.rst
@@ -264,6 +264,32 @@ note are:
      multi_user: true
      identity_mapping_config_path: /path/to/idmap_config.json
 
+- ``user_config_template_path``
+
+  The path to the user endpoint configuration Jinja2 template YAML file.  If not specified,
+  the default template path will be used: ``~/.globus_compute/user_config_template.yaml.j2``.
+
+  See :ref:`user-config-template-yaml-j2` for more information.
+
+  .. code-block:: yaml
+     :caption: Example MEP ``config.yaml`` with a custom user config template path
+
+     multi_user: true
+     user_config_template_path: /path/to/my_template.yaml.j2
+
+- ``user_config_schema_path``
+
+  The path to the user endpoint configuration JSON schema file.  If not specified, the
+  default schema path will be used: ``~/.globus_compute/user_config_schema.json``.
+
+  See :ref:`user-config-schema-json` for more information.
+
+  .. code-block:: yaml
+     :caption: Example MEP ``config.yaml`` with a custom user config schema path
+
+     multi_user: true
+     user_config_schema_path: /path/to/my_schema.json
+
 - ``public``
 
   A boolean value, dictating whether other users can discover this MEP in the Globus

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -491,6 +491,8 @@ and an error is thrown if a user tries to send it as a user option:
    #   Unable to start user endpoint process for <user> [exit code: 77; (ValueError)
    #   'parent_config' is a reserved word and cannot be passed in via user config]")
 
+.. _user-config-schema-json:
+
 ``user_config_schema.json``
 ---------------------------
 


### PR DESCRIPTION
# Description

Enabled multi-user administrators to specify custom user configuration template and schema paths with the `user_config_template_path` and `user_config_schema_path` config options.

[sc-39429](https://app.shortcut.com/globus/story/39429/add-ep-config-variable-to-specify-template-dir)

## Type of change

- New feature (non-breaking change that adds functionality)
