### PR TITLE
Ensure test prerequisite

### DIFF
--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
@@ -162,7 +162,7 @@ def test_connection_closed_shuts_down(start_task_q_subscriber):
     # The RabbitMQ queue is configured for exclusive use, so attempting
     # to reconnect will cause an error.
     tqs.connect_attempt_limit = 1
-    try_assert(lambda: tqs._connection, "Ensure we establish a connection")
+    try_assert(lambda: tqs._connection and tqs._connection.is_open, "Test prereq")
 
     assert not tqs._stop_event.is_set()
     tqs._connection.close()


### PR DESCRIPTION
Avoid a minor race-condition where the open operation is only half-complete before the close operation begins:

    AMQPConnector - reporting failure: AMQPConnectorAMQPHandshakeError: ConnectionOpenAborted: ("Connection.close() called before connection finished opening: prev_state=TUNE (200): 'Normal shutdown'",)

## Type of change

- Code maintenance/cleanup