### PR TITLE
Request refresh tokens when initializing GlobusApp

### DIFF
--- a/changelog.d/20250325_120334_LeiGlobus_refresh_token_request_sc_40211.rst
+++ b/changelog.d/20250325_120334_LeiGlobus_refresh_token_request_sc_40211.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Refresh tokens were not being requested properly since 2.28.0 when going through login flow.  Now they are requested as expected.  This previously prevented auto refreshing of access tokens upon expiry.

--- a/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
@@ -13,7 +13,10 @@ DEFAULT_CLIENT_ID = "4cf29807-cf21-49ec-9443-ff9a3fb9f81c"
 def get_globus_app(environment: str | None = None) -> GlobusApp:
     app_name = platform.node()
     client_id, client_secret = get_client_creds()
-    config = GlobusAppConfig(token_storage=get_token_storage(environment=environment))
+    config = GlobusAppConfig(
+        token_storage=get_token_storage(environment=environment),
+        request_refresh_tokens=True,
+    )
 
     if client_id and client_secret:
         return ClientApp(

--- a/compute_sdk/tests/unit/auth/test_globus_app.py
+++ b/compute_sdk/tests/unit/auth/test_globus_app.py
@@ -20,6 +20,8 @@ def test_get_globus_app(
 
     app = get_globus_app()
 
+    assert app.config.request_refresh_tokens
+
     if client_id and client_secret:
         assert isinstance(app, ClientApp)
     else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,7 +44,7 @@ Changed
 
 - Update ``parsl`` dependency from `2025.2.17
   <https://pypi.org/project/parsl/2025.2.17/>`_ to `2025.3.17
-  //<https://pypi.org/project/parsl/2025.3.17/>`_
+  <https://pypi.org/project/parsl/2025.3.17/>`_
 
 - |ShellFunction| and |MPIFunction| erroneously used the full ``cmd`` string as a function name.
   These classes now default the function name to the class name. User may customize the function


### PR DESCRIPTION
[sc-40211]

Compute asks for login flow before refresh_token expiry
See [support ticket](https://globusonline.zendesk.com/agent/tickets/389213) and [Slack discussion](https://globus.slack.com/archives/C0896RYMBGX/p1742853460624439)

Refresh tokens were removed going from 2.27.1 -> 2.28.0 from .globus_compute/storage.db

The related change:  [Using GlobusApp for authentication: ](https://globus-compute.readthedocs.io/en/latest/changelog.html#globus-compute-sdk-globus-compute-endpoint-v2-28-0)

This appears to be caused by a missing request_refresh_tokens=True param in GlobusAppConfig.

Also fixes a formatting issue with the changelog for the earlier version bump for 3.4.0a0