### PR TITLE
Add a function for handling GAREs

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/utils/gare.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/gare.py
@@ -1,0 +1,22 @@
+import typing as t
+
+from globus_sdk import GlobusAPIError, GlobusApp
+from globus_sdk.gare import to_gares
+
+
+def gare_handler(app: GlobusApp, f: t.Callable, *args, **kwargs):
+    try:
+        return f(*args, **kwargs)
+    except GlobusAPIError as e:
+        gares = to_gares([e.raw_json or {}])
+        if not gares:
+            raise
+
+        for gare in gares:
+            auth_params = gare.authorization_parameters
+            if auth_params.session_message is None:
+                auth_params.session_message = gare.extra.get("reason")
+
+            app.login(auth_params=auth_params)
+
+        return f(*args, **kwargs)


### PR DESCRIPTION
# Description

Generic function that handles retrying functions when GAREs are encountered. To be used in [[sc-33476]](https://app.shortcut.com/globus/story/33476/create-auth-policy-commands-do-not-prompt-for-re-authentication-as-needed) and [[sc-39660]](https://app.shortcut.com/globus/story/39660/expire-or-disable-result-rabbitmq-queues-along-with-defined-auth-policy-timeout).

## Type of change

- New feature (non-breaking change that adds functionality)