### PR TITLE
remove language that associates timeouts with high-assurance

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -359,10 +359,7 @@ def version_command():
 )
 @optgroup.option(
     "--auth-timeout",
-    help=(
-        "How old (in seconds) a login session can be and still be compliant. "
-        "If set, the auth policy will be High Assurance(HA)"
-    ),
+    help="How old (in seconds) a login session can be and still be compliant",
     type=click.IntRange(min=0),
     default=None,
 )


### PR DESCRIPTION
We have already changed a policy's HA-ness to be based on the user's endpoint configure flag instead of timeout in https://github.com/globus/globus-compute/pull/1860 but missed changing the help message.  

This just removes that part of the help text for --timeout