### PR TITLE
context manager not needed for RequestsMock

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -106,7 +106,6 @@ def test_start_endpoint_data_passthrough(fs):
     assert req_json["subscription_uuid"] == str(ep_conf.subscription_id)
 
 
-@responses.activate
 def test_stop_remote_endpoint(mocker):
     ep_uuid = "some-uuid"
     ep_dir = pathlib.Path("some_ep_dir") / "abc-endpoint"


### PR DESCRIPTION
While in a hurry to review the previous one, missed that the decorator isn't needed any longer now that you moved its use to two context managed calls