### PR TITLE
Rename to MockEngine

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -17,7 +17,7 @@ from globus_compute_endpoint.endpoint.rabbit_mq import (
     ResultPublisher,
     TaskQueueSubscriber,
 )
-from tests.integration.endpoint.executors.mock_executors import MockExecutor
+from tests.integration.endpoint.executors.mock_executors import MockEngine
 from tests.utils import try_assert
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.interchange."
@@ -43,7 +43,7 @@ def mock_log(mocker):
 
 @pytest.fixture
 def mock_engine(endpoint_uuid):
-    m = MockExecutor()
+    m = MockEngine()
     m.endpoint_id = endpoint_uuid
     m.get_status_report.return_value = EPStatusReport(
         endpoint_id=endpoint_uuid, global_state={}, task_statuses=[]

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -12,7 +12,7 @@ from globus_compute_common.messagepack import pack, unpack
 from globus_compute_common.messagepack.message_types import EPStatusReport, Result, Task
 from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange
-from tests.integration.endpoint.executors.mock_executors import MockExecutor
+from tests.integration.endpoint.executors.mock_executors import MockEngine
 from tests.utils import try_for_timeout
 
 _test_func_ids = [str(uuid.uuid4()) for i in range(3)]
@@ -34,7 +34,7 @@ def run_interchange_process(
     """
 
     def run_it(reg_info: dict, endpoint_uuid, endpoint_dir):
-        mock_exe = MockExecutor()
+        mock_exe = MockEngine()
         mock_exe.endpoint_id = endpoint_uuid
         mock_exe.executor_exception = None
         mock_exe.get_status_report.return_value = EPStatusReport(
@@ -212,7 +212,7 @@ def test_bad_resource_specification(
     """
     Verify that a result is returned for a task that carries
     a bad resource_spec, in this case we use {"BAD_KEY": ...}
-    to trigger an exception in the MockExecutor
+    to trigger an exception in the MockEngine
     """
     ix_proc, tmp_path, ep_uuid, reg_info = run_interchange_process
 
@@ -223,7 +223,7 @@ def test_bad_resource_specification(
     task_q_name = task_q["queue"]
     task_exch = task_q["exchange"]
 
-    # The MockExecutor raises an exception on receiving res_spec with BAD_KEY
+    # The MockEngine raises an exception on receiving res_spec with BAD_KEY
     resource_specification = json.dumps({"BAD_KEY": "BAD_VALUE"})
     with pika.BlockingConnection(pika_conn_params) as mq_conn:
         with mq_conn.channel() as chan:

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -11,7 +11,7 @@ from globus_compute_sdk import Client
 from parsl.executors.errors import InvalidResourceSpecification
 
 
-class MockExecutor(unittest.mock.Mock):
+class MockEngine(unittest.mock.Mock):
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
         self.passthrough = True


### PR DESCRIPTION
`MockExecutor` pre-dated the introduction of the `*Engine` thought-process by 8 months.[1]  Meanwhile, we recently fully removed the HTEX fork.[2]  Now it's time to update the mock class name.

[1] See:
  - PR #869 (e75892fe21e30842331f8d4478ef2241100cc064)
  - PR #1129 (11e07e6cd2c0ea1fe3e1ba701535671faf60b2b9)

[2] See:
  - PR #1757 (20ee473745963fa59aa421d6ddc19650a28756cc)
  - PR #1784 (ab700ac07c4b3386cc8cd72be71c8888bedb1d7d)

## Type of change

- Code maintenance/cleanup