### PR TITLE
unhide HA option when configuring

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -301,7 +301,6 @@ def version_command():
     "--high-assurance",
     is_flag=True,
     default=False,
-    hidden=True,  # Until HA features are complete
     help="Configure endpoint as high assurance capable",
 )
 @click.option(


### PR DESCRIPTION
Removing the 'hidden' flag from high-assurance.

[sc-40477]

Silently make it (more) visible, to be announced at Globus World first, so no changelog or redirection to documentation.