### PR TITLE
Add a stricter upper bound for click version

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     # provides easy daemonization of the endpoint
     "python-daemon>=2,<3",
     # CLI parsing
-    "click>=8,<9",
+    "click>=8,<8.2.0",
     "click-option-group>=0.5.6,<1",
     # disallow use of 22.3.0; the whl package on some platforms causes ZMQ issues
     #


### PR DESCRIPTION


# Description

Click minor version 8.2.0[^1], which released two days before this commit, involves some major breaking changes, including dropping support for some old Python versions, of which we still support 3.9. It also removes an argument that we use in a test runner (`CliRunner`'s `mix_stderr` constructor arg).

In the future, we should update to a more recent version, but for now this just makes the upper bound on the click dependency stricter.

[^1]: https://click.palletsprojects.com/en/stable/changes/#version-8-2-0

## Type of change

- Bug fix (non-breaking change that fixes an issue)
