### PR TITLE
Pin pyfakefs

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -50,7 +50,7 @@ TEST_REQUIRES = [
     "pytest>=7.2",
     "coverage>=5.2",
     "pytest-mock==3.2.0",
-    "pyfakefs",
+    "pyfakefs<5.9.2",  # 5.9.2 (Jul 30, 2025), breaks us; retry after 6.0.0 lands?
 ]
 
 


### PR DESCRIPTION
PyFakeFS 5.9.2 doesn't seem to clean itself up deterministically or correctly, resulting in test failures in otherwise sound tests that have been working for years.  Pin to less than 5.9.2 for the being.

With thanks to @chris-janidlo for the pointer

## Type of change

- Bug fix (in tests)