### PR TITLE
Fix missing uep config log message

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -241,7 +241,7 @@ def load_user_config_template(template_path: pathlib.Path) -> str:
     # load the file data into a string before dropping privileges.
     if not template_path.exists():
         file_name = template_path.name
-        log.info(f"{file_name}.yaml.j2 does not exist; trying .yaml")
+        log.info(f"{file_name} does not exist; trying .yaml")
         template_path = pathlib.Path(re.sub(r"\.j2$", "", str(template_path)))
     return _read_config_file(template_path)
 

--- a/compute_endpoint/tests/unit/test_config_utils.py
+++ b/compute_endpoint/tests/unit/test_config_utils.py
@@ -401,12 +401,15 @@ def test_load_user_config_template_valid_extensions(
     assert load_user_config_template(template_path) == template_str
 
 
-def test_load_user_config_template_tries_yaml_if_j2_not_found():
+def test_load_user_config_template_tries_yaml_if_j2_not_found(mock_log):
     conf_dir = pathlib.Path("/")
     template_path_yaml = conf_dir / "user_config_template.yaml"
     template_path_yaml.write_text("yaml")
     template_path_j2 = conf_dir / "user_config_template.yaml.j2"
+
     assert load_user_config_template(template_path_j2) == "yaml"
+    a, *_ = mock_log.info.call_args
+    assert "user_config_template.yaml.j2 does not exist" in a[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

The former message added an additional ".yaml.j2" to the filename.

## Type of change

- Code maintenance/cleanup
