### PR TITLE
Address EP interchange shutdown race condition

### DIFF
--- a/changelog.d/20250310_105447_kevin_address_shutdown_race_condition.rst
+++ b/changelog.d/20250310_105447_kevin_address_shutdown_race_condition.rst
@@ -1,0 +1,8 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address a shutdown time race condition where an endpoint could receive a task
+  just as it was shutting down, effectively losing the task.  Implement a check
+  after receiving tasks; if the endpoint is shutting down, do not
+  ``ACK``nowledge the task so that the AMQP service will retain it for a later
+  endpoint instance.

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import random
 import signal
 import string
@@ -87,9 +88,11 @@ def mock_quiesce():
 
     def mock_is_set():
         nonlocal quiesce_mock_wait
+        os.sched_yield()
         return quiesce_mock_wait
 
     def mock_wait(*a, **k):
+        os.sched_yield()
         return quiesce_mock_wait
 
     m = mock.Mock(spec=threading.Event)

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -54,7 +54,7 @@ def test_non_configured_endpoint(mocker, tmp_path):
         "😎 Great display/.name",
     ],
 )
-def test_start_endpoint_display_name(mocker, fs, display_name):
+def test_start_endpoint_display_name(fs, display_name):
     responses.add(  # 404 == we are verifying the POST, not the response
         responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
     )

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -16,6 +16,7 @@ class MockExecutor(unittest.mock.Mock):
         super().__init__(**kwargs)
         self.results_passthrough: queue.Queue | None = None
         self.passthrough = True
+        self.executor_exception = False
 
     def start(
         self,


### PR DESCRIPTION
There was a moment in time right at shutdown where a task would be received by the receiving thread.  The thread dutifully sent it on to be processed, naive to the fact that the whole process would shutdown.  Combined with the ACK, this made for lost tasks.
    
New approach: lock the heartbeat kernel, so that when to quiesce is deterministic.  Attempt to take the same lock in the thread; if the quiesce flag is set, then do *not* ACK the result.  The AMQP service will resend the task when the EP next connects.

[sc-36175]

## Type of change

- Bug fix (non-breaking change that fixes an issue)