### PR TITLE
Disable Globus SDK retries in tests

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -34,6 +34,8 @@ def patch_compute_client(mocker):
     )
     gcc.web_service_address = _SVC_ADDY
     gcc._compute_web_client = _ComputeWebClient(base_url=_SVC_ADDY)
+    gcc._compute_web_client.v2.transport.max_retries = 0
+    gcc._compute_web_client.v3.transport.max_retries = 0
 
     yield mocker.patch(f"{_MOCK_BASE}Client", return_value=gcc)
 


### PR DESCRIPTION
This makes no difference in the happy-path, but no sense in waiting to fail while debugging the errant-case.

## Type of change

- Code maintenance/cleanup