### PR TITLE
change HA policy creation to be based on configure HA flag, not timeout

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -447,6 +447,7 @@ def configure_endpoint(
             description=auth_policy_description,
             include_domains=include_domain_list,
             exclude_domains=exclude_domain_list,
+            high_assurance=high_assurance or MISSING,
             timeout=auth_timeout or MISSING,
             require_mfa=auth_policy_mfa_required or MISSING,
         )
@@ -883,6 +884,7 @@ def create_auth_policy(
     description: str,
     include_domains: list[str] | MissingType,
     exclude_domains: list[str] | MissingType,
+    high_assurance: bool | MissingType,
     timeout: int | MissingType,
     require_mfa: bool | MissingType,
 ) -> str:
@@ -890,7 +892,6 @@ def create_auth_policy(
     Uses the Globus SDK to create an auth policy and returns
     the policy_id after creation
     """
-
     try:
         resp = ac.create_policy(
             project_id=project_id,
@@ -898,7 +899,7 @@ def create_auth_policy(
             description=description,
             domain_constraints_include=include_domains,
             domain_constraints_exclude=exclude_domains,
-            high_assurance=bool(timeout),
+            high_assurance=high_assurance,
             authentication_assurance_timeout=timeout,
             required_mfa=require_mfa,
         )

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -970,6 +970,7 @@ def test_configure_ep_auth_policy_defaults(
         "description": _AUTH_POLICY_DEFAULT_DESC,
         "include_domains": MISSING,
         "exclude_domains": MISSING,
+        "high_assurance": MISSING,
         "timeout": MISSING,
         "require_mfa": MISSING,
     }
@@ -1008,6 +1009,7 @@ def test_configure_ep_auth_param_parse(
         "description": "policy desc",
         "include_domains": ["xyz.com", "example.org"],
         "exclude_domains": ["nope.com"],
+        "high_assurance": True,
         "timeout": 30,
         "require_mfa": True,
     }
@@ -1065,34 +1067,6 @@ def test_configure_ep_auth_policy_creates_or_chooses_project(
     )
 
     assert isinstance(res.exception, StopTest)
-
-
-@pytest.mark.parametrize("timeout", [None] + list(range(5)))
-def test_configure_ep_auth_policy_timeout_sets_ha(
-    mocker,
-    run_line,
-    mock_cli_state,
-    make_endpoint_dir,
-    ep_name,
-    mock_app: UserApp,
-    mock_auth_client: ComputeAuthClient,
-    timeout,
-):
-    mock_auth_client.create_policy.return_value = {"policy": {"id": "foo"}}
-
-    if timeout is None:
-        line = f"configure --auth-policy-project-id=bar {ep_name}"
-    else:
-        line = (
-            f"configure --auth-policy-project-id=bar --auth-timeout={timeout} {ep_name}"
-        )
-
-    run_line(line)
-
-    assert mock_auth_client.create_policy.called
-    assert mock_auth_client.create_policy.call_args.kwargs["high_assurance"] == bool(
-        timeout
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See thread https://globus.slack.com/archives/C0896RYMBGX/p1744755803507389

We want to create an HA policy based on the endpoint configure value, not whether there's a timeout.