### PR TITLE
Avoid redundant login flows in CLI

### DIFF
--- a/changelog.d/20250602_121437_30907815+rjmello_multiple_login_flows_sc_42021.rst
+++ b/changelog.d/20250602_121437_30907815+rjmello_multiple_login_flows_sc_42021.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Starting a multi-user endpoint no longer prompts the user to complete multiple login flows.

--- a/compute_endpoint/globus_compute_endpoint/auth.py
+++ b/compute_endpoint/globus_compute_endpoint/auth.py
@@ -1,0 +1,18 @@
+from click import ClickException
+from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
+from globus_compute_sdk.sdk.auth.globus_app import get_globus_app
+from globus_sdk import ComputeClient, GlobusApp
+
+
+def get_globus_app_with_scopes() -> GlobusApp:
+    try:
+        app = get_globus_app()
+    except (RuntimeError, ValueError) as e:
+        raise ClickException(str(e))
+    app.add_scope_requirements(
+        {
+            ComputeClient.scopes.resource_server: ComputeClient.default_scope_requirements,  # noqa E501
+            ComputeAuthClient.scopes.resource_server: ComputeAuthClient.default_scope_requirements,  # noqa E501
+        }
+    )
+    return app

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -11,6 +11,7 @@ import uuid
 import click
 from click import ClickException
 from click_option_group import optgroup
