### PR TITLE
Remove legacy get_containers method

### DIFF
--- a/changelog.d/20250516_095252_30907815+rjmello_remove_get_containers.rst
+++ b/changelog.d/20250516_095252_30907815+rjmello_remove_get_containers.rst
@@ -1,0 +1,5 @@
+Removed
+^^^^^^^
+
+- Removed legacy ``Client.get_containers`` method, which is no longer supported by the
+  Globus Compute web service.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -656,29 +656,6 @@ class Client:
             return self._compute_web_client.v2.get_result_amqp_url().data
 
     @_client_gares_handler
-    def get_containers(self, name, description=None):
-        """
-        Register a DLHub endpoint with the Globus Compute service and get
-        the containers to launch.
-
-        Parameters
-        ----------
-        name : str
-            Name of the endpoint
-        description : str
-            Description of the endpoint
-
-        Returns
-        -------
-        int
-            The port to connect to and a list of containers
-        """
-        data = {"endpoint_name": name, "description": description}
-        with self._request_lock:
-            r = self._compute_web_client.v2.post("/v2/get_containers", data=data)
-        return r.data["endpoint_uuid"], r.data["endpoint_containers"]
-
-    @_client_gares_handler
     def get_container(self, container_uuid, container_type):
         """Get the details of a container for staging it locally.
 

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -56,7 +56,6 @@ client_api_reqs = {
     gc.Client.build_container: (ContainerSpec(),),
     gc.Client.delete_endpoint: ("some ep id",),
     gc.Client.delete_function: ("some func id",),
-    gc.Client.get_containers: ("some name",),
     gc.Client.register_endpoint: ("ep name", None),
     gc.Client.register_function: (lambda: "some function",),
     gc.Client.register_container: ("some loc", "some container type"),


### PR DESCRIPTION
# Description

The Globus Compute web service does not support the corresponding API route: `/v2/get_containers`.

[sc-32334]

## Type of change

- Code maintenance/cleanup
