### PR TITLE
Adds podman-hpc for running at NERSC

### DIFF
--- a/changelog.d/20250423_130657_nicholas.s.tyler.4_add_podman_hpc.rst
+++ b/changelog.d/20250423_130657_nicholas.s.tyler.4_add_podman_hpc.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added support for podman-hpc in :class:`~globus_compute_endpoint.engines.globus_compute.GlobusComputeEngine` as a supported container type

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -24,20 +24,12 @@ from parsl.multiprocessing import SpawnQueue
 
 logger = logging.getLogger(__name__)
 # Docker, podman, and podman-hpc all use the same syntax
-DOCKER_CMD_TEMPLATE = (
-    "{cmd_name} run {options} -v {rundir}:{rundir} -t {image} {command}"
-)
+DOCKER_CMD_TEMPLATE = "{cmd} run {options} -v {rundir}:{rundir} -t {image} {command}"
 # Apptainer and Singularity use the same syntax
-APPTAINER_CMD_TEMPLATE = "{cmd_name} run {options} {image} {command}"
-VALID_CONTAINER_TYPES = (
-    "docker",
-    "singularity",
-    "apptainer",
-    "podman",
-    "podman-hpc",
-    "custom",
-    None,
-)
+APPTAINER_CMD_TEMPLATE = "{cmd} run {options} {image} {command}"
+_DOCKER_TYPES = ("docker", "podman", "podman-hpc")
+_APPTAINER_TYPES = ("apptainer", "singularity")
+VALID_CONTAINER_TYPES = _DOCKER_TYPES + _APPTAINER_TYPES + ("custom", None)
 
 
 class JobStatusPollerKwargs(t.TypedDict, total=False):
@@ -227,17 +219,17 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         launch_cmd = self.executor.launch_cmd
         # Adding assert here since mypy can't figure out launch_cmd's type
         assert launch_cmd
-        if self.container_type in ["docker", "podman", "podman-hpc"]:
+        if self.container_type in _DOCKER_TYPES:
             launch_cmd = DOCKER_CMD_TEMPLATE.format(
-                cmd_name=self.container_type,
+                cmd=self.container_type,
                 image=self.container_uri,
                 rundir=self.run_dir,
                 command=launch_cmd,
                 options=self.container_cmd_options or "",
             )
