### PR TITLE
Add .vscode folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,8 @@ venv.bak/
 # Intellij
 .idea/
 
+# Visual Studio Code
+.vscode/
+
 # MacOS Finder Cache
 .DS_Store


### PR DESCRIPTION
# Description

We have this in our other repos, just not this one. Came up now that VS Code is refactoring its python env support to a plugin rather than an internal feature.

## Type of change

- Code maintenance/cleanup
