### PR TITLE
Ensure failed audit setup shuts down MEP

### DIFF
--- a/compute_endpoint/tests/unit/test_mep_audit_log.py
+++ b/compute_endpoint/tests/unit/test_mep_audit_log.py
@@ -181,6 +181,19 @@ def test_audit_log_shutsdown_on_write_error(
     assert em._time_to_stop, "Key outcome"
 
 
+def test_audit_log_shutsdown_on_general_error(
+    tmp_path, ep_uuid, conf, reg_info, mock_os, randomstring
+):
+    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+
+    exc_text = randomstring()
+    with mock.patch(f"{_MOCK_BASE}open", side_effect=MemoryError(exc_text)):
+        with pytest.raises(MemoryError) as pyt_e:
+            em._audit_log_impl()
+    assert exc_text in str(pyt_e.value), "Verify that test induced failure"
+    assert em._time_to_stop is True, "Expect shutdown, no matter the error"
+
+
 def test_audit_log_pipe_hookup(mock_log, tmp_path, ep_uuid, conf, reg_info, mock_os):
     em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
 


### PR DESCRIPTION
Don't overthink it&nbsp;&mdash;&nbsp;if the audit method has a problem, there is a problem. Don't fix it, ignore it, or attempt to be graceful.  Explode the log with the traceback (we already do), and *shut down the MEP.*

To the reviewer: consider ignoring whitespace to see the salient change.  (`try: ... finally:`)

[sc-35488]

## Type of change

- Bug fix (a not-yet-release bug, but still)