### PR TITLE
Teach GCFuture executor_task_id

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
-from concurrent.futures import Future
 
 import parsl.executors
+from globus_compute_endpoint.engines.base import GCExecutorFuture
 from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
 
 
@@ -34,6 +34,11 @@ class GlobusMPIEngine(GlobusComputeEngine):
         resource_specification: t.Dict,
         *args: t.Any,
         **kwargs: t.Any,
-    ) -> Future:
+    ) -> GCExecutorFuture:
         # override submit since super rejects resource_specification
-        return self.executor.submit(func, resource_specification, *args, **kwargs)
+        f = t.cast(
+            GCExecutorFuture,
+            self.executor.submit(func, resource_specification, *args, **kwargs),
+        )
+        f.executor_task_id = f.parsl_executor_task_id  # type: ignore[attr-defined]
+        return f

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -17,6 +17,7 @@ class MockHTEX:
     ManagerLost errors"""
 
     def __init__(self, fail_count=1):
+        self._task_counter = 0
         self.fail_count = fail_count
         self.ex = ThreadPoolExecutor()
 
@@ -28,6 +29,9 @@ class MockHTEX:
             future.set_exception(ManagerLost(b"DEAD", "Faking Manager death!"))
         else:
             future = self.ex.submit(func, *args, **kwargs)
+        self._task_counter += 1
+        future.parsl_executor_task_id = self._task_counter  # match what Parsl does
+
         return future
 
     def shutdown(self):

--- a/compute_endpoint/tests/unit/engine/conftest.py
+++ b/compute_endpoint/tests/unit/engine/conftest.py
@@ -1,0 +1,22 @@
+from unittest import mock
+
+import pytest
+from parsl.executors import HighThroughputExecutor, MPIExecutor
+
+
+@pytest.fixture
+def mock_htex():
+    m = mock.Mock(spec=HighThroughputExecutor)
+    m.status_polling_interval = 5
+    m.launch_cmd = "launchy"
+    m.interchange_launch_cmd = "ix-launchy"
+    return m
+
+
+@pytest.fixture
+def mock_mpiex():
+    m = mock.Mock(spec=MPIExecutor)
+    m.status_polling_interval = 5
+    m.launch_cmd = "launchy"
+    m.interchange_launch_cmd = "ix-launchy"
+    return m

--- a/compute_endpoint/tests/unit/engine/test_globuscompute.py
+++ b/compute_endpoint/tests/unit/engine/test_globuscompute.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import parsl
 import pytest
-from globus_compute_endpoint.engines import GlobusComputeEngine
+from globus_compute_endpoint.engines import GCFuture, GlobusComputeEngine
 from globus_compute_sdk.sdk.utils import get_py_version_str
 
 _MOCK_BASE = "globus_compute_endpoint.engines.globus_compute."
@@ -160,3 +160,11 @@ def test_status_poller_started_late(fs, htex, mock_jsp, ep_uuid):
     assert gce.job_status_poller is not None
     a, _ = gce.job_status_poller.add_executors.call_args
     assert a[0] == [htex], "Expect executor to be polled"
+
+
+def test_sets_task_id(fs, mock_htex, endpoint_uuid, task_uuid):
+    eng = GlobusComputeEngine(executor=mock_htex)
+    eng.start(endpoint_id=endpoint_uuid, run_dir="/")
+    f = GCFuture(gc_task_id=task_uuid)
+    eng.submit(f, b"bytes", {})
+    assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/engine/test_globusmpi.py
+++ b/compute_endpoint/tests/unit/engine/test_globusmpi.py
@@ -1,0 +1,11 @@
+from globus_compute_endpoint.engines import GCFuture, GlobusMPIEngine
+
+_MOCK_BASE = "globus_compute_endpoint.engines.globus_mpi."
+
+
+def test_sets_task_id(fs, mock_mpiex, endpoint_uuid, task_uuid):
+    eng = GlobusMPIEngine(executor=mock_mpiex)
+    eng.start(endpoint_id=endpoint_uuid, run_dir="/")
+    f = GCFuture(gc_task_id=task_uuid)
+    eng.submit(f, b"bytes", {})
+    assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/engine/test_processpool.py
+++ b/compute_endpoint/tests/unit/engine/test_processpool.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+from globus_compute_endpoint.engines import GCFuture, ProcessPoolEngine
+
+_MOCK_BASE = "globus_compute_endpoint.engines.process_pool."
+
+
+def test_sets_task_id(endpoint_uuid, task_uuid):
+    with mock.patch(f"{_MOCK_BASE}NativeExecutor"):
+        eng = ProcessPoolEngine()
+        eng.start(endpoint_id=endpoint_uuid)
+        f = GCFuture(gc_task_id=task_uuid)
+        eng.submit(f, b"bytes", {})
+        assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/engine/test_threadpool.py
+++ b/compute_endpoint/tests/unit/engine/test_threadpool.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+from globus_compute_endpoint.engines import GCFuture, ThreadPoolEngine
+
+_MOCK_BASE = "globus_compute_endpoint.engines.thread_pool."
+
+
+def test_sets_task_id(endpoint_uuid, task_uuid):
+    with mock.patch(f"{_MOCK_BASE}NativeExecutor"):
+        eng = ThreadPoolEngine()
+        eng.start(endpoint_id=endpoint_uuid)
+        f = GCFuture(gc_task_id=task_uuid)
+        eng.submit(f, b"bytes", {})
+        assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/test_gcfuture.py
+++ b/compute_endpoint/tests/unit/test_gcfuture.py
@@ -1,0 +1,33 @@
+import uuid
+
+import pytest
+from globus_compute_endpoint.engines import GCFuture
+
+
+def test_gcfuture_happy_path():
+    tid = uuid.uuid4()
+    f = GCFuture(gc_task_id=tid)
+    f.executor_task_id = 1
+    assert f.gc_task_id == tid
+    assert f.executor_task_id == 1
+
+
+def test_gcfuture_task_id_coerced():
+    tid = uuid.uuid4()
+    fraw = GCFuture(gc_task_id=tid)
+    fstr = GCFuture(gc_task_id=str(tid))
+    assert fraw.gc_task_id == fstr.gc_task_id
+    assert isinstance(fstr.gc_task_id, uuid.UUID)
+
+
+@pytest.mark.parametrize("ex_tid", (None, 1, "1"))
+def test_gcfuture_repr(ex_tid):
+    tid = uuid.uuid4()
+    tids = str(tid)
+    f = GCFuture(gc_task_id=tid)
+    assert f"gc_task_id={tids!r}" in repr(f)
+    assert "executor_task_id=None" in repr(f)
+
+    f = GCFuture(gc_task_id=tid, executor_task_id=ex_tid)
+    assert f"gc_task_id={tids!r}" in repr(f)
+    assert f"executor_task_id={ex_tid!r}" in repr(f)


### PR DESCRIPTION
Parsl adds a `parsl_executor_task_id` attribute to the Futures it returns; translate this to a generic name, and teach all executors to have an `executor_task_id` before setting that on the `GCFuture` returned to the interchange.

[sc-35488]

## Type of change

- New feature (well, progress _toward_ the user-facing feature; still internal days)
