### PR TITLE
Pass future to engine instead

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/__init__.py
@@ -1,9 +1,11 @@
+from .base import GCFuture
 from .globus_compute import GlobusComputeEngine
 from .globus_mpi import GlobusMPIEngine
 from .process_pool import ProcessPoolEngine
 from .thread_pool import ThreadPoolEngine
 
 __all__ = (
+    "GCFuture",
     "GlobusComputeEngine",
     "GlobusMPIEngine",
     "ProcessPoolEngine",

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -241,21 +241,18 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
 
     def submit(
         self,
-        task_id: str,
+        task_f: GCFuture,
         packed_task: bytes,
         resource_specification: dict,
-    ) -> GCFuture:
+    ):
         """GC Endpoints should submit tasks via this method so that tasks are
         tracked properly.
 
-        :param task_id: Globus Compute web-services task identifier; should be a UUID
+        :param task_f: The future to be notified when task is complete
         :param packed_task: The payload task (function and args) to eventually invoke
         :param resource_specification: MPI resource specification
-        :return: A GCFuture that wraps the internal retry (if specified)
         """
         self._ensure_ready()
-
-        task_f = GCFuture(gc_task_id=task_id)
 
         submission_partial = functools.partial(
             self._submit,
@@ -271,8 +268,6 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         self._invoke_submission(
             task_f, submission_partial, retry_count=self.max_retries_on_system_failure
         )
-
-        return task_f
 
     @abstractmethod
     def shutdown(self, /, **kwargs) -> None:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_shell_functions.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_shell_functions.py
@@ -1,6 +1,6 @@
 import pytest
 from globus_compute_common import messagepack
-from globus_compute_endpoint.engines import GlobusComputeEngine
+from globus_compute_endpoint.engines import GCFuture, GlobusComputeEngine
 from globus_compute_sdk.sdk.shell_function import ShellFunction
 
 
@@ -9,7 +9,8 @@ def test_shell_function(engine_runner, tmp_path, task_uuid, serde, ez_pack_task)
     engine = engine_runner(GlobusComputeEngine)
     shell_func = ShellFunction("pwd")
     task_bytes = ez_pack_task(shell_func)
-    future = engine.submit(task_uuid, task_bytes, resource_specification={})
+    future = GCFuture(gc_task_id=task_uuid)
+    engine.submit(future, task_bytes, resource_specification={})
 
     packed_result = future.result()
     result = messagepack.unpack(packed_result)
@@ -40,7 +41,8 @@ def test_fail_shell_function(
     engine = engine_runner(GlobusComputeEngine, run_in_sandbox=True)
     shell_func = ShellFunction(cmd, walltime=0.1)
     task_bytes = ez_pack_task(shell_func)
-    future = engine.submit(task_uuid, task_bytes, resource_specification={})
+    future = GCFuture(gc_task_id=task_uuid)
+    engine.submit(future, task_bytes, resource_specification={})
 
     packed_result = future.result()
     result = messagepack.unpack(packed_result)
@@ -58,7 +60,8 @@ def test_no_sandbox(engine_runner, task_uuid, serde, ez_pack_task):
     engine = engine_runner(GlobusComputeEngine, run_in_sandbox=False)
     shell_func = ShellFunction("pwd")
     task_bytes = ez_pack_task(shell_func)
-    future = engine.submit(task_uuid, task_bytes, resource_specification={})
+    future = GCFuture(gc_task_id=task_uuid)
+    engine.submit(future, task_bytes, resource_specification={})
 
     packed_result = future.result()
     result = messagepack.unpack(packed_result)

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -126,7 +126,7 @@ def test_epi_forwards_tasks_and_results(
                     content_type="application/json",
                     content_encoding="utf-8",
                     headers={
-                        "function_uuid": "some_func",
+                        "function_uuid": str(uuid.uuid4()),
                         "task_uuid": str(task_uuid),
                         "resource_specification": "null",
                     },
@@ -177,7 +177,7 @@ def test_resource_specification(
             chan.queue_purge(res_q_name)
             # publish our canary task
             header = {
-                "function_uuid": "some_func",
+                "function_uuid": str(uuid.uuid4()),
                 "task_uuid": str(task_uuid),
             }
 
@@ -238,7 +238,7 @@ def test_bad_resource_specification(
                     content_type="application/json",
                     content_encoding="utf-8",
                     headers={
-                        "function_uuid": "some_func",
+                        "function_uuid": str(uuid.uuid4()),
                         "task_uuid": str(task_uuid),
                         "resource_specification": resource_specification,
                     },

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 from globus_compute_common import messagepack
-from globus_compute_endpoint.engines import GlobusComputeEngine
+from globus_compute_endpoint.engines import GCFuture, GlobusComputeEngine
 from parsl.executors.high_throughput.interchange import ManagerLost
 from parsl.providers import LocalProvider
 from tests.utils import double
@@ -62,7 +62,8 @@ def test_success_after_fails(mock_gce, serde, ez_pack_task, fail_count):
     task_bytes = ez_pack_task(double, num)
 
     engine.executor.fail_count = fail_count
-    f = engine.submit(task_id, task_bytes, resource_specification={})
+    f = GCFuture(gc_task_id=task_id)
+    engine.submit(f, task_bytes, resource_specification={})
 
     packed_result: bytes = f.result()
     result = messagepack.unpack(packed_result)
@@ -81,7 +82,8 @@ def test_repeated_fail(mock_gce, ez_pack_task, fail_count):
 
     # Set executor to continue failures beyond retry limit
     engine.executor.fail_count = fail_count + 1
-    f = engine.submit(task_id, task_bytes, resource_specification={})
+    f = GCFuture(gc_task_id=task_id)
+    engine.submit(f, task_bytes, resource_specification={})
 
     packed_result = f.result()
     result = messagepack.unpack(packed_result)

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -3,7 +3,7 @@ import random
 
 import pytest
 from globus_compute_common import messagepack
-from globus_compute_endpoint.engines import GlobusMPIEngine
+from globus_compute_endpoint.engines import GCFuture, GlobusMPIEngine
 from globus_compute_sdk.sdk.mpi_function import MPIFunction
 from globus_compute_sdk.sdk.shell_function import ShellResult
 from parsl.executors.errors import InvalidResourceSpecification
@@ -19,7 +19,8 @@ def test_mpi_function(engine_runner, nodeslist, serde, task_uuid, ez_pack_task):
 
     mpi_func = MPIFunction("pwd")
     task_bytes = ez_pack_task(mpi_func)
-    future = engine.submit(task_uuid, task_bytes, resource_specification=resource_spec)
+    future = GCFuture(gc_task_id=task_uuid)
+    engine.submit(future, task_bytes, resource_specification=resource_spec)
 
     packed_result = future.result(timeout=10)
     result = messagepack.unpack(packed_result)
@@ -36,8 +37,9 @@ def test_env_vars(engine_runner, nodeslist, serde, task_uuid, ez_pack_task):
     engine = engine_runner(GlobusMPIEngine)
     task_bytes = ez_pack_task(get_env_vars)
     num_nodes = random.randint(1, len(nodeslist))
-    future = engine.submit(
-        task_uuid,
+    future = GCFuture(gc_task_id=task_uuid)
+    engine.submit(
+        future,
         task_bytes,
         resource_specification={"num_nodes": num_nodes, "num_ranks": 2},
     )

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import (
+    GCFuture,
     GlobusComputeEngine,
     ProcessPoolEngine,
     ThreadPoolEngine,
@@ -105,7 +106,7 @@ def test_submit_pass(tmp_path, task_uuid, mock_gcengine):
     mock_gcengine.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
 
     mock_gcengine.submit(
-        task_id=task_uuid,
+        task_f=GCFuture(gc_task_id=task_uuid),
         packed_task=b"PACKED_TASK",
         resource_specification={},
     )


### PR DESCRIPTION
The `Future` object returned by the engine is now a `GCFuture`.  It's purpose is to inform watchers when the associated task is complete.  But rather than make the engine responsible for creating this object, pass one in already instantiated.  The idea is that the task-result concept has a larger lifetime than just what the engine sees, so it doesn't quite align to have the engine be the generator.  The engine certainly is a part of the task lifecycle, but what creates the task is the interchange when it receives the task from upstream.

Beyond philosophy, this means that the interchange can use the same object in multiple branches, rather than creating different instances to satisfy the interface.  In upcoming changes, there will be attributes beyond just `gc_task_id` that will better motivate this organization.

[sc-35488]

## Type of change

- Code maintenance/cleanup