### PR TITLE
Enable HA function registration

### DIFF
--- a/changelog.d/20250404_172727_30907815+rjmello_ha_endpoint_id.rst
+++ b/changelog.d/20250404_172727_30907815+rjmello_ha_endpoint_id.rst
@@ -1,0 +1,11 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Enabled support for registering a function to a specific HA endpoint via the
+  ``ha_endpoint_id`` argument in the following methods:
+
+  - :meth:`~globus_compute_sdk.Client.register_function`
+  - :meth:`~globus_compute_sdk.Executor.register_function`
+
+  Since HA functions cannot be shared, this argument is mutually exclusive with the
+  ``group`` and ``public`` arguments.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -722,6 +722,7 @@ class Client:
         public=False,
         group=None,
         searchable=None,
+        ha_endpoint_id: UUID_LIKE_T | None = None,
     ) -> str:
         """Register a function code with the Globus Compute service.
 
@@ -750,6 +751,10 @@ class Client:
             appropriate permissions
 
             DEPRECATED - ingesting functions to Globus Search is not currently supported
+        ha_endpoint_id : UUID | str | None
+            Users will only be able to run this function on the specified HA endpoint.
+            Since HA functions cannot be shared, this argument is mutually exclusive
+            with the ``group`` and ``public`` arguments.
 
         Returns
         -------
@@ -773,6 +778,7 @@ class Client:
             public=public,
             group=group,
             serializer=self.fx_serializer,
+            ha_endpoint_id=ha_endpoint_id,
         )
         logger.info("Registering function: %s", data.function_name)
         logger.debug("Function data: %s", data)

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -52,6 +52,7 @@ class FunctionRegistrationData:
         public: bool = False,
         group: t.Optional[str] = None,
         serializer: t.Optional[ComputeSerializer] = None,
+        ha_endpoint_id: t.Optional[UUID_LIKE_T] = None,
     ):
         if function is not None:
             if any((function_name, function_code, metadata)):
@@ -77,6 +78,11 @@ class FunctionRegistrationData:
                 " `function_code`, and `metadata`."
             )
 
+        if ha_endpoint_id and (public or group):
+            raise ValueError(
+                "`ha_endpoint_id` is mutually exclusive with `public` and `group`"
+            )
+
         if container_uuid:
             warnings.warn(
                 "`container_uuid` is deprecated and no longer specified per function;"
@@ -90,6 +96,7 @@ class FunctionRegistrationData:
         self.metadata = metadata
         self.public = public
         self.group = group
+        self.ha_endpoint_id = ha_endpoint_id
 
     def to_dict(self):
         data = {
@@ -103,6 +110,8 @@ class FunctionRegistrationData:
             data["public"] = True
         if self.group:
             data["group"] = self.group
+        if self.ha_endpoint_id:
+            data["ha_endpoint_id"] = self.ha_endpoint_id
         return data
 
     def __repr__(self) -> str:

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -452,20 +452,6 @@ def test_function_registration_data_data_function(serde):
     assert frd.metadata.serde_identifier == serde.code_serializer.identifier.strip()
 
 
-@pytest.mark.parametrize("missing", ("description", "public", "group"))
-def test_function_registration_data_optional_data(missing):
-    cond_data = {
-        "description": "some description",
-        "public": True,
-        "group": "some gorup",
-    }
-    cond_data.pop(missing)
-    frd = FunctionRegistrationData(function=funk, **cond_data)
-
-    for k, v in cond_data.items():
-        assert getattr(frd, k) == v, frd.to_dict()
-
-
 @pytest.mark.parametrize("desc", ("some desc", None))
 @pytest.mark.parametrize("public", (True, False))
 @pytest.mark.parametrize("group", ("some group", None))


### PR DESCRIPTION
# Description

Enabled support for registering a function to a specific HA endpoint via the `ha_endpoint_id` argument in the `register_function` methods of the `Client` and `Executor` classes.

Since HA functions cannot be shared, this argument is mutually exclusive with the `group` and `public` arguments.

[sc-35310](https://app.shortcut.com/globus/story/35310/allow-a-function-to-be-marked-as-restricted-to-a-specific-ha-endpoint)

## Type of change

- New feature (non-breaking change that adds functionality)
