### PR TITLE
Add `PureSource*` strategies to `CombinedCode`

### DIFF
--- a/changelog.d/20250325_160052_chris_pure_source_combined.rst
+++ b/changelog.d/20250325_160052_chris_pure_source_combined.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added :class:`~globus_compute_sdk.serialize.PureSourceDill` and
+  :class:`~globus_compute_sdk.serialize.PureSourceTextInspect` as sub-strategies to
+  :class:`~globus_compute_sdk.serialize.CombinedCode`.

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -228,8 +228,9 @@ class PureSourceTextInspect(SerializationStrategy):
           - ❌
     """
 
-    identifier = "st\n"  # "Source TextInspect"
-    for_code = True
+    # "Source TextInspect"
+    identifier = "st\n"  #:
+    for_code = True  #:
 
     _separator = ":"
 
@@ -268,8 +269,9 @@ class PureSourceDill(SerializationStrategy):
           - ❌
     """
 
-    identifier = "sd\n"  # "Source Dill"
-    for_code = True
+    # "Source Dill"
+    identifier = "sd\n"  #:
+    for_code = True  #:
 
     _separator = ":"
 


### PR DESCRIPTION
# Description

Adds two new sub-strategies to `CombinedCode` (which requires moving them around a little). Also fixes the documentation comments for both `PureSource` strategies.

## Type of change

- New feature (non-breaking change that adds functionality)