+from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.boot_persistence import disable_on_boot, enable_on_boot
 from globus_compute_endpoint.endpoint.config import (
     ManagerEndpointConfig,
@@ -25,13 +26,11 @@ from globus_compute_endpoint.endpoint.utils import (
 from globus_compute_endpoint.exception_handling import handle_auth_errors
 from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
-from globus_compute_sdk.sdk.auth.globus_app import get_globus_app
 from globus_compute_sdk.sdk.auth.whoami import print_whoami_info
 from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
 from globus_compute_sdk.sdk.diagnostic import do_diagnostic_base
 from globus_compute_sdk.sdk.utils.gare import gare_handler
-from globus_compute_sdk.sdk.web_client import WebClient
-from globus_sdk import MISSING, AuthClient, GlobusAPIError, GlobusApp, MissingType
+from globus_sdk import MISSING, AuthClient, GlobusAPIError, MissingType
 
 try:
     from globus_compute_endpoint.endpoint.endpoint_manager import EndpointManager
@@ -75,20 +74,6 @@ def init_config_dir() -> pathlib.Path:
 def get_config_dir() -> pathlib.Path:
     state = CommandState.ensure()
     return state.endpoint_config_dir
-
-
-def get_globus_app_with_scopes() -> GlobusApp:
-    try:
-        app = get_globus_app()
-    except (RuntimeError, ValueError) as e:
-        raise ClickException(str(e))
-    app.add_scope_requirements(
-        {
-            WebClient.scopes.resource_server: WebClient.default_scope_requirements,
-            ComputeAuthClient.scopes.resource_server: ComputeAuthClient.default_scope_requirements,  # noqa E501
-        }
-    )
-    return app
 
 
 def get_cli_endpoint(conf: UserEndpointConfig) -> Endpoint:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -23,6 +23,7 @@ import setproctitle
 import texttable
 import yaml
 from globus_compute_endpoint import __version__
+from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.endpoint.config import BaseConfig, UserEndpointConfig
 from globus_compute_endpoint.endpoint.config.utils import serialize_config
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange
@@ -335,13 +336,15 @@ class Endpoint:
 
     @staticmethod
     def get_funcx_client(config: BaseConfig | None) -> Client:
+        app = get_globus_app_with_scopes()
         if config:
             return Client(
                 local_compute_services=config.local_compute_services,
                 environment=config.environment,
+                app=app,
             )
         else:
-            return Client()
+            return Client(app=app)
 
     def start_endpoint(
         self,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -34,6 +34,7 @@ from globus_compute_common.messagepack import pack
 from globus_compute_common.messagepack.message_types import EPStatusReport
 from globus_compute_common.pydantic_v1 import BaseModel
 from globus_compute_endpoint import __version__
+from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.endpoint.config import ManagerEndpointConfig
 from globus_compute_endpoint.endpoint.config.config import MINIMUM_HEARTBEAT
 from globus_compute_endpoint.endpoint.config.utils import (
@@ -209,6 +210,7 @@ class EndpointManager:
                 gcc = GC.Client(
                     local_compute_services=config.local_compute_services,
                     environment=config.environment,
+                    app=get_globus_app_with_scopes(),
                 )
                 reg_info = gcc.register_endpoint(
                     name=conf_dir.name,
@@ -636,6 +638,7 @@ class EndpointManager:
             client_options = {
                 "local_compute_services": self._config.local_compute_services,
                 "environment": self._config.environment,
+                "app": get_globus_app_with_scopes(),
             }
             log.debug("Ascertaining user identity set (%s)", client_options)
 

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -14,13 +14,22 @@ from globus_compute_endpoint.cli import _do_stop_endpoint, app
 from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_sdk.sdk.client import _ComputeWebClient
+from globus_sdk import UserApp
+from pytest_mock import MockFixture
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint."
 _SVC_ADDY = "http://api.funcx.fqdn"  # something clearly not correct
 
 
 @pytest.fixture(autouse=True)
-def patch_compute_client(mocker):
+def mock_app(mocker: MockFixture) -> UserApp:
+    _app = mock.Mock(spec=UserApp)
+    mocker.patch(f"{_MOCK_BASE}get_globus_app_with_scopes", return_value=_app)
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def patch_compute_client(mocker: MockFixture):
     responses.add(
         responses.GET,
         _SVC_ADDY + "/v2/version",

--- a/compute_endpoint/tests/unit/test_auth.py
+++ b/compute_endpoint/tests/unit/test_auth.py
@@ -1,0 +1,39 @@
+import sys
+
+import pytest
+from click import ClickException
+from globus_compute_endpoint.auth import get_globus_app_with_scopes
+from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
+from globus_sdk import ComputeClient
+from pytest_mock import MockFixture
+
+_MOCK_BASE = "globus_compute_endpoint.auth."
+
+
+def test_get_globus_app_with_scopes(mocker: MockFixture):
+    mock_stdin = mocker.patch.object(sys, "stdin")
+    mock_stdin.isatty.return_value = True
+    mock_stdin.closed = False
+
+    app = get_globus_app_with_scopes()
+
+    scopes = []
+    for scope_list in app.scope_requirements.values():
+        for scope in scope_list:
+            scopes.append(str(scope))
+
+    assert len(scopes) > 0
+    assert all(str(s) in scopes for s in ComputeClient.default_scope_requirements)
+    assert all(str(s) in scopes for s in ComputeAuthClient.default_scope_requirements)
+
+
+@pytest.mark.parametrize("exception_type", [ValueError, RuntimeError])
+def test_get_globus_app_with_scopes_handles_exception(
+    exception_type: Exception, mocker: MockFixture
+):
+    mocker.patch(
+        f"{_MOCK_BASE}get_globus_app", side_effect=exception_type("Test exception")
+    )
+    with pytest.raises(ClickException) as exc:
+        get_globus_app_with_scopes()
+    assert "Test exception" in str(exc)

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -37,7 +37,8 @@ from globus_compute_endpoint.endpoint.rabbit_mq import (
     ResultPublisher,
 )
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds
-from globus_sdk import GlobusAPIError, NetworkError
+from globus_sdk import GlobusAPIError, NetworkError, UserApp
+from pytest_mock import MockFixture
 
 try:
     import pyprctl
@@ -169,6 +170,13 @@ def mock_reg_info(ep_uuid) -> str:
             "queue_publish_kwargs": {},
         },
     }
+
+
+@pytest.fixture(autouse=True)
+def mock_app(mocker: MockFixture) -> UserApp:
+    _app = mock.Mock(spec=UserApp)
+    mocker.patch(f"{_MOCK_BASE}get_globus_app_with_scopes", return_value=_app)
+    return _app
 
 
 @pytest.fixture

--- a/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/globus_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 
 from globus_sdk import ClientApp, GlobusApp, GlobusAppConfig, UserApp
@@ -11,6 +12,7 @@ DEFAULT_CLIENT_ID = "4cf29807-cf21-49ec-9443-ff9a3fb9f81c"
 
 
 def get_globus_app(environment: str | None = None) -> GlobusApp:
+    environment = environment or os.getenv("GLOBUS_SDK_ENVIRONMENT")
     app_name = platform.node()
     client_id, client_secret = get_client_creds()
     config = GlobusAppConfig(

--- a/compute_sdk/tests/unit/auth/test_globus_app.py
+++ b/compute_sdk/tests/unit/auth/test_globus_app.py
@@ -33,13 +33,23 @@ def test_get_globus_app(
         assert app.client_id == DEFAULT_CLIENT_ID
 
 
-def test_get_globus_app_with_environment(mocker: MockerFixture, randomstring):
+@pytest.mark.parametrize("env_arg", ["some-arg", None])
+@pytest.mark.parametrize("env_var", ["some-var", None])
+def test_get_globus_app_with_environment(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    env_arg: str | None,
+    env_var: str | None,
+):
     mock_get_token_storage = mocker.patch(f"{_MOCK_BASE}get_token_storage")
     mocker.patch(f"{_MOCK_BASE}UserApp", autospec=True)
 
-    env = randomstring()
-    get_globus_app(environment=env)
+    if env_var:
+        monkeypatch.setenv("GLOBUS_SDK_ENVIRONMENT", env_var)
 
+    get_globus_app(environment=env_arg)
+
+    env = env_arg or env_var
     mock_get_token_storage.assert_called_once_with(environment=env)
 
 


### PR DESCRIPTION
# Description

We now request all required scopes when authenticating with the Globus Compute and Auth APIs via the CLI. This avoids prompting the user to run multiple login flows when starting a multi-user endpoint.

[sc-42021](https://app.shortcut.com/globus/story/42021/avoid-unnecessary-re-auths-when-starting-an-mep)

## Type of change

- Bug fix (non-breaking change that fixes an issue)