### PR TITLE
Implement UEP audit method

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -577,6 +577,7 @@ def _do_start_endpoint(
     ep_info = {}
     reg_info = {}
     config_str: str | None = None
+    audit_fd: int | None = None
     fn_allow_list: list[str] | None | int = _no_fn_list_canary
     if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
         try:
@@ -591,7 +592,8 @@ def _do_start_endpoint(
 
             ep_info = stdin_data.get("ep_info", {})
             reg_info = stdin_data.get("amqp_creds", {})
-            config_str = stdin_data.get("config", None)
+            config_str = stdin_data.get("config")
+            audit_fd = stdin_data.get("audit_fd")
             fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
 
             del stdin_data  # clarity for intended scope
@@ -656,6 +658,7 @@ def _do_start_endpoint(
                 reg_info,
                 ep_info,
                 die_with_parent,
+                audit_fd,
             )
 
     except (SystemExit, Exception) as e:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -346,6 +346,7 @@ class Endpoint:
         reg_info: dict,
         ep_info: dict,
         die_with_parent: bool = False,
+        audit_fd: int | None = None,
     ):
         # If we are running a full detached daemon then we will send the output to
         # log files, otherwise we can piggy back on our stdout
@@ -416,6 +417,9 @@ class Endpoint:
             raise
 
         try:
+            files_preserve = []
+            if audit_fd:
+                files_preserve.append(audit_fd)
             pid_file = endpoint_dir / "daemon.pid"
             context = daemon.DaemonContext(
                 working_directory=endpoint_dir,
@@ -424,6 +428,7 @@ class Endpoint:
                 stdout=stdout,
                 stderr=stderr,
                 detach_process=endpoint_config.detach_endpoint,
+                files_preserve=files_preserve,
             )
 
         except Exception:
@@ -599,6 +604,7 @@ class Endpoint:
                 result_store,
                 parent_pid,
                 ep_info,
+                audit_fd,
             )
 
     @staticmethod
@@ -610,6 +616,7 @@ class Endpoint:
         result_store: ResultStore,
         parent_pid: int,
         ep_info: dict,
+        audit_fd: int | None,
     ):
         log.info(f"\n\n========== Endpoint begins: {endpoint_uuid}")
 
@@ -622,6 +629,7 @@ class Endpoint:
             logdir=endpoint_dir,
             parent_pid=parent_pid,
             ep_info=ep_info,
+            audit_fd=audit_fd,
         )
 
         interchange.start()

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -36,6 +36,9 @@ class MockEngine(unittest.mock.Mock):
         result_serializers: t.Optional[t.List[str]] = None,
     ):
         task: Task = messagepack.unpack(packed_task)
+        task_f.executor_task_id = 1
+        task_f.job_id = 12
+        task_f.block_id = 123
         res = Result(task_id=task_f.gc_task_id, data=task.task_buffer)
 
         # This is a hack to trigger an InvalidResourceSpecification

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -255,7 +255,7 @@ def test_endpoint_uuid_name_not_supported(run_line, cli_cmd):
         (True, json.dumps({"config": "myconfig"})),
         (True, json.dumps({"amqp_creds": {}, "config": ""})),
         (True, json.dumps({"amqp_creds": {"a": 1}, "config": "myconfig"})),
-        (True, json.dumps({"amqp_creds": {}, "config": "myconfig"})),
+        (True, json.dumps({"amqp_creds": {}, "config": "myconfig", "audit_fd": 1})),
     ],
 )
 def test_start_ep_reads_stdin(
@@ -280,14 +280,18 @@ def test_start_ep_reads_stdin(
     run_line(f"start {ep_name}")
     mock_ep, _ = mock_cli_state
     assert mock_ep.start_endpoint.called
-    reg_info_found = mock_ep.start_endpoint.call_args[0][5]
+    s_ep_a, _ = mock_ep.start_endpoint.call_args
+    reg_info_found = s_ep_a[5]
+    audit_fd_found = s_ep_a[8]
 
     if data_is_valid:
         data_dict = json.loads(data)
         reg_info = data_dict.get("amqp_creds", {})
-        config_str = data_dict.get("config", None)
+        config_str = data_dict.get("config")
+        audit_fd = data_dict.get("audit_fd")
 
         assert reg_info_found == reg_info
+        assert audit_fd_found == audit_fd
         if config_str:
             config_str_found = mock_load_conf.call_args[0][0]
             assert config_str_found == config_str

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -198,9 +198,9 @@ def test_start_endpoint_populates_ep_static_info(
         ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info=ep_info)
     assert mock_launch.called, "Should launch successfully"
 
-    (*_, found), _k = mock_launch.call_args
+    (*_, found, _audit_fd), _k = mock_launch.call_args
     assert found is ep_info
-    assert found["canary"] == canary_value, "Should *add* data, no overwrite"
+    assert found["canary"] == canary_value, "Should *add* data, not overwrite"
 
     found_start_iso = datetime.fromisoformat(found["start_iso"])
     found_start_unix = found["start_unix"]


### PR DESCRIPTION
The implementation is fairly self-explanatory: call a method at opportune points in a task lifetime on the endpoint.  Points of note:

- Enforce that audit logging is only available for HA endpoints by removing the `audit()`ing method implementation`

- Events logged are `RECEIVED`, `EXEC_START`, `RUNNING`, and `EXEC_END` to denote when the task is received by the interchange, when it's received by the executor, when it's known to be running (i.e., if assigned to a `block_id`), and when the execution is complete.

- Auditing records are written to an externally provided file descriptor. Pragmatically, this means that auditing will only be available to UEPs on HA MEPs.

[sc-35488]

## Type of change

- New feature (not user-functional yet; next PR)