### PR TITLE
Pass mapped identity info to user config template

### DIFF
--- a/changelog.d/20250612_090019_30907815+rjmello_mapped_id_jinja_var.rst
+++ b/changelog.d/20250612_090019_30907815+rjmello_mapped_id_jinja_var.rst
@@ -1,0 +1,15 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Endpoint administrators now have access to information about the user's mapped
+  identity in the user configuration template (``user_config_template.yaml.j2``)
+  via the ``mapped_identity`` variable. The following fields are available:
+
+  - ``mapped_identity.local.uname``: Local user's username
+  - ``mapped_identity.local.uid``: Local user's ID
+  - ``mapped_identity.local.gid``: Local user's primary group ID
+  - ``mapped_identity.local.groups``: List of group IDs the local user is a member of
+  - ``mapped_identity.local.gecos``: Local user's GECOS field
+  - ``mapped_identity.local.shell``: Local user's login shell
+  - ``mapped_identity.local.dir``: Local user's home directory
+  - ``mapped_identity.globus.id``: Matched Globus identity ID

--- a/compute_endpoint/globus_compute_endpoint/endpoint/identity_mapper.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/identity_mapper.py
@@ -4,8 +4,11 @@ import json
 import logging
 import os
 import pathlib
+import pwd
 import threading
 import typing as t
+import uuid
+from dataclasses import dataclass
 
 from globus_identity_mapping.loader import load_mappers
 from globus_identity_mapping.protocol import IdentityMappingProtocol
@@ -240,3 +243,19 @@ class PosixIdentityMapper:
                 )
 
         return results
+
+
+@dataclass
+class MappedPosixIdentity:
+    local_user_record: pwd.struct_passwd
+
+    # Example structure:
+    # In this example data,
+    #  - the first mapper found no identities or failed
+    #  - the second mapper mapped uuid1 to both alice and bob and additionally mapped
+    #    uuid2 to charlie.
+    #  - the third mapper mapped uuid1 to darla
+    # [[], [{"uuid1": ["alice", "bob"], "uuid2": ["charlie"]}], [{"uuid1": ["darla"]}]]
+    globus_identity_candidates: list[list[dict[str, list[str]]]]
+
+    matched_identity: uuid.UUID | str | None

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -486,6 +486,31 @@ Every template also has access to the following variables:
   submitting the task request, such as Python version. See |UserRuntime| for a complete
   list of available information.
 
+- ``mapped_identity``: Contains information about the user's mapped identity. The following
+  fields are available:
+
+  - ``mapped_identity.local.uname``: Local user's username
+  - ``mapped_identity.local.uid``: Local user's ID
+  - ``mapped_identity.local.gid``: Local user's primary group ID
+  - ``mapped_identity.local.groups``: List of group IDs the local user is a member of
+  - ``mapped_identity.local.gecos``: Local user's GECOS field
+  - ``mapped_identity.local.shell``: Local user's login shell
+  - ``mapped_identity.local.dir``: Local user's home directory
+  - ``mapped_identity.globus.id``: Matched Globus identity ID
+
+  .. code-block:: yaml+jinja
+     :caption: Example usage of ``mapped_identity`` in config template
+
+      engine:
+         type: GlobusComputeEngine
+         provider:
+            type: SlurmProvider
+      {% if 1001 in mapped_identity.local.groups %}
+            partition: {{ partition }}
+      {% else %}
+            partition: default
+      {% endif %}
+
 These are reserved words and their values cannot be overridden by the user or admin,
 and an error is thrown if a user tries to send it as a user option:
 


### PR DESCRIPTION
# Description

Endpoint administrators now have access to identity mapping information in the user configuration template via the `mapped_identity` variable. The following fields are available:

  - `mapped_identity.local.uname`: Local user's username
  - `mapped_identity.local.uid`: Local user's ID
  - `mapped_identity.local.gid`: Local user's primary group ID
  - `mapped_identity.local.groups`: List of group IDs the local user is a member of
  - `mapped_identity.local.gecos`: Local user's GECOS field
  - `mapped_identity.local.shell`: Local user's login shell
  - `mapped_identity.local.dir`: Local user's home directory
  - `mapped_identity.globus.id`: Matched Globus identity ID

[sc-42194](https://app.shortcut.com/globus/story/42194/include-identity-mapping-info-in-uep-template)

## Type of change

- New feature (non-breaking change that adds functionality)
