### PR TITLE
Invert mistaken boolean conditional

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -203,7 +203,7 @@ class EndpointInterchange:
 
             def _parent_watcher(ppid: int):
                 while ppid == os.getppid():
-                    if not self._quiesce_event.wait(timeout=1):
+                    if self._quiesce_event.wait(timeout=1):
                         return
                 log.warning(f"Parent ({ppid}) has gone away; initiating shut down")
                 self.stop()

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -168,12 +168,13 @@ def test_die_with_parent_refuses_to_start_if_not_parent(mocker, ep_ix_factory):
     assert "refusing to start" in warn_msg
 
 
-def test_die_with_parent_goes_away_if_parent_dies(mocker, ep_ix_factory, mock_rp):
-    ppid = os.getppid()
+def test_die_with_parent_goes_away_if_parent_dies(
+    mocker, ep_ix_factory, mock_rp, mock_tqs
+):
+    ppid = random.randint(2, 1_000_000)
 
-    mocker.patch(f"{_MOCK_BASE}time.sleep")
     mock_ppid = mocker.patch(f"{_MOCK_BASE}os.getppid")
-    mock_ppid.side_effect = (ppid, 1)
+    mock_ppid.side_effect = [ppid] * 100 + [1]  # sometime in future, parent dies
     ei = ep_ix_factory(parent_pid=ppid)
     mock_warn = mocker.patch.object(log, "warning")
     assert not ei.time_to_quit, "Verify test setup"


### PR DESCRIPTION
To date, the thread has quit immediately before completing the first iteration. This is a mistake as the thread should stay around for the life of the endpoint to verify that the parent always exists.  Whoops!

The automated test missed this because while it verified the loop conditional, it did not verify the internal conditional.  Correct by ensuring loop iterates at least a few times.  (Overkill to 100, "just because.")

## Type of change

- Bug fix (non-breaking change that fixes an issue)