### PR TITLE
Update globus-compute-common

### DIFF
--- a/changelog.d/20250611_132435_kevin_update_common.rst
+++ b/changelog.d/20250611_132435_kevin_update_common.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Bump ``globus-compute-common`` requirement to version ``0.7.1``.
+

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -7,7 +7,6 @@ REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
     "globus-compute-sdk==3.8.0",
-    "globus-compute-common==0.5.0",
     "globus-identity-mapping==0.4.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
     "globus-sdk>=3.56.0,<4",
-    "globus-compute-common==0.5.0",
+    "globus-compute-common==0.7.1",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy


### PR DESCRIPTION
To 0.7.1.  The main change of interest is dropping support for Python 3.8, allowing other tools that rely upon the Compute SDK to bump their requirements.

To the reviewer: removed requirement from -endpoint because -sdk has it already.

## Type of change

- Code maintenance/cleanup