### PR TITLE
remove reference to Globus RPM-GPG-KEY from DEB and RPM instructions

### DIFF
--- a/docs/endpoints/installation.rst
+++ b/docs/endpoints/installation.rst
@@ -90,7 +90,7 @@ RPM Installation
 
 .. code-block::
 
-   # install Globus' public key
+   # get the Globus installer
    dnf install https://downloads.globus.org/globus-connect-server/stable/installers/repo/rpm/globus-repo-latest.noarch.rpm
 
    # install the Globus Compute Agent package
@@ -101,10 +101,9 @@ DEB Installation
 
 .. code-block::
 
-   # install Globus' public key
+   # get the Globus installer
    curl -LOs https://downloads.globus.org/globus-connect-server/stable/installers/repo/deb/globus-repo_latest_all.deb
    dpkg -i globus-repo_latest_all.deb
-   apt-key add /usr/share/globus-repo/RPM-GPG-KEY-Globus
 
    # install the Globus Compute Agent package
    apt update


### PR DESCRIPTION
The apt-key file `/usr/share/globus-repo/RPM-GPG-KEY-Globus` is apparently deprecated for DEB and RPM and the file is no longer included, so removing the lines from readthedocs installation instructions for packages.

Based on [GCS docs here](https://docs.globus.org/globus-connect-server/v5/#gcsv5-install)

See https://globus.slack.com/archives/C0896RYMBGX/p1744228361088989