### PR TITLE
Refactor engine infra to use futures

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
-import queue
 import typing as t
 import uuid
 from concurrent.futures import Future
@@ -46,7 +45,6 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         *args,
         endpoint_id: t.Optional[uuid.UUID] = None,
         run_dir: t.Optional[str] = None,
-        results_passthrough: t.Optional[queue.Queue] = None,
         **kwargs,
     ) -> None:
         """
@@ -54,7 +52,6 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         ----------
         endpoint_id: Endpoint UUID
         run_dir: endpoint run directory
-        results_passthrough: Queue to which packed results will be posted
         Returns
         -------
         """
@@ -69,9 +66,6 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
 
         assert endpoint_id, "ProcessPoolEngine requires kwarg:endpoint_id at start"
         self.endpoint_id = endpoint_id
-        if results_passthrough:
-            self.results_passthrough = results_passthrough
-        assert self.results_passthrough
         self.set_working_dir(run_dir=run_dir)
 
         self._engine_ready = True

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
-import queue
 import typing as t
 import uuid
 from concurrent.futures import Future
@@ -44,7 +43,6 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         *args,
         endpoint_id: t.Optional[uuid.UUID] = None,
         run_dir: t.Optional[str] = None,
-        results_passthrough: t.Optional[queue.Queue] = None,
         **kwargs,
     ) -> None:
         """
@@ -52,16 +50,11 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         ----------
         endpoint_id: Endpoint UUID
         run_dir: endpoint run directory
-        results_passthrough: Queue to which packed results will be posted
         Returns
         -------
         """
         assert endpoint_id, "ThreadPoolEngine requires kwarg:endpoint_id at start"
         self.endpoint_id = endpoint_id
-        if results_passthrough:
-            self.results_passthrough = results_passthrough
-        assert self.results_passthrough
-
         self.set_working_dir(run_dir=run_dir)
         # mypy think the thread can be none
         self._engine_ready = True

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import multiprocessing
 import time
 import uuid
