### PR TITLE
Implement Endpoint manager hot restart

### DIFF
--- a/changelog.d/20250430_135103_kevin_implement_mep_hot_restart.rst
+++ b/changelog.d/20250430_135103_kevin_implement_mep_hot_restart.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Implement hot-restart functionality for Multi-user endpoint.  See
+  :ref:`hot-restart` for full documentation, but the synopsis is send the
+  ``SIGHUP`` signal to the MEP (parent) process.  Currently, there is no
+  equivalent built-in sub-command to ``globus-compute-endpoint``.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -577,6 +577,7 @@ def _do_start_endpoint(
     reg_info = {}
     config_str: str | None = None
     audit_fd: int | None = None
+    restart_fd: int | None = None
     fn_allow_list: list[str] | None | int = _no_fn_list_canary
     if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
         try:
@@ -593,6 +594,7 @@ def _do_start_endpoint(
             reg_info = stdin_data.get("amqp_creds", {})
             config_str = stdin_data.get("config")
             audit_fd = stdin_data.get("audit_fd")
+            restart_fd = stdin_data.get("restart_fd")
             fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
 
             del stdin_data  # clarity for intended scope
@@ -639,7 +641,10 @@ def _do_start_endpoint(
                 raise ClickException(
                     "multi-user endpoints are not supported on this system"
                 )
+
             epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
+            if restart_fd:
+                epm._finish_hot_restart(restart_fd)
             epm.start()
         else:
             assert isinstance(ep_config, UserEndpointConfig)


### PR DESCRIPTION
This implements a restart-in-place mechanism via `exec()`.  The logic serializes and re-establishes state:

- The child processes do not lose their parent; the new endpoint instance maintains the exact same PID

- In-flight audit records are protected, and the new instance sets up writing to the MEP file.  A hot restart will be visible in the audit log file as the MEP shutting down and restarting.

- A log record is emitted to the "normal" logs indicating that hot restart is happening

- Until we have a proper MEP pid file, the only access to hot-restart an MEP is to send the process `SIGHUP`.

[sc-40933]

## Type of change

- New feature (non-breaking change that adds functionality)