### PR TITLE
Add get endpoint options

### DIFF
--- a/changelog.d/20250710_132341_yadudoc1729_add_get_endpoint_options.rst
+++ b/changelog.d/20250710_132341_yadudoc1729_add_get_endpoint_options.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add a new ``role`` keyword argument to the ``Client.get_endpoints`` method
+  that enables querying for endpoints that are accessble to, but not owned by,
+  the user (e.g., MEPs). Valid options for ``role`` are ``owner`` and ``any``.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -752,16 +752,23 @@ class Client:
             return self._compute_web_client.v2.get_endpoint(endpoint_uuid).data
 
     @_client_gares_handler
-    def get_endpoints(self):
-        """Get a list of all endpoints owned by the current user across all systems.
+    def get_endpoints(self, role: str | None = None):
+        """Get a list of endpoints available to the current user.
+
+        Parameters
+        ----------
+        role: str
+            Filter returned list by user's association to endpoints (e.g., ``owner``,
+            ``any``).  The default value is unset, in which case the API (currently)
+            assumes ``owner``.
 
         Returns
         -------
         list
-            A list of dictionaries which contain endpoint info
+            A list of dictionaries which contain endpoint information
         """
         with self._request_lock:
-            return self._compute_web_client.v2.get_endpoints().data
+            return self._compute_web_client.v2.get_endpoints(role=role).data
 
     @_client_gares_handler
     def register_function(

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.56.0,<4",
+    "globus-sdk>=3.59.0,<4",
     "globus-compute-common==0.7.1",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear

--- a/compute_sdk/tests/unit/conftest.py
+++ b/compute_sdk/tests/unit/conftest.py
@@ -10,12 +10,13 @@ from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
 from globus_sdk import GlobusHTTPResponse
 
 
+def randomstring_impl(length=5, alphabet=string.ascii_letters):
+    return "".join(random.choice(alphabet) for _ in range(length))
+
+
 @pytest.fixture
 def randomstring():
-    def func(length=5, alphabet=string.ascii_letters):
-        return "".join(random.choice(alphabet) for _ in range(length))
-
-    return func
+    return randomstring_impl
 
 
 @pytest.fixture

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -14,6 +14,7 @@ from unittest import mock
 import globus_compute_sdk as gc
 import pytest
 import requests
+from conftest import randomstring_impl
 from globus_compute_sdk import ContainerSpec, __version__
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
@@ -1102,3 +1103,12 @@ def test_ha_register_and_submit_warning_deduplication(gcc, mocker):
     assert len(records) == 2, "Only two distinct messages; warnings suppresses dups"
     assert arbitrary_hatext == str(records[0].message)
     assert "abcd" == str(records[1].message)
+
+
+@pytest.mark.parametrize("role", (None, randomstring_impl(), "any"))
+def test_get_endpoints_with_role(gcc, role):
+    gcc.get_endpoints()  # always check the "send nothing" case
+    gcc._compute_web_client.v2.get_endpoints.assert_called_with(role=None)
+
+    gcc.get_endpoints(role=role)
+    gcc._compute_web_client.v2.get_endpoints.assert_called_with(role=role)


### PR DESCRIPTION
# Description

This PR adds a new `role` kwarg to `client.get_endpoints()` method. Currently, this method returns endpoints that the user owns. Setting `role="any"` fetches MEPs in addition to the endpoints that are owned by the user.

* Updated `globus-sdk` version to required `3.59.0` that shipped support for the `role` kwarg in the v2 client. 
* `role` accepts `owner` (default behavior) and `any`

Refer: https://github.com/globus/globus-sdk-python/pull/1238

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
