### PR TITLE
JSON-escape user_runtime in UEP config template

### DIFF
--- a/changelog.d/20250428_144312_30907815+rjmello_escape_user_runtime.rst
+++ b/changelog.d/20250428_144312_30907815+rjmello_escape_user_runtime.rst
@@ -1,0 +1,7 @@
+Security
+^^^^^^^^^
+
+- Apply JSON escaping to the values of the ``user_runtime`` Jinja variable
+  passed to the user endpoint configuration template. This matches our handling
+  of user-provided template variables and helps endpoint administrators prevent
+  YAML injection attacks.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -264,6 +264,9 @@ def render_config_user_template(
     _validate_user_opts(_user_opts, user_config_schema)
     _user_opts = _sanitize_user_opts(_user_opts)
 
+    _user_runtime = user_runtime or {}
+    _user_runtime = _sanitize_user_opts(_user_runtime)
+
     user_config_template_dir = user_config_template_path.parent
     try:
         list(user_config_template_dir.iterdir())
@@ -283,7 +286,7 @@ def render_config_user_template(
 
     try:
         return template.render(
-            **_user_opts, parent_config=parent_config, user_runtime=user_runtime
+            **_user_opts, parent_config=parent_config, user_runtime=_user_runtime
         )
     except jinja2.exceptions.UndefinedError as e:
         log.debug("Missing required user option: %s", e)


### PR DESCRIPTION
# Description

Apply JSON escaping to the values of the ``user_runtime`` Jinja variable passed to the user endpoint configuration template. This matches our handling of user-provided template variables and helps endpoint administrators prevent YAML injection attacks.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
