### PR TITLE
Separate ShellResult command for copy/paste

### DIFF
--- a/compute_sdk/tests/unit/test_shell_functions.py
+++ b/compute_sdk/tests/unit/test_shell_functions.py
@@ -1,8 +1,146 @@
 import os
+import random
 import uuid
 
 import pytest
 from globus_compute_sdk.sdk.shell_function import ShellFunction, ShellResult
+
+
+@pytest.mark.parametrize("rc", (0, random.randint(1, 256)))
+@pytest.mark.parametrize("exc", (None, "Some Exception Text"))
+@pytest.mark.parametrize("res_len", (1024, 1025))
+def test_shell_result_str(rc, exc, res_len):
+    sout = " sout\n"
+    sout = (sout * (1 + res_len // len(sout)))[:res_len]
+    serr = sout.replace("sout", "serr")
+    assert len(sout) == res_len, "Verify test setup"
+
+    s = str(ShellResult("cmd", sout, serr, rc, exc))
+
+    exp_sout = "\n".join(sout.strip()[-1024:].splitlines()[-10:])
+
+    assert f"exit code: {rc}\n" in s
+    assert "   stdout:\n" in s
+    assert exp_sout in s
+    if exp_sout != sout:
+        assert "truncated; see .stdout" in s
+
+    if rc == 0:
+        assert "stderr:" not in s
+        assert "exception:" not in s
+    else:
+        exp_serr = "\n".join(serr.strip()[-1024:].splitlines()[-10:])
+
+        assert "   stderr:\n" in s
+        assert exp_serr in s
+        if exp_serr != serr:
+            assert "truncated; see .stderr" in s
+
+        if exc:
+            assert f"\n\nexception: {exc}" in s
+
+
+@pytest.mark.parametrize("excname", (None, "Some Exception name"))
+def test_shell_result_repr(excname):
+    cmd = "some command more than 80 chars: " + "a" * 80
+    sr = ShellResult(
+        cmd,
+        stdout="some stdout",
+        stderr="some stderr",
+        returncode=43,
+        exception_name=excname,
+    )
+    r = repr(sr)
+
+    assert r.startswith(ShellResult.__name__)
+    assert f"returncode={sr.returncode}" in r
+    assert f"cmd={cmd!r}" in r
+    assert f"stdout={sr.stdout!r}" in r
+    assert f"stderr={sr.stderr!r}" in r
+
+    if excname is not None:
+        assert f"exception_name={excname!r}" in r
+
+
+@pytest.mark.parametrize("name", (None, "somename"))
+@pytest.mark.parametrize("walltime", (None, 15.7))
+@pytest.mark.parametrize("sout", (None, "/some / path"))
+@pytest.mark.parametrize("serr", (None, "/other/path/"))
+@pytest.mark.parametrize("lines", (None, 12345))
+@pytest.mark.parametrize("cmd_len", (10, 1024, 1025))
+def test_shell_function_str(name, walltime, sout, serr, lines, cmd_len):
+    cmd = "some script's line\n"
+    cmd = (cmd * (1 + cmd_len // len(cmd)))[:cmd_len]
+    assert len(cmd) == cmd_len, "Verify test setup"
+
+    k = {
+        "name": name,
+        "walltime": walltime,
+        "stdout": sout,
+        "stderr": serr,
+    }
+    if lines:
+        k["snippet_lines"] = lines
+
+    sf = ShellFunction(cmd, **k)
+    s = str(sf)
+    name = name or ShellFunction.__name__
+
+    assert s.startswith(f"{name}\n")
+    if walltime is not None:
+        assert f"\n wall time: {walltime}" in s
+    if sout is not None:
+        assert f"\n    stdout: {sout!r}" in s
+    if serr is not None:
+        assert f"\n    stderr: {serr!r}" in s
+
+    exp_lines = f"\n     lines: {lines or 1000}"
+    assert exp_lines in s
+
+    command_header = "   command: "
+    exp_cmd = "\n".join(cmd.strip()[:1024].splitlines()[:10])
+    if "\n" not in exp_cmd:
+        assert f"\n{command_header}{exp_cmd}" in s
+    else:
+        indent = "\n" + " " * len(command_header)
+        exp_cmd = exp_cmd.strip().replace("\n", indent)
+        assert f"\n   command: -----{indent}{exp_cmd}" in s
+        assert "truncated; see .cmd for full script" in s
+
+
+@pytest.mark.parametrize("name", (None, "somename"))
+@pytest.mark.parametrize("walltime", (None, 0.5, 15.7))
+@pytest.mark.parametrize("sout", (None, "/some / path"))
+@pytest.mark.parametrize("serr", (None, "/other/path/"))
+@pytest.mark.parametrize("lines", (None, 918273))
+def test_shell_function_repr(name, walltime, sout, serr, lines):
+    cmd = "some command -with --arguments just because"
+    k = {
+        "name": name,
+        "walltime": walltime,
+        "stdout": sout,
+        "stderr": serr,
+    }
+    if lines:
+        k["snippet_lines"] = lines
+
+    sf = ShellFunction(cmd, **k)
+    s = repr(sf)
+
+    assert s.startswith(ShellFunction.__name__)
+    if walltime is not None:
+        assert f"walltime={walltime!r}" in s
+    if sout is not None:
+        assert f"stdout={sout!r}" in s
+    if serr is not None:
+        assert f"stderr={serr!r}" in s
+
+    if name is not None:
+        assert f"name={name!r}" in s
+
+    exp_lines = f"snippet_lines={lines or 1000}"
+    assert exp_lines in s
+    assert f"cmd={cmd!r}" in s
 
 
 def test_shell_function_no_stdfile(run_in_tmp_dir):
@@ -17,7 +155,7 @@ def test_shell_function_no_stdfile(run_in_tmp_dir):
     assert bf.__name__ == type(bf).__name__
     assert "Hello" in bf_result.stdout
     assert not bf_result.stderr
-    assert "returned with exit status: 0" in str(bf_result)
+    assert "exit code: 0" in str(bf_result)
 
 
 def test_shell_function_with_stdfile(run_in_tmp_dir):
@@ -33,7 +171,7 @@ def test_shell_function_with_stdfile(run_in_tmp_dir):
 
     assert "Hello" in bf_result.stdout
     assert not bf_result.stderr
-    assert "returned with exit status: 0" in str(bf_result)
+    assert "exit code: 0" in str(bf_result)
     assert os.path.exists(f"{os.environ['GC_TASK_SANDBOX_DIR']}/foo.out")
     assert os.path.exists(f"{run_in_tmp_dir}/foo.err")
 


### PR DESCRIPTION
Per a user request, update the `ShellResult` and `ShellFunction` classes to more clearly delineate the important bits.  In particular, ensure that command is easily identified and copy-paste ready.

[sc-43548]

## Type of change

- New feature (non-breaking change that adds functionality)