### PR TITLE
Load HA results from web service

### DIFF
--- a/changelog.d/20250515_080955_kevin_executor_handles_ha_tasks.rst
+++ b/changelog.d/20250515_080955_kevin_executor_handles_ha_tasks.rst
@@ -1,0 +1,8 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Enable use of the Executor with High Assurance (HA) endpoints.  The
+  fundamental change is that rather than receiving the result directly via
+  AMQP, it instead is only notified that a result is ready.  The Executor will
+  then reach out to the web-services to collect the known-complete tasks,
+  thereby initiating an HA check.


### PR DESCRIPTION
# Description

The web-service does not send High Assurance results via AMQP.  Instead, it notes merely that task is complete.  This commit teaches the Compute SDK Executor to recognize those HA result responses (which present as failed tasks but with the AMQP header `high_assurance` set), and to reach out to the web-service to collect them.

[sc-39660]

## Type of change

- New feature (non-breaking change that adds functionality)