### PR TITLE
Use v3 register_function API route

### DIFF
--- a/changelog.d/20250305_205605_kevin_v3_function_registration.rst
+++ b/changelog.d/20250305_205605_kevin_v3_function_registration.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+- Updated minimum Globus SDK requirement to v3.51.0
+
+- Implement use of the |/v3/functions|_ API route in the Client.  For most
+  users, this will be a transparent change.  However, for those who manually
+  construct the serialized function code, this will necessitate also now
+  specifying the function metadata, including the new serializer identifier.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -774,8 +774,9 @@ class Client:
             group=group,
             serializer=self.fx_serializer,
         )
-        logger.info(f"Registering function : {data}")
-        r = self._compute_web_client.v2.register_function(data.to_dict())
+        logger.info("Registering function: %s", data.function_name)
+        logger.debug("Function data: %s", data)
+        r = self._compute_web_client.v3.register_function(data.to_dict())
         return r.data["function_uuid"]
 
     @requires_login

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -5,7 +5,6 @@ import copy
 import json
 import logging
 import os
-import platform
 import queue
 import random
 import sys
@@ -20,7 +19,6 @@ from concurrent.futures import InvalidStateError
 import pika
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result
-from globus_compute_sdk import __version__
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.client import Client
@@ -471,14 +469,7 @@ class Executor(concurrent.futures.Executor):
 
         log.debug("Function not registered. Registering: %s", fn)
         func_register_kwargs.pop("function", None)  # just to be sure
-        reg_kwargs = {
-            "function_name": fn.__name__,
-            "container_uuid": self.container_id,
-            "metadata": {
-                "python_version": platform.python_version(),
-                "sdk_version": __version__,
-            },
-        }
+        reg_kwargs = {"container_uuid": self.container_id}
         reg_kwargs.update(func_register_kwargs)
 
         try:

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.50.0,<4",
+    "globus-sdk>=3.51.0,<4",
     "globus-compute-common==0.5.0",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import platform
 import random
 import threading
 import typing as t
@@ -12,7 +11,7 @@ import pika
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result, ResultErrorDetails
-from globus_compute_sdk import Client, Executor, __version__
+from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.client import _ComputeWebClient
@@ -498,17 +497,6 @@ def test_register_function_sends_container_id(gce, container_id):
 
     expected_container_id = as_optional_uuid(container_id)
     assert k["container_uuid"] == expected_container_id
-
-
-def test_register_function_sends_metadata(gce):
-    gcc = gce.client
-
-    gce.register_function(noop)
-
-    assert gcc.register_function.called
-    a, k = gcc.register_function.call_args
-    assert k["metadata"].get("python_version") == platform.python_version()
-    assert k["metadata"].get("sdk_version") == __version__
 
 
 @pytest.mark.parametrize(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2848,3 +2848,6 @@ New Functionality
 .. _HighThroughputExecutor: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.HighThroughputExecutor.html
 .. |LocalProvider| replace:: ``LocalProvider``
 .. _LocalProvider: https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.LocalProvider.html
+
+.. |/v3/functions| replace:: ``/v3/functions``
+.. _/v3/functions: https://compute.api.globus.org/redoc#tag/Functions/operation/register_function_v3_functions_post


### PR DESCRIPTION
For most users, this will be a silent difference.  However, for users who manually serialize and specify the function parts, they will now need to specify the function metadata, and, in particular the serialization method.

[sc-36296]

## Type of change

- New feature (non-breaking change that adds functionality)