### PR TITLE
Use full path for changelog method references

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -165,8 +165,8 @@ New Functionality
 - Enabled support for registering a function to a specific HA endpoint via the
   ``ha_endpoint_id`` argument in the following methods:
 
-  - :meth:`~globus_compute_sdk.Client.register_function`
-  - :meth:`~globus_compute_sdk.Executor.register_function`
+  - :meth:`globus_compute_sdk.Client.register_function`
+  - :meth:`globus_compute_sdk.Executor.register_function`
 
   Since HA functions cannot be shared, this argument is mutually exclusive with the
   ``group`` and ``public`` arguments.


### PR DESCRIPTION
# Description

Dropped the `~` to include the full method path.

## Type of change

- Documentation update
