### PR TITLE
Add a passthrough interface to the Client's serializer through the Executor

### DIFF
--- a/changelog.d/20250320_135249_chris_executor_serializer.rst
+++ b/changelog.d/20250320_135249_chris_executor_serializer.rst
@@ -1,0 +1,23 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The :class:`~globus_compute_sdk.Executor` can now access the underlying
+  :class:`~globus_compute_sdk.serialize.ComputeSerializer` directly through the
+  ``serializer`` constructor argument and property. Eg:
+
+  .. code-block:: python
+
+    from globus_compute_sdk import Client, Executor
+    from globus_compute_sdk.serialize import ComputeSerializer, CombinedCode
+
+    # this code block:
+    gcc = Client(code_serialization_strategy=CombinedCode())
+    gce = Executor("<some uuid>", client=gcc)
+
+    # is equivalent to this:
+    serde = ComputeSerializer(strategy_code=CombinedCode())
+    gce = Executor("<some uuid>", serializer=serde)
+
+    # or this:
+    with Executor("<some uuid>") as gce:
+        gce.serializer = ComputeSerializer(strategy_code=CombinedCode())

--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -83,12 +83,11 @@ This appears to be an error with serialization. If it is, using a different
 serialization strategy from globus_compute_sdk.serialize might resolve the issue. For
 example, to use globus_compute_sdk.serialize.CombinedCode:
 
-    from globus_compute_sdk import Client, Executor
-    from globus_compute_sdk.serialize import CombinedCode
+  from globus_compute_sdk import Executor
+  from globus_compute_sdk.serialize import ComputeSerializer, CombinedCode
 
-    gcc = Client(code_serialization_strategy=CombinedCode())
-    with Executor('<your-endpoint-id>', client=gcc) as gcx:
-        # do something with gcx
+  with Executor('<your-endpoint-id>') as gcx:
+    gcx.serializer = ComputeSerializer(strategy_code=CombinedCode())
 
 For more information, see:
     https://globus-compute.readthedocs.io/en/latest/sdk.html#specifying-a-serialization-strategy

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -306,21 +306,17 @@ function code and arguments).
 
 The default strategies are :class:`~globus_compute_sdk.serialize.DillCode` for function code and :class:`~globus_compute_sdk.serialize.DillDataBase64` for
 function ``*args`` and ``**kwargs``, which are both wrappers around |dill|_. To choose
-another serializer, use the ``code_serialization_strategy`` and
-``data_serialization_strategy`` members of the Compute :class:`~globus_compute_sdk.Client`:
+another serializer, use the ``serializer`` member of the Compute :class:`~globus_compute_sdk.Executor`:
 
 .. code:: python
 
-  from globus_compute_sdk import Client, Executor
-  from globus_compute_sdk.serialize import CombinedCode, JSONData
+  from globus_compute_sdk import Executor
+  from globus_compute_sdk.serialize import ComputeSerializer, CombinedCode, JSONData
 
-  gcc = Client(
-    code_serialization_strategy=CombinedCode(),
-    data_serialization_strategy=JSONData()
-  )
-  gcx = Executor('4b116d3c-1703-4f8f-9f6f-39921e5864df', client=gcc)
-
-  # do something with gcx
+  with Executor('<your-endpoint-id>') as gcx:
+    gcx.serializer = ComputeSerializer(
+      strategy_code=CombinedCode(), strategy_data=JSONData()
+    )
 
 :doc:`See here for a up-to-date list of serialization strategies. </reference/serialization_strategies>`
 


### PR DESCRIPTION
# Description

Preliminary work related to result serialization. The list of result serializers will live on the Executor, so to keep things consistent, this change makes all client-side serialization knobs (of which there is currently one) accessible through the Executor.

## Type of change

- New feature (non-breaking change that adds functionality)
