### PR TITLE
Use V3 route in Client.stop_endpoint

### DIFF
--- a/changelog.d/20250702_101404_30907815+rjmello_stop_endpoint_v3.rst
+++ b/changelog.d/20250702_101404_30907815+rjmello_stop_endpoint_v3.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fixed the ``Client.stop_endpoint`` method to work with multi-user endpoints
+  in addition to single-user endpoints.

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -124,7 +124,7 @@ def test_stop_remote_endpoint(mocker):
     mocker.patch("globus_compute_endpoint.cli.get_config")
     mocker.patch(f"{_MOCK_BASE}Endpoint.get_endpoint_id", return_value=ep_uuid)
 
-    path = f"/v2/endpoints/{ep_uuid}/lock"
+    path = f"/v3/endpoints/{ep_uuid}/lock"
     with responses.RequestsMock() as resp:
         lock_resp = resp.post(_SVC_ADDY + path, json={}, status=200)
         _do_stop_endpoint(ep_dir=ep_dir, remote=False)

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -1004,7 +1004,7 @@ class Client:
             The response of the request
         """
         with self._request_lock:
-            return self._compute_web_client.v2.lock_endpoint(endpoint_id)
+            return self._compute_web_client.v3.lock_endpoint(endpoint_id)
 
     @_client_gares_handler
     def delete_endpoint(self, endpoint_id: str):

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -296,7 +296,7 @@ class WebClient(globus_sdk.BaseClient):
         return self.get(f"/v3/endpoints/{endpoint_id}/allowed_functions")
 
     def stop_endpoint(self, endpoint_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
-        return self.post(f"/v2/endpoints/{endpoint_id}/lock", data={})
+        return self.post(f"/v3/endpoints/{endpoint_id}/lock", data={})
 
     def delete_endpoint(
         self, endpoint_id: UUID_LIKE_T

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -407,6 +407,15 @@ def test_container_build_status_failure(gcc):
     assert type(excinfo.value) is SystemError
 
 
+def test_stop_endpoint(gcc: gc.Client):
+    ep_uuid_str = uuid.uuid4()
+    gcc._compute_web_client = mock.MagicMock()
+
+    gcc.stop_endpoint(ep_uuid_str)
+
+    gcc._compute_web_client.v3.lock_endpoint.assert_called_with(ep_uuid_str)
+
+
 def test_register_function(gcc: gc.Client, serde: ComputeSerializer):
     gcc._compute_web_client = mock.MagicMock()
     gcc.register_function(funk)


### PR DESCRIPTION
# Description

Currently, only the V3 route supports dropping RMQ credentials for multi-user endpoints.

[sc-42844](https://app.shortcut.com/globus/story/42844/support-remotely-stopping-meps-with-sdk)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
