### PR TITLE
Configure audit log by default if HA

### DIFF
--- a/changelog.d/20250531_143312_kevin_ha_audit_log_by_default.rst
+++ b/changelog.d/20250531_143312_kevin_ha_audit_log_by_default.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+- Under the assumption that newly configured `High Assurance`_ (HA) endpoints
+  will typically require audit logging, the new endpoint configuration (i.e.,
+  the :ref:`configure <multi-user-configuration>` subcommand) routine now sets
+  the |audit_log_path| configuration item to a default value.  (In effect,
+  audit log functionality is now opt-out, not opt-in.)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -74,6 +74,10 @@ class Endpoint:
         return endpoint_dir / "example_identity_mapping_config.json"
 
     @staticmethod
+    def _audit_log_path(endpoint_dir: pathlib.Path) -> pathlib.Path:
+        return endpoint_dir / "audit.log"
+
+    @staticmethod
     def update_config_file(
         original_path: pathlib.Path,
         target_path: pathlib.Path,
@@ -89,12 +93,6 @@ class Endpoint:
         if display_name:
             config_dict["display_name"] = display_name
 
-        if auth_policy:
-            config_dict["authentication_policy"] = auth_policy
-
-        if high_assurance:
-            config_dict["high_assurance"] = high_assurance
-
         if multi_user:
             config_dict["multi_user"] = multi_user
             config_dict.pop("engine", None)
@@ -103,6 +101,15 @@ class Endpoint:
                     target_path.parent
                 )
             )
+
+        if auth_policy:
+            config_dict["authentication_policy"] = auth_policy
+
+        if high_assurance:
+            config_dict["high_assurance"] = high_assurance
+            if multi_user:
+                audit_path = Endpoint._audit_log_path(target_path.parent)
+                config_dict["audit_log_path"] = str(audit_path)
 
         if subscription_id:
             config_dict["subscription_id"] = subscription_id
@@ -114,12 +121,12 @@ class Endpoint:
     def init_endpoint_dir(
         endpoint_dir: pathlib.Path,
         endpoint_config: pathlib.Path | None = None,
-        multi_user=False,
-        high_assurance=False,
+        multi_user: bool = False,
+        high_assurance: bool = False,
         display_name: str | None = None,
         auth_policy: str | None = None,
         subscription_id: str | None = None,
-    ):
+    ) -> None:
         """Initialize a clean endpoint dir
 
         :param endpoint_dir: Path to the endpoint configuration dir

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -109,6 +109,28 @@ class TestStart:
         else:
             assert "multi_user" not in config_dict
 
+    @pytest.mark.parametrize("ha", (False, True))
+    @pytest.mark.parametrize("mu", (False, True))
+    def test_configure_ha_audit_default(self, ha, mu):
+        manager = Endpoint()
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
+        config_file = Endpoint._config_file_path(config_dir)
+        audit_path = Endpoint._audit_log_path(config_dir)
+
+        with patch(f"{_MOCK_BASE}print"):  # quiet, please
+            manager.configure_endpoint(
+                config_dir, None, multi_user=mu, high_assurance=ha
+            )
+
+        assert config_file.exists(), "Verify setup"
+        conf = yaml.safe_load(config_file.read_text())
+        if not (mu and ha):
+            assert "audit_log_path" not in conf
+        else:
+            assert conf.get("multi_user"), conf
+            assert conf.get("high_assurance"), conf
+            assert conf.get("audit_log_path") == str(audit_path), conf
+
     @pytest.mark.skip(
         "This test needs to be re-written after endpoint_register is updated"
     )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,7 +34,7 @@ New Functionality
        # Samir Nagheenanajar (sysadmin, HPC services)
        - a6a7b9ee-be04-4e45-9832-d3737c2fafa2
 
-- Enable use of the Executor with High Assurance (HA) endpoints.  The
+- Enable use of the Executor with `High Assurance`_ (HA) endpoints.  The
   fundamental change is that rather than receiving the result directly via
   AMQP, it instead is only notified that a result is ready.  The Executor will
   then reach out to the web-services to collect the known-complete tasks,
@@ -3092,6 +3092,7 @@ New Functionality
 .. |ShellFunction| replace:: :class:`ShellFunction <globus_compute_sdk.sdk.shell_function.ShellFunction>`
 .. |UserRuntime| replace:: :class:`UserRuntime <globus_compute_sdk.sdk.batch.UserRuntime>`
 
+.. |audit_log_path| replace:: :class:`audit_log_path <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
 .. |detach_endpoint| replace:: :class:`detach_endpoint <globus_compute_endpoint.endpoint.config.config.UserEndpointConfig>`
 .. |GlobusComputeEngine| replace:: :class:`GlobusComputeEngine <globus_compute_endpoint.engines.globus_compute.GlobusComputeEngine>`
 .. |GlobusMPIEngine| replace:: :class:`GlobusMPIEngine <globus_compute_endpoint.engines.globus_mpi.GlobusMPIEngine>`
@@ -3105,3 +3106,5 @@ New Functionality
 
 .. |/v3/functions| replace:: ``/v3/functions``
 .. _/v3/functions: https://compute.api.globus.org/redoc#tag/Functions/operation/register_function_v3_functions_post
+
+.. _High Assurance: https://docs.globus.org/guides/overviews/high-assurance/

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -171,6 +171,8 @@ user must manage |nbsp| --- |nbsp| many users will barely even need to open thei
 terminal, much less an SSH terminal on a login node.
 
 
+.. _multi-user-configuration:
+
 Configuration
 =============
 


### PR DESCRIPTION
Under the expectation that if a setup requires High Assurance, it will also require audit logs, setup a default path directly.  This is a convenience, but one to help education of the feature, and easily disabled if not desired.

[sc-41662]

## Type of change

- New feature (non-breaking change that adds functionality)