### PR TITLE
Multi-user API flag iff process is privileged

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -202,7 +202,7 @@ class EndpointManager:
                     name=conf_dir.name,
                     endpoint_id=endpoint_uuid,
                     metadata=self.get_metadata(config),
-                    multi_user=True,
+                    multi_user=privileged,
                     display_name=config.display_name,
                     allowed_functions=config.allowed_functions,
                     auth_policy=config.authentication_policy,


### PR DESCRIPTION
To-date, we've conflated the `multi_user` flag to mean "template capable" and supports multiple users.  In the meantime, the EP would make the actual decision based on whether it had privileges and identity mapping set up.

The web-service now uses the existence of the template as an indicator that the EP expects start UEP commands, and we can set the `multi_user=True` only if we have privileges at registration time.

[sc-43660]

## Type of change

- Bug fix (non-breaking change that fixes an issue)