-        elif self.container_type in ["apptainer", "singularity"]:
+        elif self.container_type in _APPTAINER_TYPES:
             launch_cmd = APPTAINER_CMD_TEMPLATE.format(
-                cmd_name=self.container_type,
+                cmd=self.container_type,
                 image=self.container_uri,
                 command=launch_cmd,
                 options=self.container_cmd_options or "",

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -24,10 +24,20 @@ from parsl.multiprocessing import SpawnQueue
 
 logger = logging.getLogger(__name__)
 # Docker, podman, and podman-hpc all use the same syntax
-DOCKER_CMD_TEMPLATE = "{cmd_name} run {options} -v {rundir}:{rundir} -t {image} {command}"
+DOCKER_CMD_TEMPLATE = (
+    "{cmd_name} run {options} -v {rundir}:{rundir} -t {image} {command}"
+)
 # Apptainer and Singularity use the same syntax
 APPTAINER_CMD_TEMPLATE = "{cmd_name} run {options} {image} {command}"
-VALID_CONTAINER_TYPES = ("docker", "singularity", "apptainer", "podman", "podman-hpc", "custom", None)
+VALID_CONTAINER_TYPES = (
+    "docker",
+    "singularity",
+    "apptainer",
+    "podman",
+    "podman-hpc",
+    "custom",
+    None,
+)
 
 
 class JobStatusPollerKwargs(t.TypedDict, total=False):

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -23,11 +23,11 @@ from parsl.monitoring.types import MessageType, TaggedMonitoringMessage
 from parsl.multiprocessing import SpawnQueue
 
 logger = logging.getLogger(__name__)
-DOCKER_CMD_TEMPLATE = "docker run {options} -v {rundir}:{rundir} -t {image} {command}"
-APPTAINER_CMD_TEMPLATE = "apptainer run {options} {image} {command}"
-SINGULARITY_CMD_TEMPLATE = "singularity run {options} {image} {command}"
-PODMAN_CMD_TEMPLATE = "podman run {options} -v {rundir}:{rundir} -t {image} {command}"
-VALID_CONTAINER_TYPES = ("docker", "singularity", "apptainer", "podman", "custom", None)
+# Docker, podman, and podman-hpc all use the same syntax
+DOCKER_CMD_TEMPLATE = "{cmd_name} run {options} -v {rundir}:{rundir} -t {image} {command}"
+# Apptainer and Singularity use the same syntax
+APPTAINER_CMD_TEMPLATE = "{cmd_name} run {options} {image} {command}"
+VALID_CONTAINER_TYPES = ("docker", "singularity", "apptainer", "podman", "podman-hpc", "custom", None)
 
 
 class JobStatusPollerKwargs(t.TypedDict, total=False):
@@ -217,29 +217,18 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         launch_cmd = self.executor.launch_cmd
         # Adding assert here since mypy can't figure out launch_cmd's type
         assert launch_cmd
-        if self.container_type == "docker":
+        if self.container_type in ["docker", "podman", "podman-hpc"]:
             launch_cmd = DOCKER_CMD_TEMPLATE.format(
+                cmd_name=self.container_type,
                 image=self.container_uri,
                 rundir=self.run_dir,
                 command=launch_cmd,
                 options=self.container_cmd_options or "",
             )
-        elif self.container_type == "apptainer":
+        elif self.container_type in ["apptainer", "singularity"]:
             launch_cmd = APPTAINER_CMD_TEMPLATE.format(
+                cmd_name=self.container_type,
                 image=self.container_uri,
-                command=launch_cmd,
-                options=self.container_cmd_options or "",
-            )
-        elif self.container_type == "singularity":
-            launch_cmd = SINGULARITY_CMD_TEMPLATE.format(
-                image=self.container_uri,
-                command=launch_cmd,
-                options=self.container_cmd_options or "",
-            )
-        elif self.container_type == "podman":
-            launch_cmd = PODMAN_CMD_TEMPLATE.format(
-                image=self.container_uri,
-                rundir=self.run_dir,
                 command=launch_cmd,
                 options=self.container_cmd_options or "",
             )

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -77,6 +77,14 @@ def test_podman(tmp_path, gce_factory):
     )
     assert container_launch_cmd.startswith(expected)
 