@@ -228,8 +227,6 @@ def test_bad_resource_specification(
     resource_specification = json.dumps({"BAD_KEY": "BAD_VALUE"})
     with pika.BlockingConnection(pika_conn_params) as mq_conn:
         with mq_conn.channel() as chan:
-            x = chan.is_open
-            logging.warning(f"Channel open : {x=}")
             chan.queue_purge(task_q_name)
             chan.queue_purge(res_q_name)
             # publish our canary task

--- a/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
@@ -1,0 +1,107 @@
+import concurrent.futures
+import random
+import typing as t
+from unittest import mock
+
+import pytest
+from globus_compute_common import messagepack
+from globus_compute_common.messagepack.message_types import Result
+from globus_compute_endpoint.engines import (
+    GlobusComputeEngine,
+    ProcessPoolEngine,
+    ThreadPoolEngine,
+)
+from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
+from tests.utils import double, get_cwd
+
+
+@pytest.mark.parametrize(
+    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
+)
+def test_engine_start(
+    engine_type: t.Type[GlobusComputeEngineBase], engine_runner, endpoint_uuid, tmp_path
+):
+    """Engine.submit should fail before engine is started"""
+
+    engine = engine_type()
+    assert not engine._engine_ready, "Engine should not be ready before start"
+
+    engine.executor = mock.Mock(status_polling_interval=0)
+
+    # task submit should raise Exception if it was not started
+    with pytest.raises(RuntimeError):
+        engine.submit(str(endpoint_uuid), b"", {})
+
+    engine.start(endpoint_id=endpoint_uuid, run_dir=tmp_path)
+    assert engine._engine_ready, "Engine should be ready after start"
+
+    engine.shutdown()
+
+
+@pytest.mark.parametrize(
+    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
+)
+def test_engine_submit(engine_type: GlobusComputeEngineBase, engine_runner):
+    """Test engine.submit with multiple engines"""
+    engine = engine_runner(engine_type)
+
+    param = random.randint(1, 100)
+    resource_spec: dict = {}
+    future = engine._submit(double, resource_spec, param)
+    assert isinstance(future, concurrent.futures.Future)
+
+    # 5-seconds is nominally "overkill," but gc on CI appears to need (at least) >1s
+    assert future.result(timeout=5) == param * 2
+
+
+@pytest.mark.parametrize(
+    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
+)
+def test_engine_working_dir(
+    engine_type: GlobusComputeEngineBase,
+    engine_runner,
+    ez_pack_task,
+    serde,
+    task_uuid,
+):
+    """working dir remains constant across multiple fn invocations
+    This test requires submitting the task payload so that the execute_task
+    wrapper is used which switches into the working_dir, which created
+    working_dir nesting when relative paths were used.
+    """
+    engine = engine_runner(engine_type)
+
+    task_args: tuple = (str(task_uuid), ez_pack_task(get_cwd), {})
+
+    future1 = engine.submit(*task_args)
+    unpacked1 = messagepack.unpack(future1.result())  # blocks; avoid race condition
+
+    future2 = engine.submit(*task_args)  # exact same task
+    unpacked2 = messagepack.unpack(future2.result())
+
+    # data is enough for test, but in error case, be kind to dev
+    assert isinstance(unpacked1, Result)
+    assert isinstance(unpacked2, Result)
+    cwd1 = serde.deserialize(unpacked1.data)
+    cwd2 = serde.deserialize(unpacked2.data)
+    assert cwd1 == cwd2, "working dir should be idempotent"
+
+
+@pytest.mark.parametrize(
+    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
+)
+def test_engine_submit_internal(
+    engine_type: GlobusComputeEngineBase, engine_runner, serde, task_uuid, ez_pack_task
+):
+    engine = engine_runner(engine_type)
+
+    task_bytes = ez_pack_task(double, 3)
+    f = engine.submit(str(task_uuid), task_bytes, resource_specification={})
+    packed_result = f.result()
+
+    # Confirm that the future got the right answer
+    assert isinstance(packed_result, bytes)
+    result = messagepack.unpack(packed_result)
+    assert isinstance(result, Result)
+    assert result.task_id == task_uuid
+    assert serde.deserialize(result.data) == 6

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -155,11 +155,7 @@ def test_rundir_passed_to_gcengine(mocker, fs, ei):
 
     ei.start_engine()
 
-    ei.engine.start.assert_called_with(
-        results_passthrough=ei.results_passthrough,
-        endpoint_id=ei.endpoint_id,
-        run_dir=ei.logdir,
-    )
+    ei.engine.start.assert_called_with(endpoint_id=ei.endpoint_id, run_dir=ei.logdir)
 
 
 def test_heartbeat_includes_static_info(ei, mock_rp, mock_tqs, mock_pack, mock_ep_info):

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -1,9 +1,7 @@
-import concurrent.futures
 import logging
 import pathlib
 import random
 import time
-import typing as t
 from unittest import mock
 
 import pytest
@@ -22,7 +20,7 @@ from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
 from globus_compute_sdk.serialize.concretes import SELECTABLE_STRATEGIES
 from parsl import HighThroughputExecutor
 from parsl.providers import KubernetesProvider
-from tests.utils import double, get_cwd, kill_manager
+from tests.utils import kill_manager
 
 logger = logging.getLogger(__name__)
 
@@ -60,98 +58,6 @@ def test_result_message_packing(serde, task_uuid):
 
     assert unpacked.task_id == task_uuid
     assert serde.deserialize(unpacked.data) == result
-
-
-@pytest.mark.parametrize(
-    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
-)
-def test_engine_start(
-    engine_type: t.Type[GlobusComputeEngineBase], engine_runner, endpoint_uuid, tmp_path
-):
-    """Engine.submit should fail before engine is started"""
-
-    engine = engine_type()
-    assert not engine._engine_ready, "Engine should not be ready before start"
-
-    engine.executor = mock.Mock(status_polling_interval=0)
-
-    # task submit should raise Exception if it was not started
-    with pytest.raises(RuntimeError):
-        engine.submit(str(endpoint_uuid), b"", {})
-
-    engine.start(endpoint_id=endpoint_uuid, run_dir=tmp_path)
-    assert engine._engine_ready, "Engine should be ready after start"
-
-    engine.shutdown()
-
-
-@pytest.mark.parametrize(
-    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
-)
-def test_engine_submit(engine_type: GlobusComputeEngineBase, engine_runner):
-    """Test engine.submit with multiple engines"""
-    engine = engine_runner(engine_type)
-
-    param = random.randint(1, 100)
-    resource_spec: dict = {}
-    future = engine._submit(double, resource_spec, param)
-    assert isinstance(future, concurrent.futures.Future)
-
-    # 5-seconds is nominally "overkill," but gc on CI appears to need (at least) >1s
-    assert future.result(timeout=5) == param * 2
-
-
-@pytest.mark.parametrize(
-    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
-)
-def test_engine_working_dir(
-    engine_type: GlobusComputeEngineBase,
-    engine_runner,
-    ez_pack_task,
-    serde,
-    task_uuid,
-):
-    """working dir remains constant across multiple fn invocations
-    This test requires submitting the task payload so that the execute_task
-    wrapper is used which switches into the working_dir, which created
-    working_dir nesting when relative paths were used.
-    """
-    engine = engine_runner(engine_type)
-
-    task_args: tuple = (str(task_uuid), ez_pack_task(get_cwd), {})
-
-    future1 = engine.submit(*task_args)
-    unpacked1 = messagepack.unpack(future1.result())  # blocks; avoid race condition
-
-    future2 = engine.submit(*task_args)  # exact same task
-    unpacked2 = messagepack.unpack(future2.result())
-
-    # data is enough for test, but in error case, be kind to dev
-    assert isinstance(unpacked1, Result)
-    assert isinstance(unpacked2, Result)
-    cwd1 = serde.deserialize(unpacked1.data)
-    cwd2 = serde.deserialize(unpacked2.data)
-    assert cwd1 == cwd2, "working dir should be idempotent"
-
-
-@pytest.mark.parametrize(
-    "engine_type", (ProcessPoolEngine, ThreadPoolEngine, GlobusComputeEngine)
-)
-def test_engine_submit_internal(
-    engine_type: GlobusComputeEngineBase, engine_runner, serde, task_uuid, ez_pack_task
-):
-    engine = engine_runner(engine_type)
-
-    task_bytes = ez_pack_task(double, 3)
-    f = engine.submit(str(task_uuid), task_bytes, resource_specification={})
-    packed_result = f.result()
-
-    # Confirm that the future got the right answer
-    assert isinstance(packed_result, bytes)
-    result = messagepack.unpack(packed_result)
-    assert isinstance(result, Result)
-    assert result.task_id == task_uuid
-    assert serde.deserialize(result.data) == 6
 
 
 @pytest.mark.parametrize(

--- a/compute_endpoint/tests/utils.py
+++ b/compute_endpoint/tests/utils.py
@@ -27,6 +27,7 @@ def create_traceback(start: int = 0) -> types.TracebackType:
             tb = types.TracebackType(tb, frame, frame.f_lasti, frame.f_lineno)
         except ValueError:
             break
+    assert tb is not None, "Developer: too many frames ignored!"
     return tb
 
 
@@ -135,13 +136,6 @@ def create_task_packer(
 
 
 def double(x: int) -> int:
-    return x * 2
-
-
-def slow_double(x: int, sleep_duration_s: int) -> int:
-    import time
-
-    time.sleep(sleep_duration_s)
     return x * 2
 
 


### PR DESCRIPTION
# Description

The engines all return Futures for each task submitted to them.  When each Future completes, it can initiate the appropriate event to forward the associated result to the AMQP service.  In so doing, remove the `results_passthrough` queue&nbsp;&mdash;&nbsp;now completely unnecessary&nbsp;&mdash;&nbsp;and similarly remove the `result_processor_thread` in the Endpoint's interchange.
    
This refactor also more nicely isolates the retry logic and retry data structure to strictly the base Engine class&nbsp;&mdash;&nbsp;the other engines can now partake in the retry goodness as well.

[sc-35488]

## Type of change

- Code maintenance/cleanup