### PR TITLE
Add Parsl monitoring queue

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -306,7 +306,7 @@ class EndpointInterchange:
             while not self._quiesce_event.wait(timeout=1):
                 for task_id, packed_result in self.result_store:
                     log.debug("Retrieved stored result (%s)", task_id)
-                    f = GCFuture(gc_task_id=task_id)
+                    f = GCFuture(task_id)
                     f.add_done_callback(forward_result)
                     f.set_result(packed_result)
                     self.result_store.discard(task_id)
@@ -395,10 +395,9 @@ class EndpointInterchange:
                         prop_headers.get("resource_specification") or "null"
                     )
                     res_spec: dict = json.loads(res_spec_s) or {}
-
                     res_serde: list[str] = prop_headers.get("result_serializers") or []
 
-                    task_f = GCFuture(gc_task_id=tid)
+                    task_f = GCFuture(tid, function_id=fid)
                     task_f.add_done_callback(forward_result)  # type: ignore[arg-type]
 
                     if fid and not self.function_allowed(fid):

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_shell_functions.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_shell_functions.py
@@ -9,7 +9,7 @@ def test_shell_function(engine_runner, tmp_path, task_uuid, serde, ez_pack_task)
     engine = engine_runner(GlobusComputeEngine)
     shell_func = ShellFunction("pwd")
     task_bytes = ez_pack_task(shell_func)
-    future = GCFuture(gc_task_id=task_uuid)
+    future = GCFuture(task_uuid)
     engine.submit(future, task_bytes, resource_specification={})
 
     packed_result = future.result()