+def test_podman_hpx(tmp_path, gce_factory):
+    gce, exp_uri, exp_opts = gce_factory(container_type="podman-hpc")
+    container_launch_cmd = gce.executor.launch_cmd
+    expected = (
+        f"podman-hpc run {exp_opts} -v {tmp_path}:{tmp_path} -t"
+        f" {exp_uri} {_LAUNCH_CMD_PREFIX}"
+    )
+    assert container_launch_cmd.startswith(expected)
 
 def test_custom_missing_options(tmp_path):
     gce = GlobusComputeEngine(

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -5,9 +5,9 @@ from unittest import mock
 
 import pytest
 from globus_compute_endpoint.engines.globus_compute import (
-    GlobusComputeEngine,
     _APPTAINER_TYPES,
     _DOCKER_TYPES,
+    GlobusComputeEngine,
 )
 
 _MOCK_BASE = "globus_compute_endpoint.engines.globus_compute."

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -4,7 +4,11 @@ import uuid
 from unittest import mock
 
 import pytest
-from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
+from globus_compute_endpoint.engines.globus_compute import (
+    GlobusComputeEngine,
+    _APPTAINER_TYPES,
+    _DOCKER_TYPES,
+)
 
 _MOCK_BASE = "globus_compute_endpoint.engines.globus_compute."
 _LAUNCH_CMD_PREFIX = (
@@ -44,45 +48,20 @@ def gce_factory(tmp_path, randomstring) -> t.Callable:
         e.shutdown()
 
 
-def test_docker(tmp_path, gce_factory):
-    gce, exp_uri, exp_opts = gce_factory(container_type="docker")
+@pytest.mark.parametrize("contype", _APPTAINER_TYPES)
+def test_apptainer_type(gce_factory, contype):
+    gce, exp_uri, exp_opts = gce_factory(container_type=contype)
+    container_launch_cmd = gce.executor.launch_cmd
+    expected = f"{contype} run {exp_opts} {exp_uri} {_LAUNCH_CMD_PREFIX}"
+    assert container_launch_cmd.startswith(expected)
+
+
+@pytest.mark.parametrize("contype", _DOCKER_TYPES)
+def test_docker_type(tmp_path, gce_factory, contype):
+    gce, exp_uri, exp_opts = gce_factory(container_type=contype)
     container_launch_cmd = gce.executor.launch_cmd
     expected = (
-        f"docker run {exp_opts} -v {tmp_path}:{tmp_path} -t"
-        f" {exp_uri} {_LAUNCH_CMD_PREFIX}"
-    )
-    assert container_launch_cmd.startswith(expected)
-
-
-def test_apptainer(gce_factory):
-    gce, exp_uri, exp_opts = gce_factory(container_type="apptainer")
-    container_launch_cmd = gce.executor.launch_cmd
-    expected = f"apptainer run {exp_opts} {exp_uri} {_LAUNCH_CMD_PREFIX}"
-    assert container_launch_cmd.startswith(expected)
-
-
-def test_singularity(gce_factory, randomstring):
-    gce, exp_uri, exp_opts = gce_factory(container_type="singularity")
-    container_launch_cmd = gce.executor.launch_cmd
-    expected = f"singularity run {exp_opts} {exp_uri} {_LAUNCH_CMD_PREFIX}"
-    assert container_launch_cmd.startswith(expected)
-
-
-def test_podman(tmp_path, gce_factory):
-    gce, exp_uri, exp_opts = gce_factory(container_type="podman")
-    container_launch_cmd = gce.executor.launch_cmd
-    expected = (
-        f"podman run {exp_opts} -v {tmp_path}:{tmp_path} -t"
-        f" {exp_uri} {_LAUNCH_CMD_PREFIX}"
-    )
-    assert container_launch_cmd.startswith(expected)
-
-
-def test_podman_hpx(tmp_path, gce_factory):
-    gce, exp_uri, exp_opts = gce_factory(container_type="podman-hpc")
-    container_launch_cmd = gce.executor.launch_cmd
-    expected = (
-        f"podman-hpc run {exp_opts} -v {tmp_path}:{tmp_path} -t"
+        f"{contype} run {exp_opts} -v {tmp_path}:{tmp_path} -t"
         f" {exp_uri} {_LAUNCH_CMD_PREFIX}"
     )
     assert container_launch_cmd.startswith(expected)

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -77,6 +77,7 @@ def test_podman(tmp_path, gce_factory):
     )
     assert container_launch_cmd.startswith(expected)
 
+
 def test_podman_hpx(tmp_path, gce_factory):
     gce, exp_uri, exp_opts = gce_factory(container_type="podman-hpc")
     container_launch_cmd = gce.executor.launch_cmd
@@ -85,6 +86,7 @@ def test_podman_hpx(tmp_path, gce_factory):
         f" {exp_uri} {_LAUNCH_CMD_PREFIX}"
     )
     assert container_launch_cmd.startswith(expected)
+
 
 def test_custom_missing_options(tmp_path):
     gce = GlobusComputeEngine(

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -443,6 +443,7 @@ following options:
     * ``docker``
     * ``singularity``
     * ``podman``
+    * ``podman-hpc``
     * ``custom``
     * ``None``
 


### PR DESCRIPTION
# Description

This both adds `podman-hpc` as a container runtime for running containers at HPC centers like NERSC. It also reduces some code duplication for running similar container runtimes.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
