### PR TITLE
Add Strategylike type and utility function

### DIFF
--- a/changelog.d/20250325_154559_chris_strategylike.rst
+++ b/changelog.d/20250325_154559_chris_strategylike.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The :class:`~globus_compute_sdk.serialize.ComputeSerializer` constructor now accepts
+  a wider range of inputs for ``strategy_code``, ``strategy_data``, and
+  ``allowed_deserializers``. See the class documentation for details.

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -42,8 +42,14 @@ class SerializationStrategy(ABC):
     for_code: t.ClassVar[bool]
 
     @classmethod
-    def get_cached(cls, identifier: str) -> t.Optional["SerializationStrategy"]:
+    def get_cached_by_id(cls, identifier: str) -> t.Optional["SerializationStrategy"]:
         return cls._CACHE.get(identifier)
+
+    T = t.TypeVar("T", bound="SerializationStrategy")
+
+    @classmethod
+    def get_cached_by_class(cls, type_: t.Type[T]) -> T:
+        return t.cast(SerializationStrategy.T, cls._CACHE[type_.identifier])
 
     @abstractmethod
     def serialize(self, data: t.Any) -> str:

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -398,7 +398,7 @@ SELECTABLE_STRATEGIES = [
 
 #: The *code* serialization strategy used by :class:`ComputeSerializer`
 #: when one is not specified.
-DEFAULT_STRATEGY_CODE: DillCode = DillCode()
+DEFAULT_STRATEGY_CODE = SerializationStrategy.get_cached_by_class(DillCode)
 #: The *data* serialization strategy used by :class:`ComputeSerializer`
 #: when one is not specified.
-DEFAULT_STRATEGY_DATA: DillDataBase64 = DillDataBase64()
+DEFAULT_STRATEGY_DATA = SerializationStrategy.get_cached_by_class(DillDataBase64)


### PR DESCRIPTION
# Description

More preliminary work for selectable result serialization. We're going to be passing around serializer import paths for that work, so it's important to have a central validation engine that supports all three modes of referring to a strategy (namely by instance, type, and import path).

## Type of change

- New feature (non-breaking change that adds functionality)
