### PR TITLE
Specify custom directory in globus-compute-diagnostic

### DIFF
--- a/changelog.d/20250723_183301_lei_diagnostic_custom_dir_sc_41807.rst
+++ b/changelog.d/20250723_183301_lei_diagnostic_custom_dir_sc_41807.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added a ``--config-dir`` option to the ``globus-compute-diagnostic`` command
+  to specify from which directory to collect configuration and log
+  files.  This option overrides both the default path (``~/.globus_compute``)
+  and the ``GLOBUS_COMPUTE_USER_DIR`` environment variable.

--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -16,6 +16,7 @@ from concurrent.futures import TimeoutError
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime as dt
 from datetime import timezone
+from pathlib import Path
 from urllib.parse import urlparse
 
 import colorama
@@ -269,13 +270,20 @@ def general_commands_list():
     ]
 
 
-def get_diagnostic_commands(log_bytes: int):
+def get_diagnostic_commands(log_bytes: int, config_dir: str | None = None):
 
     commands = filter_by_os(hardware_commands_list())
     commands.extend(general_commands_list())
     commands.extend(connection_tests())
 
-    gc_home_dir = ensure_compute_dir()
+    gc_base_dir = ensure_compute_dir()
+    if config_dir:
+        specified_path = Path(config_dir)
+        if specified_path.exists() and specified_path.is_dir():
+            gc_base_dir = specified_path
+        else:
+            print(f"{specified_path.absolute()} is not a valid directory")
+            sys.exit(1)
 
     # Run endpoint related diagnostics when it is installed
     ep_install_dir = print_endpoint_install_dir()
@@ -294,11 +302,11 @@ def get_diagnostic_commands(log_bytes: int):
             commands.append(
                 cat(
                     [
-                        f"{gc_home_dir}/*/*.yaml",
-                        f"{gc_home_dir}/*/*.log",
-                        f"{gc_home_dir}/*/*.py",
-                        f"{gc_home_dir}/*/*.j2",
-                        f"{gc_home_dir}/*/*.json",
+                        f"{gc_base_dir}/*/*.yaml",
+                        f"{gc_base_dir}/*/*.log",
+                        f"{gc_base_dir}/*/*.py",
+                        f"{gc_base_dir}/*/*.j2",
+                        f"{gc_base_dir}/*/*.json",
                     ],
                     wildcard=True,
                     max_bytes=log_bytes,
@@ -353,7 +361,11 @@ def run_single_command(cmd: str):
 
 
 def run_all_diags_wrapper(
-    print_only: bool, log_bytes: int, verbose: bool, ep_uuid: str | None = None
+    print_only: bool,
+    log_bytes: int,
+    verbose: bool,
+    ep_uuid: str | None = None,
+    config_dir: str | None = None,
 ):
     """
     This is the diagnostic wrapper that obtains the list of commands to be run
@@ -381,6 +393,7 @@ def run_all_diags_wrapper(
     :param ep_uuid:           # If specified, register a sample function and
                                 send a task that uses the function UUID to the
                                 endpoint to test end to end connectivity
+    :param config_dir:         The base directory to use when gathering config/logs
     """
 
     current_time = dt.now().astimezone(timezone.utc).strftime("%Y-%m-%d-%H-%M-%SZ")
@@ -388,7 +401,7 @@ def run_all_diags_wrapper(
 
     diagnostic_output = []
 
-    diag_cmds, ep_install_dir = get_diagnostic_commands(log_bytes)
+    diag_cmds, ep_install_dir = get_diagnostic_commands(log_bytes, config_dir)
 
     if ep_install_dir or ep_uuid:
         # If the Endpoint is installed we will be running ``whoami`` and ``list``
@@ -548,10 +561,25 @@ def do_diagnostic_base(diagnostic_args):
             "UUID is required."
         ),
     )
+    parser.add_argument(
+        "-c",
+        "--config-dir",
+        default=None,
+        type=str,
+        help=(
+            "Gather endpoint configuration and log info from the specified "
+            "parent directory instead of the default ~/.globus_compute or "
+            "what is set in $GLOBUS_COMPUTE_USER_DIR"
+        ),
+    )
 
     args = parser.parse_args(diagnostic_args)
     run_all_diags_wrapper(
-        args.print_only, args.log_kb * 1024, args.verbose, args.endpoint_uuid
+        args.print_only,
+        args.log_kb * 1024,
+        args.verbose,
+        args.endpoint_uuid,
+        args.config_dir,
     )
 
 

--- a/compute_sdk/tests/unit/conftest.py
+++ b/compute_sdk/tests/unit/conftest.py
@@ -42,6 +42,18 @@ def run_in_tmp_dir(tmp_path):
 @pytest.fixture
 def mock_gc_home(tmp_path):
     env = os.environ.copy()
-    env["GLOBUS_COMPUTE_USER_DIR"] = str(tmp_path / "home")
+    env["GLOBUS_COMPUTE_USER_DIR"] = str(tmp_path / "home/mock_gc")
     with mock.patch.dict(os.environ, env):
         yield ensure_compute_dir().absolute()
+
+
+@pytest.fixture
+def mock_gc_home_other(tmp_path):
+    def _mock_base_dir(base_dir: str):
+        env = os.environ.copy()
+        base_absolute_dir = str((tmp_path / base_dir).absolute())
+        env["GLOBUS_COMPUTE_USER_DIR"] = base_absolute_dir
+        with mock.patch.dict(os.environ, env):
+            return ensure_compute_dir().absolute()
+
+    yield _mock_base_dir


### PR DESCRIPTION
Add a custom ``--config-dir`` param to ``globus-compute-diagnostic`` so logs can be gathered from a different globus_compute root instead.

Currently will raise ValueError if specified path is invalid instead of defaulting to the base path, expecting it is a user typo.

(Apparently paths may behave differently on ubuntu vs. macOS, TBD fix test)