@@ -41,7 +41,7 @@ def test_fail_shell_function(
     engine = engine_runner(GlobusComputeEngine, run_in_sandbox=True)
     shell_func = ShellFunction(cmd, walltime=0.1)
     task_bytes = ez_pack_task(shell_func)
-    future = GCFuture(gc_task_id=task_uuid)
+    future = GCFuture(task_uuid)
     engine.submit(future, task_bytes, resource_specification={})
 
     packed_result = future.result()
@@ -60,7 +60,7 @@ def test_no_sandbox(engine_runner, task_uuid, serde, ez_pack_task):
     engine = engine_runner(GlobusComputeEngine, run_in_sandbox=False)
     shell_func = ShellFunction("pwd")
     task_bytes = ez_pack_task(shell_func)
-    future = GCFuture(gc_task_id=task_uuid)
+    future = GCFuture(task_uuid)
     engine.submit(future, task_bytes, resource_specification={})
 
     packed_result = future.result()

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -19,6 +19,7 @@ class MockHTEX:
     def __init__(self, fail_count=1):
         self._task_counter = 0
         self.fail_count = fail_count
+        self.monitoring_messages = mock.Mock()
         self.ex = ThreadPoolExecutor()
 
     def submit(self, func, _resource_spec, *args, **kwargs):
@@ -66,7 +67,7 @@ def test_success_after_fails(mock_gce, serde, ez_pack_task, fail_count):
     task_bytes = ez_pack_task(double, num)
 
     engine.executor.fail_count = fail_count
-    f = GCFuture(gc_task_id=task_id)
+    f = GCFuture(task_id)
     engine.submit(f, task_bytes, resource_specification={})
 
     packed_result: bytes = f.result()
@@ -86,7 +87,7 @@ def test_repeated_fail(mock_gce, ez_pack_task, fail_count):
 
     # Set executor to continue failures beyond retry limit
     engine.executor.fail_count = fail_count + 1
-    f = GCFuture(gc_task_id=task_id)
+    f = GCFuture(task_id)
     engine.submit(f, task_bytes, resource_specification={})
 
     packed_result = f.result()

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -19,7 +19,7 @@ def test_mpi_function(engine_runner, nodeslist, serde, task_uuid, ez_pack_task):
 
     mpi_func = MPIFunction("pwd")
     task_bytes = ez_pack_task(mpi_func)
-    future = GCFuture(gc_task_id=task_uuid)
+    future = GCFuture(task_uuid)
     engine.submit(future, task_bytes, resource_specification=resource_spec)
 
     packed_result = future.result(timeout=10)
@@ -37,7 +37,7 @@ def test_env_vars(engine_runner, nodeslist, serde, task_uuid, ez_pack_task):
     engine = engine_runner(GlobusMPIEngine)
     task_bytes = ez_pack_task(get_env_vars)
     num_nodes = random.randint(1, len(nodeslist))
-    future = GCFuture(gc_task_id=task_uuid)
+    future = GCFuture(task_uuid)
     engine.submit(
         future,
         task_bytes,

--- a/compute_endpoint/tests/unit/engine/test_base.py
+++ b/compute_endpoint/tests/unit/engine/test_base.py
@@ -1,0 +1,30 @@
+from globus_compute_endpoint.engines import GCFuture, ThreadPoolEngine
+from tests.utils import double
+
+
+class _Dict(dict):
+    def __init__(self, *a, **k):
+        self.deleted_items = []
+        super().__init__(*a, **k)
+
+    def pop(self, key, *a, **k):
+        val = dict.pop(self, key, *a, **k)
+        self.deleted_items.append((key, val))
+        return val
+
+
+def test_tasks_cleared_when_complete(ez_pack_task, endpoint_uuid, task_uuid):
+    # important for memory that we clean up each task
+    eng = ThreadPoolEngine()
+    eng.start(endpoint_id=endpoint_uuid)
+    eng._task_id_map = _Dict()
+    task_bytes = ez_pack_task(double, 1)
+    f = GCFuture(task_uuid)
+
+    eng.submit(f, task_bytes, {})
+
+    _ = f.result()  # ensure task is done before test continues
+    assert len(eng._task_id_map) == 0
+    ex_tid, ex_fut = eng._task_id_map.deleted_items[-1]
+    assert ex_tid == f.executor_task_id
+    assert ex_fut is f

--- a/compute_endpoint/tests/unit/engine/test_globuscompute.py
+++ b/compute_endpoint/tests/unit/engine/test_globuscompute.py
@@ -151,20 +151,20 @@ def test_status_report_provider_specific_terms(
     assert sr.global_state["account"] == account_val
 
 
-def test_status_poller_started_late(fs, htex, mock_jsp, ep_uuid):
+def test_status_poller_started_late(tmp_path, htex, mock_jsp, ep_uuid):
     gce = GlobusComputeEngine(endpoint_id=ep_uuid, executor=htex)
     assert gce.job_status_poller is None, "JSP must be started *after* daemonization"
     assert not mock_jsp.called, "`.start()` not yet invoked."
-    gce.start(endpoint_id=ep_uuid, run_dir="/")
+    gce.start(endpoint_id=ep_uuid, run_dir=str(tmp_path))
     assert mock_jsp.called, "Expect JSP created in engine's process"
     assert gce.job_status_poller is not None
     a, _ = gce.job_status_poller.add_executors.call_args
     assert a[0] == [htex], "Expect executor to be polled"
 
 
-def test_sets_task_id(fs, mock_htex, endpoint_uuid, task_uuid):
+def test_sets_task_id(tmp_path, mock_htex, endpoint_uuid, task_uuid):
     eng = GlobusComputeEngine(executor=mock_htex)
-    eng.start(endpoint_id=endpoint_uuid, run_dir="/")
-    f = GCFuture(gc_task_id=task_uuid)
+    eng.start(endpoint_id=endpoint_uuid, run_dir=str(tmp_path))
+    f = GCFuture(task_uuid)
     eng.submit(f, b"bytes", {})
     assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/engine/test_globusmpi.py
+++ b/compute_endpoint/tests/unit/engine/test_globusmpi.py
@@ -3,9 +3,9 @@ from globus_compute_endpoint.engines import GCFuture, GlobusMPIEngine
 _MOCK_BASE = "globus_compute_endpoint.engines.globus_mpi."
 
 
-def test_sets_task_id(fs, mock_mpiex, endpoint_uuid, task_uuid):
+def test_sets_task_id(tmp_path, mock_mpiex, endpoint_uuid, task_uuid):
     eng = GlobusMPIEngine(executor=mock_mpiex)
-    eng.start(endpoint_id=endpoint_uuid, run_dir="/")
-    f = GCFuture(gc_task_id=task_uuid)
+    eng.start(endpoint_id=endpoint_uuid, run_dir=str(tmp_path))
+    f = GCFuture(task_uuid)
     eng.submit(f, b"bytes", {})
     assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/engine/test_processpool.py
+++ b/compute_endpoint/tests/unit/engine/test_processpool.py
@@ -9,6 +9,6 @@ def test_sets_task_id(endpoint_uuid, task_uuid):
     with mock.patch(f"{_MOCK_BASE}NativeExecutor"):
         eng = ProcessPoolEngine()
         eng.start(endpoint_id=endpoint_uuid)
-        f = GCFuture(gc_task_id=task_uuid)
+        f = GCFuture(task_uuid)
         eng.submit(f, b"bytes", {})
         assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/engine/test_threadpool.py
+++ b/compute_endpoint/tests/unit/engine/test_threadpool.py
@@ -9,6 +9,6 @@ def test_sets_task_id(endpoint_uuid, task_uuid):
     with mock.patch(f"{_MOCK_BASE}NativeExecutor"):
         eng = ThreadPoolEngine()
         eng.start(endpoint_id=endpoint_uuid)
-        f = GCFuture(gc_task_id=task_uuid)
+        f = GCFuture(task_uuid)
         eng.submit(f, b"bytes", {})
         assert f.executor_task_id is not None

--- a/compute_endpoint/tests/unit/test_gcfuture.py
+++ b/compute_endpoint/tests/unit/test_gcfuture.py
@@ -1,3 +1,5 @@
+import random
+import typing as t
 import uuid
 
 import pytest
@@ -6,7 +8,7 @@ from globus_compute_endpoint.engines import GCFuture
 
 def test_gcfuture_happy_path():
     tid = uuid.uuid4()
-    f = GCFuture(gc_task_id=tid)
+    f = GCFuture(tid)
     f.executor_task_id = 1
     assert f.gc_task_id == tid
     assert f.executor_task_id == 1
@@ -14,20 +16,71 @@ def test_gcfuture_happy_path():
 
 def test_gcfuture_task_id_coerced():
     tid = uuid.uuid4()
-    fraw = GCFuture(gc_task_id=tid)
-    fstr = GCFuture(gc_task_id=str(tid))
+    fraw = GCFuture(tid)
+    fstr = GCFuture(str(tid))
     assert fraw.gc_task_id == fstr.gc_task_id
     assert isinstance(fstr.gc_task_id, uuid.UUID)
 
 
-@pytest.mark.parametrize("ex_tid", (None, 1, "1"))
-def test_gcfuture_repr(ex_tid):
+def test_gcfuture_function_id_coerced():
     tid = uuid.uuid4()
-    tids = str(tid)
-    f = GCFuture(gc_task_id=tid)
-    assert f"gc_task_id={tids!r}" in repr(f)
-    assert "executor_task_id=None" in repr(f)
+    fraw = GCFuture(tid, function_id=tid)
+    fstr = GCFuture(tid, function_id=str(tid))
+    fadd = GCFuture(tid)
+    fadd.function_id = str(tid)
+    assert fraw.function_id == fstr.function_id
+    assert fraw.function_id == fadd.function_id
+    assert isinstance(fraw.function_id, uuid.UUID)
 
-    f = GCFuture(gc_task_id=tid, executor_task_id=ex_tid)
-    assert f"gc_task_id={tids!r}" in repr(f)
-    assert f"executor_task_id={ex_tid!r}" in repr(f)
+
+@pytest.mark.parametrize("tid", (uuid.uuid4(), str(uuid.uuid4())))
+@pytest.mark.parametrize("fid", (None, str(uuid.uuid4())))
+@pytest.mark.parametrize("bid", (None, 1, "1"))
+@pytest.mark.parametrize("jid", (None, 2, "2"))
+@pytest.mark.parametrize("ex_tid", (None, 3, "3"))
+def test_gcfuture_repr(tid, fid, bid, jid, ex_tid):
+    f = GCFuture(
+        tid,
+        function_id=fid,
+        block_id=bid,
+        job_id=jid,
+        executor_task_id=ex_tid,
+    )
+    tids = str(tid)
+
+    r = repr(f)
+    assert f"{tids!r}" in r
+
+    assert (fid is None and "function_id" not in r) ^ (f"function_id={fid!r}" in r)
+    assert (bid is None and "block_id" not in r) ^ (f"block_id={bid!r}" in r)
+    assert (jid is None and "job_id" not in r) ^ (f"job_id={jid!r}" in r)
+    assert (ex_tid is None and "executor_task_id" not in r) ^ (
+        f"executor_task_id={ex_tid!r}" in r
+    )
+
+
+def test_gcfuture_bind():
+    def val_change(name: str) -> t.Callable[[GCFuture, t.Any], None]:
+        def _(fut: GCFuture, new_val) -> None:
+            changed[name] = new_val
+
+        return _
+
+    changed = {}
+    f = GCFuture(uuid.uuid4())
+    f.bind("block_id", val_change("bid"))
+    f.bind("job_id", val_change("jid"))
+    f.bind("executor_task_id", val_change("exid"))
+    for _ in range(3):
+        new_bid = random.randint(0, 1000)
+        new_jid = random.randint(2000, 3000)
+        new_exid = random.randint(4000, 5000)
+        f.block_id = new_bid
+        assert changed["bid"] == new_bid
+        f.job_id = new_jid
+        assert changed["jid"] == new_jid
+        f.executor_task_id = new_exid
+        assert changed["exid"] == new_exid
+    assert "bid" in changed
+    assert "jid" in changed
+    assert "exid" in changed

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -106,9 +106,7 @@ def test_submit_pass(tmp_path, task_uuid, mock_gcengine):
     mock_gcengine.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
 
     mock_gcengine.submit(
-        task_f=GCFuture(gc_task_id=task_uuid),
-        packed_task=b"PACKED_TASK",
-        resource_specification={},
+        task_f=GCFuture(task_uuid), packed_task=b"SomeBytes", resource_specification={}
     )
 
     mock_gcengine.executor.submit.assert_called()


### PR DESCRIPTION
Tell Parsl to send monitoring events (when nodes have new state/tasks), and then watch the incoming monitoring information to update each task with block and job identifiers.

Because jobs can be rescheduled or retried internally, also implement an observer pattern to account for updates to the GCFuture information.

[sc-35488]

## Type of change

- New feature (still internal days yet)