### PR TITLE
Convert persistent_volumes to a list of tuples

### DIFF
--- a/changelog.d/20250513_102548_30907815+rjmello_k8s_pers_vol_type.rst
+++ b/changelog.d/20250513_102548_30907815+rjmello_k8s_pers_vol_type.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Defining ``persistent_volumes`` when using the ``KubernetesProvider`` in an
+  endpoint configuration will no longer raise an error.
+

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -63,6 +63,7 @@ class LauncherModel(BaseConfigModel):
 class ProviderModel(BaseConfigModel):
     type: str
     launcher: t.Optional[LauncherModel]
+    persistent_volumes: t.Optional[t.List[t.Tuple[str, str]]]  # KubernetesProvider
 
     _validate_type = _validate_import("type", parsl_providers)
     _validate_launcher = _validate_params("launcher")


### PR DESCRIPTION
# Description

The `persistent_volumes` argument to Parsl's `KubernetesProvider` expects a list of tuples, so we perform a conversion when loading the endpoint YAML configuration.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
