### PR TITLE
Refactor endpoint docs for v4 architecture changes

### DIFF
--- a/docs/endpoints/configs/anvil.yaml
+++ b/docs/endpoints/configs/anvil.yaml
@@ -1,5 +1,4 @@
 amqp_port: 443
-display_name: Anvil CPU
 engine:
   type: GlobusComputeEngine
   max_workers_per_node: 2

--- a/docs/endpoints/configs/bebop.yaml
+++ b/docs/endpoints/configs/bebop.yaml
@@ -1,5 +1,3 @@
-display_name: Bebop@ANL
-
 engine:
     type: GlobusComputeEngine
     max_workers_per_node: 2

--- a/docs/endpoints/configs/delta.yaml
+++ b/docs/endpoints/configs/delta.yaml
@@ -1,5 +1,4 @@
 amqp_port: 443
-display_name: NCSA Delta 2 CPU
 engine:
     type: GlobusComputeEngine
     max_workers_per_node: 2

--- a/docs/endpoints/configs/expanse.yaml
+++ b/docs/endpoints/configs/expanse.yaml
@@ -1,5 +1,3 @@
-display_name: Expanse@SDSC
-
 engine:
     type: GlobusComputeEngine
     max_workers_per_node: 2

--- a/docs/endpoints/configs/expanse_mpi.yaml
+++ b/docs/endpoints/configs/expanse_mpi.yaml
@@ -1,5 +1,3 @@
-display_name: ExpanseMPI@SDSC
-
 engine:
     type: GlobusMPIEngine
     mpi_launcher: srun

--- a/docs/endpoints/configs/faster.yaml
+++ b/docs/endpoints/configs/faster.yaml
@@ -1,5 +1,4 @@
 amqp_port: 443
-display_name: Access Tamu Faster
 engine:
     type: GlobusComputeEngine
     worker_debug: False

--- a/docs/endpoints/configs/frontera.yaml
+++ b/docs/endpoints/configs/frontera.yaml
@@ -1,5 +1,3 @@
-display_name: Frontera@TACC
-
 engine:
     type: GlobusComputeEngine
     max_workers_per_node: 2
@@ -13,7 +11,7 @@ engine:
         type: SlurmProvider
 
         # e.g., EAR22001
-        account: {{ YOUR_FRONTERA_ACCOUNT }}
+        account: {{ FRONTERA_ACCOUNT }}
 
         # e.g., development
         partition: {{ PARTITION }}

--- a/docs/endpoints/configs/ospool.yaml
+++ b/docs/endpoints/configs/ospool.yaml
@@ -1,4 +1,3 @@
-display_name: OSPool
 engine:
   type: GlobusComputeEngine
   max_workers_per_node: 1

--- a/docs/endpoints/configs/perlmutter.yaml
+++ b/docs/endpoints/configs/perlmutter.yaml
@@ -1,4 +1,3 @@
-display_name: Permutter@NERSC
 engine:
     type: GlobusComputeEngine
     worker_debug: False

--- a/docs/endpoints/configs/polaris.yaml
+++ b/docs/endpoints/configs/polaris.yaml
@@ -1,5 +1,3 @@
-display_name: Polaris@ALCF
-
 engine:
   type: GlobusComputeEngine
   max_workers_per_node: 4
@@ -20,7 +18,7 @@ engine:
       bind_cmd: --cpu-bind
       overrides: --depth=64 --ppn 1
 
-    account: {{ YOUR_POLARIS_ACCOUNT }}
+    account: {{ POLARIS_ACCOUNT }}
     queue: debug-scaling
     cpus_per_node: 32
     select_options: ngpus=4

--- a/docs/endpoints/configs/stampede3.yaml
+++ b/docs/endpoints/configs/stampede3.yaml
@@ -1,5 +1,3 @@
-display_name: Stampede3@TACC
-
 engine:
   type: GlobusComputeEngine
   max_workers_per_node: 2
@@ -12,7 +10,7 @@ engine:
     type: SlurmProvider
 
     # e.g., EAR22001
-    account: {{ YOUR_TACC_ALLOCATION }}
+    account: {{ TACC_ALLOCATION }}
 
     # e.g., skx-dev
     partition: {{ PARTITION }}

--- a/docs/endpoints/configs/uchicago_ai_cluster.yaml
+++ b/docs/endpoints/configs/uchicago_ai_cluster.yaml
@@ -1,4 +1,3 @@
-display_name: AI Cluster CS@UChicago
 engine:
     type: GlobusComputeEngine
     label: fe.cs.uchicago

--- a/docs/endpoints/endpoint_examples.rst
+++ b/docs/endpoints/endpoint_examples.rst
@@ -5,9 +5,9 @@ Example Configurations
 
 While Globus Compute is in use on various systems around the world, getting to a working
 configuration that matches the underlying system constraints and the requirements of the
-site-administrator often takes trial and error.  Below are example configurations for some
-well-known systems that are known to work.  These serve as a reference for getting
-started.
+site-administrator often takes trial and error.  Below are example user endpoint configuration
+templates for some well-known systems that are known to work.  These serve as a reference
+for getting started.
 
 If you would like to add your system to this list please contact the Globus Compute Team
 via `Slack <https://funcx.slack.com/>`_.  (The `#help channel`_ is a good place to
@@ -28,7 +28,8 @@ configuration assumes the user is running on a login node, uses the ``SlurmProvi
 interface with the scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/anvil.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Delta (NCSA)
@@ -42,7 +43,8 @@ assumes the user is running on a login node, uses the ``SlurmProvider`` to inter
 with the scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/delta.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Expanse (SDSC)
@@ -56,7 +58,8 @@ user is running on a login node, uses the ``SlurmProvider`` to interface with th
 scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/expanse.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 The |GlobusMPIEngine|_ adds support for running MPI applications. The following snippet
 shows an example configuration for Expanse that uses the ``SlurmProvider`` to provision
@@ -64,7 +67,8 @@ batch jobs each with 4 nodes, which can be dynamically partitioned to launch
 MPI functions with ``srun``.
 
 .. literalinclude:: configs/expanse_mpi.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 UChicago AI Cluster
@@ -79,7 +83,8 @@ Cluster.  The configuration assumes the user is running on a login node and uses
 Link to `docs <https://howto.cs.uchicago.edu/slurm:ai>`_.
 
 .. literalinclude:: configs/uchicago_ai_cluster.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 Here is some Python that demonstrates how to compute the variables in the YAML example
 above:
@@ -99,13 +104,15 @@ uses the ``SlurmProvider`` to interface with the scheduler, and uses the
 ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/midway.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 The following configuration example uses an Apptainer (formerly Singularity) container
 on Midway.
 
 .. literalinclude:: configs/midway_apptainer.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Kubernetes Clusters
@@ -120,7 +127,8 @@ the Python Kubernetes API, which assumes that you have kube config in
 ``~/.kube/config``.
 
 .. literalinclude:: configs/kube.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Polaris (ALCF)
@@ -134,7 +142,8 @@ and connects to Polaris's PBS scheduler using the ``PBSProProvider``.  This
 configuration assumes that the script is being executed on the login node of Polaris.
 
 .. literalinclude:: configs/polaris.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Perlmutter (NERSC)
@@ -150,7 +159,8 @@ request a particular node type (GPU) and to configure a specific Python environm
 the worker nodes using Anaconda.
 
 .. literalinclude:: configs/perlmutter.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Frontera (TACC)
@@ -164,7 +174,8 @@ the ``SlurmProvider`` to interface with the scheduler, and uses the ``SrunLaunch
 launch workers.
 
 .. literalinclude:: configs/frontera.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Bebop (LCRC, ANL)
@@ -178,7 +189,8 @@ node, uses the ``SlurmProvider`` to interface with the scheduler, and uses the
 ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/bebop.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Bridges-2 (PSC)
@@ -192,7 +204,8 @@ the ``SlurmProvider`` to interface with the scheduler, and uses the ``SrunLaunch
 launch workers.
 
 .. literalinclude:: configs/bridges-2.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 FASTER (TAMU)
@@ -204,7 +217,8 @@ the user is running on a login node, uses the ``SlurmProvider`` to interface wit
 scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/faster.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Open Science Pool
@@ -224,7 +238,8 @@ to the workers.
    shared-filesystem, **encryption** is disabled in the configuration below.
 
 .. literalinclude:: configs/ospool.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 
 Stampede3 (TACC)
@@ -239,7 +254,8 @@ to launch workers across nodes.
 
 
 .. literalinclude:: configs/stampede3.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 Pinning Workers to devices
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -256,7 +272,8 @@ specific identity assigned: ``CUDA_VISIBLE_DEVICES``, ``ROCR_VISIBLE_DEVICES``,
 
 
 .. literalinclude:: configs/worker_pinning.yaml
-   :language: yaml
+   :language: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
 
 .. |nbsp| unicode:: 0xA0
    :trim:

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -1,26 +1,32 @@
-Globus Compute Endpoints
-************************
+Endpoint User Guide
+*******************
 
-A Globus Compute Endpoint is a process launched by the user to serve as a conduit for
-executing functions on a computing resource.  The Compute Endpoint process manages the
-site‑specific interactions for executing functions, leaving users with only a single API
-necessary for running code on their laptop, campus cluster, or even leadership‑class HPC
-machines.
-
-In the mental model of Globus Compute, Endpoints are the remote instance:
-
-- Globus Compute SDK |nbsp| --- |nbsp| i.e., the script a researcher writes to submit
-  functions to ...
-
-- Globus Compute Web Services |nbsp| --- |nbsp| the Globus‑provided cloud‑services that
-  authenticate and ferry functions and tasks
-
-- **Globus Compute Endpoint** |nbsp| --- |nbsp| a site-specific process, typically on a
-  cluster head node, that manages user‑accessible compute resources to run tasks
-  submitted by the SDK
+This guide will walk you through most of the features of Globus Compute endpoints.
 
 The Compute Endpoint may be installed via PyPI in the usual manner, as well as via
 system packages.  See :doc:`installation` for more information.
+
+
+Overview
+========
+
+A Globus Compute Endpoint serves as a conduit for executing functions on computing
+resources. The Compute Endpoint manages site‑specific interactions for function
+execution, providing users with a unified API for running code across diverse
+environments -- from laptops to campus clusters to leadership‑class HPC systems.
+
+A Globus Compute Endpoint consists of three main process types:
+
+- **Manager endpoint process (MEP)** - Renders a configuration template to launch and manage
+  user endpoint processes.
+
+- **User endpoint process (UEP)** - Establishes secure communication with Globus Compute web
+  services to receive user-submitted tasks, launch worker processes, and publish results.
+
+- **Worker process** - Executes submitted tasks on the target computing resources (e.g., HPC
+  cluster nodes) according to the rendered configuration template.
+
+For a detailed look at how a task makes its way to a user endpoint process, see :ref:`tracing-a-task`.
 
 
 Quickstart
@@ -39,217 +45,238 @@ For those just looking for the quickstart commands:
    $ globus-compute-endpoint stop my_first_endpoint
 
 
-Getting Started
-===============
-
-Creating New Compute Endpoints
-------------------------------
+Configuring an Endpoint
+=======================
 
 Create a new endpoint directory and default files in ``$HOME/.globus_compute/`` via the
 ``configure`` subcommand:
 
 .. code-block:: console
 
-   $ globus-compute-endpoint configure my_first_endpoint
-   Created profile for endpoint named <my_first_endpoint>
+   $ globus-compute-endpoint configure my_endpoint
+   Created multi-user profile for endpoint named <my_endpoint>
 
-       Configuration file: /.../.globus_compute/my_first_endpoint/config.yaml
+       Configuration file: /home/user/.globus_compute/my_endpoint/config.yaml
 
-This new Compute Endpoint will also be in the output of the ``list`` subcommand:
+       User endpoint configuration template: /home/user/.globus_compute/my_endpoint/user_config_template.yaml.j2
+       User endpoint configuration schema: /home/user/.globus_compute/my_endpoint/user_config_schema.json
+       User endpoint environment variables: /home/user/.globus_compute/my_endpoint/user_environment.yaml
 
-.. code-block:: console
+   Use the `start` subcommand to run it:
 
-   $ globus-compute-endpoint list
-   +--------------------------------------+--------------+--------------------+
-   |             Endpoint ID              |    Status    |   Endpoint Name    |
-   +======================================+==============+====================+
-   | None                                 | Initialized  | my_first_endpoint  |
-   +--------------------------------------+--------------+--------------------+
+   globus-compute-endpoint start my_endpoint
 
-The Compute endpoint will receive an endpoint identifier from the Globus Compute web
-service upon first connect.  Until then, it exists solely as a subdirectory of
-``$HOME/.globus_compute/``.
+.. hint::
+   If run as a privileged user (e.g., root), the ``configure`` subcommand will generate an additional
+   :ref:`example-idmap-config` file. See :ref:`multi-user-configuration` for more information.
 
-.. _cea_configuration:
 
-As Globus Compute endpoints may be run on a diverse set of computational resources
-(i.e., the gamut from laptops to supercomputers), it is important to configure each
-instance to match the underlying capabilities and restrictions of the resource.  The
-default configuration is functional |nbsp| --- |nbsp| it will process tasks |nbsp| ---
-|nbsp| but it is intentionally limited to only use processes on the Endpoint host; in
-particular, on an HPC host, it will not use any additional computational nodes.  In
-its entirety, the default configuration is:
+``config.yaml``
+---------------
+
+The ``config.yaml`` file controls the manager endpoint process. Please refer to
+:ref:`endpoint-manager-config` for details on each field.
 
 .. code-block:: yaml
-   :caption: ``$HOME/.globus_compute/my_first_endpoint/config.yaml``
+   :caption: Default ``config.yaml`` configuration
 
+   amqp_port: 443
    display_name: null
+
+.. note::
+   ``display_name`` is an optional field that determines how the endpoint will
+   appear in the `Web UI`_.
+
+
+.. _user-config-template-yaml-j2:
+
+``user_config_template.yaml.j2``
+--------------------------------
+
+The manager endpoint process will render this template with user defined variables
+to launch a user endpoint process. More than simple interpolation, the endpoint
+treats this file as a `Jinja template`_, enabling a good bit of flexibility.
+
+The template file lives in the manager endpoint directory by default, but users can
+specify a different template path using the ``user_config_template_path`` setting in
+the manager's :ref:`config.yaml <endpoint-manager-config>`.
+
+The default template includes a basic single-worker configuration and defines two
+variables: ``endpoint_setup`` and ``worker_init``. Both variables default to empty
+strings when not specified by the user, as indicated by the ``...|default()`` filter.
+
+.. code-block:: yaml+jinja
+   :caption: Default ``user_config_template.yaml.j2``
+
+   endpoint_setup: {{ endpoint_setup|default() }}
+
    engine:
-     max_workers_per_node: 1
-     type: GlobusComputeEngine
-     provider:
-       type: LocalProvider
-       init_blocks: 1
-       max_blocks: 1
-       min_blocks: 0
+      type: GlobusComputeEngine
+      max_workers_per_node: 1
 
-For now, the key items to observe are the structure (e.g., ``provider`` as a child of
-``engine``), the engine type, ``GlobusComputeEngine``, and the provider type,
-``LocalProvider``.
+      provider:
+         type: LocalProvider
+         min_blocks: 0
+         max_blocks: 1
+         init_blocks: 1
+         worker_init: {{ worker_init|default() }}
 
-The *engine* pulls tasks from the incoming queue and conveys them to the *provider* for
-execution.  Globus Compute implements three engines: ``ThreadPoolEngine``,
-``ProcessPoolEngine``, and ``GlobusComputeEngine``.  The first two are Compute endpoint
-wrappers of Python's |ThreadPoolExecutor|_ and |ProcessPoolExecutor|_.  These engines
-are most appropriate for single‑host installations (e.g., a personal workstation).  For
-scheduler‑based clusters, |GlobusComputeEngine|_, as a wrapper over Parsl's
-|HighThroughputExecutor|_, enables access to multiple computation nodes.
+   idle_heartbeats_soft: 10
+   idle_heartbeats_hard: 5760
 
-In contrast to the engine, the *provider* speaks to the site's available resources.  For
-example, if an endpoint is on the local workstation, the configuration might use the
-|LocalProvider|_, but for running jobs on a Slurm cluster, the endpoint would need the
-|SlurmProvider|_.  (|LocalProvider|_ and |SlurmProvider|_ are an arbitrary selection for
-this discussion; Parsl implements `a number of other providers`_.)
+The default configuration is functional |nbsp| --- |nbsp| it will process tasks |nbsp|
+--- |nbsp| but the `LocalProvider`_ will only use processes on the endpoint host.
+Thus, on an HPC head node, the endpoint will not use any additional computational nodes.
 
-Using the full power of the underlying resources requires site‑specific setup, and can
-be tricky to get right.  For instance, configuring the endpoint to submit tasks to a
-batch scheduler might require a scheduler account id, awareness of which queues are
-accessible for the account id and the job size at hand (that can change!), knowledge of
-which network interface cards to use, administrator‑chosen setup steps, and so forth ...
-the :doc:`list of example configurations <endpoint_examples>` is a good first resource
-as these are known working configurations.
+Our docs showcase many :doc:`example configurations <endpoint_examples>`, but please
+refer to :ref:`uep-conf` for an in-depth explanation of configuration features and
+:doc:`templates` for details on template capabilities and peculiarities.
 
-.. |ThreadPoolExecutor| replace:: ``concurrent.futures.ThreadPoolExecutor``
-.. _ThreadPoolExecutor: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
-.. |ProcessPoolExecutor| replace:: ``concurrent.futures.ProcessPoolExecutor``
-.. _ProcessPoolExecutor: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor
-.. |pipx for library isolation| replace:: ``pipx`` for library isolation
-.. _pipx for library isolation: https://pipx.pypa.io/stable/
-.. |GlobusComputeEngine| replace:: ``GlobusComputeEngine``
-.. _GlobusComputeEngine: ../reference/engine.html#globus_compute_endpoint.engines.GlobusComputeEngine
-.. |HighThroughputExecutor| replace:: ``HighThroughputExecutor``
-.. _HighThroughputExecutor: https://parsl.readthedocs.io/en/latest/stubs/parsl.executors.HighThroughputExecutor.html
-.. |LocalProvider| replace:: ``LocalProvider``
-.. _LocalProvider: https://parsl.readthedocs.io/en/latest/stubs/parsl.providers.LocalProvider.html
-.. |SlurmProvider| replace:: ``SlurmProvider``
-.. _SlurmProvider: https://parsl.readthedocs.io/en/latest/stubs/parsl.providers.SlurmProvider.html
-.. _a number of other providers: https://parsl.readthedocs.io/en/latest/reference.html#providers
 
+.. _user-config-schema-json:
+
+``user_config_schema.json``
+---------------------------
+
+Admins can define a `JSON schema <https://json-schema.org/>`_ to validate user-defined
+variables. The schema file lives in the manager endpoint directory by default, but users
+can specify a different schema path using the ``user_config_schema_path`` variable in the
+manager's :ref:`config.yaml <endpoint-manager-config>`.
+
+The default schema is quite permissive, enforcing that the two default template variables
+are strings, then allowing any other user-defined properties:
+
+.. code-block:: json
+   :caption: Default ``user_config_schema.json``
+
+   {
+     "$schema": "https://json-schema.org/draft/2020-12/schema",
+     "type": "object",
+     "properties": {
+       "endpoint_setup": { "type": "string" },
+       "worker_init": { "type": "string" }
+     },
+     "additionalProperties": true
+   }
+
+.. important::
+
+   The default schema sets ``additionalProperties`` to ``true``, allowing properties
+   not explicitly defined in the schema. This enables the default template to work
+   without customization.
+
+   Setting ``additionalProperties`` to ``false`` will reject unexpected properties and
+   enable more transparent failures.
+
+
+``user_environment.yaml``
+-------------------------
+
+Use this file to specify site-specific environment variables to export to the user
+endpoint process. Though this is a YAML file, it is interpreted internally as a simple
+top-level-only set of key-value pairs.  Nesting of data structures will probably not
+behave as expected. Example:
+
+.. code-block:: yaml
+
+   COMPILER_PATH: /opt/compiler/3.2.9/bin
+   LD_LIBRARY_PATH: /opt/compiler/lib:/opt/cray/lib64:/opt/nvidia/Linux_x86_64/nccl/lib
+   LD_PRELOAD: /opt/lib64/libsite.so
+
+These will be injected into the user endpoint process as environment variables.
+
+
+.. _starting-the-endpoint:
 
 Starting the Endpoint
----------------------
+=====================
 
-After configuration, start the endpoint instance with the ``start`` subcommand:
-
-.. code-block:: console
-
-   $ globus-compute-endpoint start my_first_endpoint
-   Starting endpoint; registered ID: <...registered UUID...>
-
-.. _endpoint-process-tree:
-
-The endpoint instance will first register with the Globus Compute web services, open two
-AMQP connections to the Globus Compute AMQP service (one to receive tasks, one to submit
-results; :ref:`both over port 443 <compute-endpoint-pre-requisites>`), print the web
-service‑provided Endpoint ID to the console, then daemonize.  Though the prompt returns,
-the process is still running:
+After configuration, start the endpoint instance with the ``start`` subcommand. Once
+started, the endpoint stays attached to the console, with a timer that updates every
+second as a hint that the manager endpoint process is running:
 
 .. code-block:: console
 
-        --- output edited for brevity ---
+   $ globus-compute-endpoint start my_endpoint
+         >>> Endpoint ID: [endpoint_uuid] <<<
+   ----> Wed Aug  6 20:03:02 2025
 
-   $ globus-compute-endpoint list
-   +--------------------------------------+--------------+--------------------+
-   |             Endpoint ID              |    Status    |   Endpoint Name    |
-   +======================================+==============+====================+
-   |   <...the same registered UUID...>   | Running      | my_first_endpoint  |
-   +--------------------------------------+--------------+--------------------+
+On the first invocation, the endpoint will emit a link to the console and ask for a
+temporary code in return. As part of this step, the Globus Compute web services will
+request access to your `Globus Auth`_ identity and `Globus Groups`_. Your Globus Auth
+identity will register as the endpoint owner and cannot be changed.
 
-   $ ps x --forest | grep -A 2 my_first_endpoint
-     [...]   \_ Globus Compute Endpoint (<THE_ENDPOINT_UUID>, my_first_endpoint) [...]
-     [...]       \_ parsl: HTEX interchange
-     [...]       \_ Globus Compute Endpoint (<THE_ENDPOINT_UUID>, my_first_endpoint) [...]
+If you start the endpoint as a non-privileged local user, then the manager and user endpoint
+processes will run as the same local user, and the endpoint will only accept tasks submitted
+by the endpoint owner. We refer to this as a single-user endpoint:
 
-The Globus Compute endpoint requires outbound access to the Globus Compute services over
-:ref:`HTTPS (port 443) and AMQPS (port 443) <compute-endpoint-pre-requisites>`.
+.. code-block:: text
+   :caption: Single-user endpoint process hierarchy
 
-.. note::
+   Manager Endpoint Process (alice, UID: 1001)
+   └── User Endpoint Process (alice, UID: 1001)
 
-   All Compute endpoints run on behalf of a user.  At the Unix level, the processes run
-   as a particular username (c.f., ``$USER``, ``uid``), but to connect to the Globus
-   Compute web services (and thereafter receive tasks and transmit results), the
-   endpoint must be associated with a `Globus Auth identity`_.  The Globus Compute web
-   services will validate incoming tasks for this endpoint against this identity.
-   Further, once registered, the endpoint instance cannot be run by another Globus Auth
-   identity.
+.. hint::
 
-.. _Globus Auth identity: https://www.globus.org/platform/services/auth
+   If you start the endpoint as a privileged user (e.g., root), then the endpoint will require
+   additional configuration to enable mapping Globus Auth identities to local user accounts.
+   Please refer to :doc:`multi_user` for more information.
 
-.. note::
 
-   On the first invocation, the endpoint will emit a long link to the console and ask
-   for a Globus Auth code in return.  As part of this step, the Globus Compute web
-   services will request access to your Globus Auth identity and Globus Groups.
-   (Subsequent runs will not need to perform this login step as the credentials are
-   cached.)
+Basic User Workflow
+===================
 
-The default configuration will fork the endpoint process to the background, returning
-control to the shell.  To debug, or for general insight into the status, look in the
-endpoint's ``endpoint.log``.  This log is also part of the corpus of information
-collected by the ``globus-compute-diagnostic`` utility:
-
-.. code-block:: console
-
-   $ tail ~/.globus_compute/my_first_endpoint/endpoint.log
-   ========== Endpoint begins: <THE_ENDPOINT_UUID>
-   ... INFO MainProcess-3650227 MainThread-136228654940160 globus_compute_endpoint.endpoint.interchange:95 __init__ Initializing EndpointInterchange process with Endpoint ID: <THE_ENDPOINT_UUID>
-   [... snipped for documentation brevity ...]
-   ... INFO MainProcess-3650227 Thread-2-136228444812864 globus_compute_endpoint.endpoint.rabbit_mq.result_publisher:135 run ResultPublisher<✗; o:0; t:0> Opening connection to AMQP service.
-
-If all is well, then using the endpoint is just as described in :ref:`Quickstart
-<quickstart-run-function>`:
+After starting the endpoint, users can specify values for the template variables when
+submitting a task:
 
 .. code-block:: python
-   :caption: ``does_it_work.py``
+   :emphasize-lines: 8,11
 
    from globus_compute_sdk import Executor
 
-   def dot_product(a, b):
-       return sum(a_i * b_i for a_i, b_i in zip(a, b))
+   def add(a, b):
+      return a + b
 
-   inp = ((1, 2, 3), (4, 5, 6))
-   with Executor(endpoint_id="<THE_ENDPOINT_UUID>") as ex:
-       f = ex.submit(dot_product, *inp)
-       print(f"  {'⸳'.join(map(str, inp))} ==> {f.result()}")
+   with Executor(
+       endpoint_id="...",
+       user_endpoint_config={"worker_init": "source /path/to/venv1/bin/activate"}
+   ) as ex:
+       print(ex.submit(add, 30, 12).result())
+       ex.user_endpoint_config["worker_init"] = "source /path/to/venv2/bin/activate"
+       print(ex.submit(add, 21, 21).result())
+
+.. note::
+   This example code highlights the ``user_endpoint_config`` attribute of the ``Executor``
+   class; please consult the :doc:`../sdk/executor_user_guide` documentation for more
+   information.
+
+The manager endpoint process renders the configuration template with the user-defined
+variables, then launches a user endpoint process. When these values change, a new
+user endpoint process is launched and can run concurrently with existing processes.
+
+Stopping the Endpoint
+=====================
+
+To stop the endpoint from the same terminal process, type ``Ctrl+\`` (SIGQUIT) or ``Ctrl+C``
+(SIGINT).
+
+To stop the endpoint from a different process, the CLI offers the ``stop`` subcommand:
 
 .. code-block:: console
 
-   $ python does_it_work.py
-     (1, 2, 3)⸳(4, 5, 6) ==> 32
+   $ globus-compute-endpoint stop my_endpoint
+   > Endpoint <my_endpoint> is now stopped
 
-Stopping the Compute Endpoint
------------------------------
-
-There are a couple of ways to stop the Compute endpoint.  The CLI offers the ``stop``
-subcommand:
+Alternatively, if the PID of the manager endpoint process is handy, then either will work:
 
 .. code-block:: console
 
-   $ globus-compute-endpoint stop my_first_endpoint
-   > Endpoint <my_first_endpoint> is now stopped
-
-Sometimes, a Unix signal may be more ergonomic for a workflow.  At the process‑level,
-the service responds to the Unix signals SIGTERM and SIGQUIT, so if the PID of the
-parent process is handy, then either will work:
-
-.. code-block:: console
-
-   $ kill -SIGQUIT <the_cea_pid>    # equivalent to -SIGTERM
-   $ kill -SIGTERM <the_cea_pid>    # equivalent to -SIGQUIT
+   $ kill -SIGQUIT <manager_pid>    # equivalent to -SIGTERM
+   $ kill -SIGTERM <manager_pid>    # equivalent to -SIGQUIT
 
 
 Listing Endpoints
------------------
+=================
 
 To list available endpoints on the current system, run:
 
@@ -286,111 +313,30 @@ Endpoints will be in one of the following states:
    ``$HOME/.globus_compute/``.
 
 
-Fine-Tuning Endpoint Setups
-===========================
-
-GlobusComputeEngine
--------------------
-
-|GlobusComputeEngine|_ is the execution backend that Globus Compute uses
-to execute functions.  To execute functions at scale, Globus Compute can be
-configured to use a range of |Providers|_ which allows it to connect to Batch schedulers
-like Slurm and PBSTorque to provision compute nodes dynamically in response to workload.
-These capabilities are largely borrowed from Parsl's |HighThroughputExecutor|_ and
-therefore all of |HighThroughputExecutor|_'s parameter options are supported as
-passthrough.
-
-.. note::
-
-   As of ``globus-compute-endpoint==2.12.0``, |GlobusComputeEngine|_ is the default
-   engine type.  The ``HighThroughputEngine`` is deprecated.
-
-Here are |GlobusComputeEngine|_ specific features:
-
-
-Retries
-^^^^^^^
-
-Functions submitted to the |GlobusComputeEngine|_ can fail due to infrastructure
-failures, for example, the worker executing the task might terminate due to it running
-out of memory, or all workers under a batch job could fail due to the batch job
-exiting as it reaches the walltime limit. |GlobusComputeEngine|_ can be configured
-to automatically retry these tasks by setting ``max_retries_on_system_failure=N``
-where N is the number of retries allowed. The endpoint config sets default retries
-to 0 since functions can be computationally expensive, not idempotent, or leave
-side effects that affect subsequent retries.
-
-Example config snippet:
-
-.. code-block:: yaml
-
-   amqp_port: 443
-   display_name: Retry_2_times
-   engine:
-       type: GlobusComputeEngine
-       max_retries_on_system_failure: 2  # Default=0
-
-
-Auto-Scaling
-^^^^^^^^^^^^
-
-|GlobusComputeEngine|_ by default automatically scales workers in response to workload.
-
-``Strategy`` configuration is limited to two options:
-
-#. ``max_idletime``: Maximum duration in seconds that workers are allowed to idle before
-   they are marked for termination
-
-#. ``strategy_period``: Set the # of seconds between strategy attempting auto-scaling
-   events
-
-The bounds for scaling are determined by the options to the ``Provider``
-(``init_blocks``, ``min_blocks``, ``max_blocks``). Please refer to the `Parsl docs
-<https://parsl.readthedocs.io/en/stable/userguide/execution.html#elasticity>`_ for more
-info.
-
-Here's an example configuration:
-
-.. code-block:: yaml
-
-   engine:
-       type: GlobusComputeEngine
-       job_status_kwargs:
-           max_idletime: 60.0      # Default = 120s
-           strategy_period: 120.0  # Default = 5s
-
-
 Ensuring Execution Environment
-------------------------------
+==============================
 
-When executing a function, endpoint *worker processes* expect to have all dependencies
-installed.  For example, if a function requires ``numpy`` and a worker environment does
-not have that package installed, attempts to execute that function on that worker will
-fail.
-
-The process tree as shown in :ref:`starting the endpoint <endpoint-process-tree>` is the
-Compute Endpoint interchange.  This is distinct from the *worker* processes, which are
-managed by the Provider.  For example, the ProcessPoolEngine |nbsp| --- |nbsp| with a
-(conceptually) built‑in provider |nbsp| --- |nbsp| will create multiple new processes on
-the same host as the endpoint itself, whereas the GlobusComputeEngine might start
-processes (via the system‑specific batch scheduler) on entirely different hosts.  In
-:abbr:`HPC (High Performance Computing)` contexts, the latter is typically the case.
+Endpoint *worker processes*, which perform the actual function execution, expect to have
+all dependencies installed.  For example, if a function requires ``numpy`` and a worker
+environment does not have that package installed, then attempts to execute that function
+on that worker will fail.
 
 As a result, it is often necessary to load in some kind of pre‑initialized environment
-for each worker.  In general there are two approaches:
+for each worker.  In general, there are two approaches:
 
-.. note::
+.. important::
 
    The worker environment must have the ``globus-compute-endpoint`` Python module
    installed.  We recommend matching the Python version and ``globus-compute-endpoint``
    module version on the worker environment and on the endpoint interchange.
 
-1. Python-Based Environment Isolation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python-Based Environments
+-------------------------
 
 Python‑based environment management uses the |worker_init|_ config option:
 
 .. code-block:: yaml
+   :caption: ``user_config_template.yaml.j2``
 
    engine:
      provider:
@@ -399,14 +345,15 @@ Python‑based environment management uses the |worker_init|_ config option:
          source /some/other/config
 
 Though the exact behavior of ``worker_init`` depends on the specific |Provider|_, this
-is typically run in the same process as (or the parent process of) the worker, allowing
-environment modification (i.e., environment variables).
+is run in the same process as the worker, allowing environment modification (i.e.,
+environment variables).
 
-In some cases, it may also be helpful to run some setup during the startup process of
-the endpoint itself, before any workers start.  This can be achieved using the top‑level
-``endpoint_setup`` config option:
+In some cases, it may also be helpful to run some setup while starting the user endpoint
+process, before any workers start.  This can be achieved using the top‑level ``endpoint_setup``
+config option:
 
 .. code-block:: yaml
+   :caption: ``user_config_template.yaml.j2``
 
    endpoint_setup: |
      conda create -n my-conda-env
@@ -416,10 +363,10 @@ the endpoint itself, before any workers start.  This can be achieved using the t
 .. warning::
 
    The script specified by ``endpoint_setup`` runs in a shell (usually ``/bin/sh``), as
-   a child process, and must finish successfully before the endpoint will continue
-   starting up.  In particular, *note that it is not possible to use this hook to set or
-   change environment variables for the endpoint*, and is a separate thought‑process
-   from ``worker_init`` which *can* set environment variables for the workers.
+   a child process, and must finish successfully before the user endpoint  process will
+   continue starting up.  In particular, *note that it is not possible to use this hook
+   to set or change environment variables for the endpoint*, and is a separate thought
+   process from ``worker_init``, which *can* set environment variables for the workers.
 
 Similarly, artifacts created by ``endpoint_setup`` may be cleaned up with
 ``endpoint_teardown``:
@@ -429,12 +376,10 @@ Similarly, artifacts created by ``endpoint_setup`` may be cleaned up with
    endpoint_teardown: |
      conda remove -n my-conda-env --all
 
-
 .. _containerized-environments:
 
-
-2. Containerized Environments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Containerized Environments
+--------------------------
 
 .. important::
    Container images must include the ``globus-compute-endpoint`` package.
@@ -444,10 +389,6 @@ Similarly, artifacts created by ``endpoint_setup`` may be cleaned up with
       # Example Dockerfile
       FROM python:3.13
       RUN pip install globus-compute-endpoint
-
-.. hint::
-   See the :doc:`../tutorials/dynamic_containers` tutorial for instructions on how
-   to specify container configuration when submitting tasks.
 
 Container support is limited to the |GlobusComputeEngine|_, and accessible via the
 following options:
@@ -471,48 +412,41 @@ following options:
     filesystem mount paths, network options etc.
 
 .. code-block:: yaml
-   :caption: Example ``config.yaml``, showing container type, uri, and cmd options to
-      run tasks inside a Docker instance.
+   :caption: Example ``user_config_template.yaml.j2`` showing container type, uri, and
+     cmd options to run tasks inside a Docker instance.
    :emphasize-lines: 4-6
 
    display_name: Docker
    engine:
      type: GlobusComputeEngine
      container_type: docker
-     container_uri: funcx/kube-endpoint:main-3.10
+     container_uri: compute-worker:4.0.0
      container_cmd_options: -v /tmp:/tmp
-     provider:
-       init_blocks: 1
-       max_blocks: 1
-       min_blocks: 0
-       type: LocalProvider
 
-For more custom use‑cases where either an unsupported container technology is required
-or building the container string programmatically is preferred use
-``container_type: custom``.  In this case, ``container_cmd_options`` is treated as a
-string template, with the following two strings replaced:
+.. hint::
+   See the :doc:`../tutorials/dynamic_containers` tutorial for instructions on how
+   to specify container configuration when submitting tasks.
 
-* ``{EXECUTOR_RUNDIR}``: All occurrences will be replaced with the engine run path
-* ``{EXECUTOR_LAUNCH_CMD}``: All occurrences will be replaced with the worker launch
+For custom use cases requiring unsupported container technologies or programmatic container
+string construction, set ``container_type: custom``. With this configuration, ``container_cmd_options``
+functions as a string template where the following placeholders are replaced:
+
+* ``{EXECUTOR_RUNDIR}``: All occurrences are replaced with the engine run path
+* ``{EXECUTOR_LAUNCH_CMD}``: All occurrences are replaced with the worker launch
   command within the container.
 
 The Docker YAML example from above could be approached via ``custom`` and the
 ``container_cmd_options`` as:
 
 .. code-block:: yaml
-   :caption: Example ``config.yaml``, showing how to use the custom container type.
+   :caption: ``user_config_template.yaml.j2``
    :emphasize-lines: 4-5
 
    display_name: Docker Custom
    engine:
      type: GlobusComputeEngine
      container_type: custom
-     container_cmd_options: docker run -v {EXECUTOR_RUNDIR}:{EXECUTOR_RUNDIR} funcx/kube-endpoint:main-3.10 {EXECUTOR_LAUNCH_CMD}
-     provider:
-       init_blocks: 1
-       max_blocks: 1
-       min_blocks: 0
-       type: LocalProvider
+     container_cmd_options: docker run -v {EXECUTOR_RUNDIR}:{EXECUTOR_RUNDIR} compute-worker:4.0.0 {EXECUTOR_LAUNCH_CMD}
 
 .. |worker_init| replace:: ``worker_init``
 .. _worker_init: https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html#parsl.providers.SlurmProvider#:~:text=worker_init%20%28str%29,env%E2%80%99
@@ -521,8 +455,163 @@ The Docker YAML example from above could be approached via ``custom`` and the
 .. _Provider: https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.base.ExecutionProvider.html
 
 
+.. _configure-multiple-python-versions:
+
+Support Multiple Python Versions
+================================
+
+Due to issues with cross-version serialization, we recommend :ref:`keeping the Python
+version running on Endpoint workers in sync <avoiding-serde-errors>` with the version
+that functions are first submitted from. However, this can be limiting for
+workflows where admins have little control over their user's SDK environments, such as
+locally run Jupyter notebooks.  This can sometimes be alleviated with :ref:`an alternate
+serialization strategy <specifying-serde-strategy>` (e.g. :class:`~globus_compute_sdk.serialize.JSONData`,
+which doesn't rely on bytecode), but not all serialization strategies work in all
+environments.  A more robust workaround is to use the ``user_runtime`` config template
+variable to detect what Python version was used to submit the task.
+
+Suppose an admin wants to accept the four most recent Python versions (3.10-3.13).
+Using `conda`_, they can create an environment for each Python version they want to
+support, and launch workers with the correct environment depending on the user's Python
+version.  A config template for that might look like:
+
+.. code-block:: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
+
+   engine:
+     type: GlobusComputeEngine
+     provider:
+        type: LocalProvider
+     {% if '3.13' in user_runtime.python_version %}
+        worker_init: conda activate py313
+     {% elif '3.12' in user_runtime.python_version %}
+        worker_init: conda activate py312
+     {% elif '3.11' in user_runtime.python_version %}
+        worker_init: conda activate py311
+     {% else %}
+        worker_init: conda activate py310
+     {% endif %}
+
+This requires that there are conda environments named ``py313``, ``py312``, ``py311``, and
+``py310`` with the appropriate Python versions installed.
+
+For more information on what the template knows about the user's runtime environment, see
+|UserRuntime|.
+
+
+Advanced Environment Customization
+==================================
+
+.. note::
+   This section is only relevant for :ref:`repository-based installations <repo-based-installation>`.
+
+There are some instances where static configuration is not enough.  For example, setting
+a user-specific environment variable or running arbitrary scripts prior to handing
+control over to the user endpoint process.  For these cases, observe that
+``/usr/sbin/globus-compute-endpoint`` is actually a shell script wrapper:
+
+.. code-block:: shell
+
+   #!/bin/sh
+
+   VENV_DIR="/opt/globus-compute-agent/venv-py39"
+
+   if type deactivate 1> /dev/null 2> /dev/null; then
+   deactivate
+   fi
+
+   . "$VENV_DIR"/bin/activate
+
+   exec "$VENV_DIR"/bin/globus-compute-endpoint "$@"
+
+While we don't suggest modifying this wrapper (for ease of future maintenance), one
+might inject another wrapper into the process, by modifying the process PATH and writing
+a custom ``globus-compute-endpoint`` wrapper:
+
+.. code-block:: yaml
+   :caption: ``user_environment.yaml``
+
+   PATH: /usr/local/admin_scripts/
+
+.. code-block:: sh
+   :caption: ``/usr/local/admin_scripts/globus-compute-endpoint``
+
+   #!/bin/sh
+
+   /some/other/executable
+   . import/some/vars/script
+
+   # remove the `/usr/local/admin_scripts` entry from the PATH
+   export PATH=/usr/local/bin:/usr/bin:/REST/OF/PATH
+
+   exec /usr/sbin/globus-compute-endpoint "$@"
+
+(The use of ``exec`` is not critical, but keeps the process tree tidy.)
+
+
+Debugging
+=========
+
+If actively debugging or iterating, the two command line arguments ``--log-to-console``
+and ``--debug`` may be helpful as they increase the verbosity and color of the text to
+the console.  Meanwhile, the log is always available at
+``.globus_compute/my_endpoint/endpoint.log``, and is the first place to look
+upon an unexpected behavior.  In a healthy endpoint setup, there will be many lines about
+processes starting and stopping:
+
+.. code-block:: text
+
+   [...] Creating new user endpoint (pid: 3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint start uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a --die-with-parent]
+   [...] Command process successfully forked for 'harper' (Globus effective identity: b072d17b-08fd-4ada-8949-1fddca189b5e).
+   [...] Command stopped normally (3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint start uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a --die-with-parent]
+
+
+Debugging User Endpoint Processes
+---------------------------------
+
+The ``--debug`` flag will not carry-over to the child user endpoint processes.
+In particular, the command executed by the manager endpoint process is:
+
+.. code-block:: python
+   :caption: arguments to ``os.execvpe``
+
+   proc_args = ["globus-compute-endpoint", "start", ep_name, "--die-with-parent"]
+
+Note the lack of the ``--debug`` flag; by default, user endpoint processes will not
+emit DEBUG level logs. To place them into debug mode, use the ``debug`` top-level
+configuration directive:
+
+.. code-block:: yaml
+   :caption: ``user_config_template.yaml.j2``
+   :emphasize-lines: 1
+
+   debug: true
+   display_name: Debugging template
+   idle_heartbeats_soft: 10
+   idle_heartbeats_hard: 5760
+   engine:
+      ...
+
+Note that this is *also* how to get the user endpoint process to emit its configuration
+to the log, which may be helpful in determining which set of logs are associated with
+which configuration or just generally while implementing and debugging.  The configuration
+is written to the logs before the user endpoint process boots; look for the following
+sentinel lines::
+
+   [TIMESTAMP] DEBUG ... Begin Compute endpoint configuration (5 lines):
+      ...
+   End Compute endpoint configuration
+
+To this end, the authors have found the following command line helpful for pulling out
+the configuration from the logs:
+
+.. code-block:: console
+
+   $ sed -n "/Begin Compute/,/End Compute/p" ~/.globus_compute/uep.[...]/endpoint.log | less
+
+
 Client Identities
------------------
+=================
 
 The usual workflow involves a human manually starting an endpoint.  After the first‑run
 and the ensuing "long‑url" login‑process, the credentials are cached in
@@ -564,7 +653,7 @@ We explain how to acquire the environment variable values in detail in
 .. _restrict-submission-serialization-methods:
 
 Restricting Submission Serialization Methods
---------------------------------------------
+============================================
 
 When submitting to an endpoint, users may :ref:`select alternate strategies to
 serialize their code and data. <specifying-serde-strategy>` When that happens, the
@@ -578,10 +667,12 @@ and there can be security concerns with `deserializing untrusted data via pickle
 which is a dependency of the default serialization strategies used by Compute.
 
 The mechanism for restricting serialization strategies is the ``allowed_serializers``
-option under the ``engine`` section of the config, which accepts a list of fully-qualified
-import paths to :doc:`Globus Compute serialization strategies </reference/serialization_strategies>`:
+option under the ``engine`` section of the config template, which accepts a list of
+fully-qualified import paths to
+:doc:`Globus Compute serialization strategies </reference/serialization_strategies>`:
 
 .. code-block:: yaml
+   :caption: ``user_config_template.yaml.j2``
 
    engine:
       type: GlobusComputeEngine
@@ -615,6 +706,7 @@ If ``allowed_serializers`` is specified, it must contain at least one ``Code``-b
 strategy and one ``Data``-based strategy:
 
 .. code-block:: yaml
+   :caption: ``user_config_template.yaml.j2``
 
    engine:
       allowed_serializers: [globus_compute_sdk.serialize.DillCodeSource]
@@ -633,6 +725,7 @@ Globus-provided Compute Data serializers. For example, the following config is
 functionally equivalent to a config that omits ``allowed_serializers``:
 
 .. code-block:: yaml
+   :caption: ``user_config_template.yaml.j2``
 
    engine:
       allowed_serializers:
@@ -646,16 +739,16 @@ functionally equivalent to a config that omits ``allowed_serializers``:
 
 .. _enable_on_boot:
 
-Starting the Compute Endpoint on Host Boot
-------------------------------------------
+Installing as a Service
+=======================
 
 Run ``globus-compute-endpoint enable-on-boot`` to install a systemd unit file:
 
 .. code-block:: console
 
-   $ globus-compute-endpoint enable-on-boot my_first_endpointendpoint
+   $ globus-compute-endpoint enable-on-boot my_endpoint
    Systemd service installed. Run
-      sudo systemctl enable globus-compute-endpoint-my_first_endpoint.service --now
+      sudo systemctl enable globus-compute-endpoint-my_endpoint.service --now
    to enable the service and start the endpoint.
 
 Run ``globus-compute-endpoint disable-on-boot`` for commands to disable and uninstall
@@ -670,158 +763,490 @@ the service:
       rm /etc/systemd/system/globus-compute-endpoint-my-endpoint.service
 
 
-AMQP Port
----------
+.. _auth-policies:
 
-Endpoints receive tasks and communicate task results via the AMQP messaging protocol.
-As of v2.11.0, newly configured endpoints use AMQP over port 443 by default, since
-firewall rules usually leave that port open. In case 443 is not open on a particular
-cluster, the port to use can be changed in the endpoint config via the ``amqp_port``
-option, like so:
+Authentication Policies
+=======================
+
+Administrators can use a `Globus authentication policy`_ to limit access to an endpoint
+and enable HA functionality. Access control is only relevant to :doc:`multi-user endpoints
+<multi_user>`, and HA features require an active HA subscription.
+
+Authentication policies are centrally managed within the Globus Auth service and can
+be shared across multiple endpoints. For detailed information on policy configuration
+and available fields, see the `Authentication Policies documentation`_.
+
+
+Create a New Authentication Policy
+----------------------------------
+
+Administrators can create new authentication policies via the `Globus Auth API
+<https://docs.globus.org/api/auth/reference/#create_policy>`_, or via the following
+``configure`` subcommand options:
+
+.. note::
+  The resulting policy will be automatically applied to the endpoint's ``config.yaml``.
+
+``--auth-policy-project-id``
+  The id of a Globus Auth project that this policy will belong to. If not provided,
+  the user will be prompted to create one.
+
+``--auth-policy-display-name``
+  A user friendly name for the policy.
+
+``--allowed-domains``
+  A comma separated list of domains that can satisfy the policy. These may include
+  wildcards.  For example, ``*.edu, globus.org``.  For more details, see
+  ``domain_constraints_include`` in the `Authentication Policies documentation`_.
+
+``--excluded-domains``
+  A comma separated list of domains that will fail the policy.  These may include
+  wildcards.  For example, ``*.edu, globus.org``.  For more details, see
+  ``domain_constraints_exclude`` in the `Authentication Policies documentation`_.
+
+``--auth-timeout``
+  The maximum amount of time in seconds that a previous authentication must have
+  occurred to satisfy the policy.  Setting this will also set ``high_assurance`` to
+  ``true``.
+
+  .. attention::
+
+     For performance reasons, the web-service caches lookups for 60s.  Pragmatically,
+     this means that smallest timeout that Compute supports is 1 minute, even though it
+     is possible to set required authorizations for high assurance policies to smaller
+     time intervals.
+
+
+Apply an Existing Authentication Policy
+---------------------------------------
+
+Administrators can apply an authentication policy directly in the endpoint's ``config.yaml``:
 
 .. code-block:: yaml
+   :caption: ``config.yaml``
+
+   authentication_policy: 2340174a-1a0e-46d8-a958-7c3ddf2c834a
+
+... or via the ``--auth-policy`` option with the ``configure`` subcommand, which will
+make the necessary changes to ``config.yaml``:
+
+.. code-block:: bash
+
+   $ globus-compute-endpoint configure my_endpoint --auth-policy 2340174a-1a0e-46d8-a958-7c3ddf2c834a
+
+
+.. _high-assurance:
+
+High-Assurance
+--------------
+
+Globus Compute endpoints may be designated as High-Assurance (HA) to meet stricter
+security, compliance, and operational requirements.  HA endpoints differ from non-HA
+endpoints in a few key ways:
+
+- in addition to running regular functions, HA endpoints may also run HA functions
+  (described below).
+
+- HA endpoints enable audit-logging, whereby the states of all tasks (whether HA or
+  not) are logged to a file.
+
+Consider deploying a High-Assurance endpoint where there is need for stronger identity
+verification and authentication controls, and for workloads that require elevated
+assurance levels, such as sensitive research or regulated data processing.
+
+.. note::
+
+   Once an endpoint has registered, the High-Assurance setting may not be toggled.
+   An endpoint may not become HA at a later date if it is not initially registered as
+   such.  The reverse ("downgrading" from HA) is similarly disallowed.
+
+
+HA Configuration
+^^^^^^^^^^^^^^^^
+
+High-Assurance functionality requires a HA-enabled `Globus subscription`_, to be
+explicitly marked as HA, and to be associated with a HA `Globus authentication policy`_.
+In configuration form, that translates to ``subscription_id``, ``high_assurance``, and
+``authentication_policy``:
+
+.. code-block:: yaml
+   :caption: Example ``config.yaml`` of a HA endpoint
+
+   ...
+   subscription_id: 2c94f030-d346-11e9-939f-02ff96a5aa76
+   high_assurance: true
+   authentication_policy: 8e6529c8-a7ce-4310-b895-244e1b33702a
+   ...
+
+In this example, the ``subscription_id`` is associated with a HA-enabled subscription,
+and the ``authentication_policy`` has similarly been setup as HA.  Both of these values
+may be found in the Globus App `Web UI`_.  Find Subscriptions available to you via
+**Settings** |rarr| **Subscriptions**.
+
+Policies are associated with projects, so first navigate to **Settings**
+|rarr| **Developers** and select or create a project.  Within a project, navigate to
+the **Policies** tab.  If creating a policy, be sure to check the "High Assurance"
+checkbox.
+
+Alternatively, a new HA policy may be created at configuration time with an
+overly-specified command line:
+
+.. code-block:: console
+   :linenos:
+
+   $ globus-compute-endpoint configure \
+       --multi-user \
+       --display-name "Example High-Assurance Compute Endpoint" \
+       --high-assurance \
+       --subscription-id 00000000-1111-...ffff \
+       --auth-policy-project-id 11111111-2222-...5555 \
+       --allowed-domains "example.edu,*.example.edu" \
+       --auth-timeout 1800 \
+      example_ha_compute_endpoint
+
+This example command line will
+
+- (Line 4) *create* a new HA (``--high-assurance``) policy ...
+- (Line 5) associated with the ``0000...`` subscription ...
+- (Line 6) under the ``1111...`` project ...
+- (Line 7) that will require users be from the ``example.edu`` domain or any subdomain ...
+- (Line 8) and that they authenticate every ``1800`` seconds.
+
+This example does not show all options; use ``configure --help`` to see what is
+available:
+
+.. code-block:: console
+
+   $ globus-compute-endpoint configure --help
+   Usage: globus-compute-endpoint configure [OPT...
+
+
+High-Assurance Functions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+A High-Assurance function is one that has been registered with the Globus Compute API
+as associated with a HA endpoint.  In other words, a HA function requires exactly one
+HA endpoint.  A HA function may not be run on any other endpoint and will be removed
+from all Globus-operated storage after 3 months of inactivity.
+
+To register a High-Assurance function, specify the ``ha_endpoint_id`` argument to
+``register_function()``:
+
+.. code-block:: python
+
+   from globus_compute_sdk import Client, Executor
+
+   def ha_func(pii: str):
+      from datetime import datetime
+      return f"ha_func: {datetime.now()} - processed pii: {pii}"
+
+   gc = Client()
+   ex = Executor()  # for illustrative purposes; strongly consider `with Executor() as ex:` style
+
+   # Registration works the same, whether via the Client or the Executor
+   ha_func_id_via_client = gc.register_function(ha_func, ha_endpoint_id='...')
+   ha_func_id_via_ex = ex.register_function(ha_func, ha_endpoint_id='...')
+
+   # Now save one of the registered ids (from this example, they point to the same
+   # function logic) for later use with `.submit_to_registered_function()`
+   print(ha_func_id_via_ex)
+
+Further, SDK usage of a HA function will require the SDK interaction to follow the HA
+requirements of the associated policy.  For example, a long running HA task (a task
+that uses an HA function) might require the SDK to login again before downloading the
+associated result:
+
+.. code-block:: python
+   :emphasize-lines: 6,15
+   :linenos:
+
+   >>> from globus_compute_sdk import Executor
+   >>> ha_endpoint_id = '...'
+   >>> ha_function_id = '...'
+   >>> with Executor(endpoint_id=ha_endpoint_id) as ex:
+   ...     fut = ex.submit_to_registered_function(ha_function_id, "ha-worthy-argument-to-function")
+   ...     print("\nResult:", fut.result())
+
+   Please authenticate with Globus here:
+   -------------------------------------
+   https://auth.globus.org/v2/oauth2/authorize?...
+   -------------------------------------
+
+   Enter the resulting Authorization Code here: ...
+
+   It is your responsibility to ensure disclosure of regulated data, such as Protected Health Information, resulting from the submission of this function and its arguments is legally authorized.
+
+   ha_func: 2025-04-29 13:39:57.888666 - processed pii: ha-worthy-argument-to-function
+
+On line 6, the script will wait until it receives notification from the AMQP server
+that the task result is ready.  Crucially, as the function is designated HA, the
+service does **not** send the result directly to the ``Executor`` instance, but instead
+simply sends notification that the task has completed.  To retrieve the result, the
+``Executor`` will make a request to the Globus Compute API which will verify, at the time
+of retrieval, that all HA requirements are met.  If they are not, then the ``Executor``
+will initiate the required login flow.
+
+Line 15 shows the standard disclaimer when working with an HA function.
+
+
+Audit Logging
+^^^^^^^^^^^^^
+
+Audit logging is available only to High-Assurance endpoints, and is enabled by the
+``audit_log_path`` |ManagerEndpointConfig| item:
+
+.. code-block:: yaml
+   :caption: Example ``config.yaml`` showing the ``audit_log_path`` configuration key
+
+   high_assurance: true
+   audit_log_path: /.../audit.log
+
+If this file does not exist, then it will be created with user-secure permissions
+(``umask=0o077``) when the endpoint starts.  It will not be checked thereafter, so it
+is incumbent on the administrator to ensure the file remains appropriately secured.
+
+When enabled, task events, if available, will be emitted one record per line:
+
+.. code-block:: text
+   :caption: Example ``audit.log`` content; the ``...`` fields are omitted for
+      documentation clarity
+
+   2025-04-10T14:44:58.742079-05:00 uid=0 pid=... eid=... Begin MEP session =====
+   ...
+   2025-04-10T14:45:30.906170-05:00 uid=... pid=... uep=... fid=... tid=... bid= RECEIVED
+   2025-04-10T14:45:30.906661-05:00 uid=... pid=... uep=... fid=... tid=... bid= EXEC_START
+   2025-04-10T14:45:37.401833-05:00 uid=... pid=... uep=... fid=... tid=... bid=4 jid=2477 RUNNING
+   2025-04-10T14:45:37.969570-05:00 uid=... pid=... uep=... fid=... tid=... bid=4 jid=2477 EXEC_END
+   ...
+   2025-04-10T14:46:39.689716-05:00 uid=0 pid=... eid=... End MEP session -----
+
+Each session begins when the MEP starts, and ends when the MEP stops (denoted with the
+sentinel lines ``Begin MEP session =====`` and ``End MEP session -----``).  Each record
+contains for the emitting process:
+
+- a local-timezone timestamp in ISO 8601 format
+- ``uid`` -- the POSIX user id
+- ``pid`` -- the POSIX process id
+- ``uep`` -- the internal UEP identifier, a UUID
+- ``fid`` -- the function identifier registered with the Compute service, a UUID
+- ``tid`` -- the task identifier registered with the Compute service, a UUID
+- ``bid`` -- the block identifier, if available, where the task was scheduled
+- ``jid`` -- the scheduler job identifier, if available
+- the task state (one of ``RECEIVED``, ``EXEC_START``, ``RUNNING``, ``EXEC_END``)
+
+The four task states describe where the task was in the execution process when the
+audit record was emitted:
+
+- ``RECEIVED`` -- denotes that the endpoint has received the task from the AMQP service
+
+- ``EXEC_START`` -- emitted when the engine has handed the task to the internal executor
+
+- ``RUNNING`` -- emitted if the engine shares this event; notably, the
+  GlobusComputeEngine does while the :ref:`ProcessPoolEngine and ThreadPoolEngines
+  <uep-conf>` do not.
+
+- ``EXEC_END`` -- emitted when the task has completed, just prior to sending the result
+  to the Compute AMQP service
+
+
+Additional High-Assurance Resources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Globus Subscriptions:
+
+  https://www.globus.org/subscriptions
+
+- High Assurance Security Overview:
+
+  https://docs.globus.org/guides/overviews/security/high-assurance-overview/
+
+
+.. _function-allowlist:
+
+Function Allow Listing
+======================
+
+To require that user endpoint processes only allow certain functions, specify the
+``allowed_functions`` top-level configuration item in ``config.yaml``:
+
+.. code-block:: yaml
+   :caption: ``config.yaml``
+
+   allowed_functions:
+      - 6d0ba55f-de15-4af2-827d-05c50c338aa7
+      - e552e7f2-c007-4671-8ca4-3a4fd84f3805
+
+At registration, the web service will be apprised of these function identifiers, and
+only tasks that invoke these functions will be sent to the user endpoint processes.
+Any= submission that specifies non-approved function identifiers will be rebuffed with
+HTTP 403 response like:
+
+.. code-block:: text
+   :caption: *Example HTTP invalid function error response via the SDK; edited for clarity*
+
+   403
+   FUNCTION_NOT_PERMITTED
+   Function <function_id> not permitted on endpoint <endpoint_id>
+
+Additionally, user endpoint processes will verify that tasks only use functions from the
+allow list. Given the guarantees of the API, this is a redundant verification, but is
+performed locally as a precautionary measure.
+
+There are some instances where an administrator may want to restrict different users to
+different functions.  In this scenario, the administrator must specify the restricted
+functions within the :ref:`Jinja template logic for the user endpoint configuration
+<user-config-template-yaml-j2>`, and *specifically not specify any restrictions* in the
+parent ``config.yaml`` file.  In this setup, the web-service will not verify task-requested
+functions as this check will be done locally by the user endpoint process.  An example
+configuration template snippet might be:
+
+.. code-block:: yaml+jinja
+   :caption: ``user_config_template.yaml.j2``
+
+   engine:
+      ...
+   allowed_functions:
+   {% if '3.13' in user_runtime.python_version %}
+     - c01ebede-06f5-4647-9712-e5649d0f573a
+     - 701fc11a-69b5-4e97-899b-58c3cb56334d
+   {% elif '3.12' in user_runtime.python_version %}
+     - 8dea796f-67cd-49ba-92b9-c9763d76a21d
+     - 0a6e8bed-ae93-4fd5-bb60-11c45bc1f42d
+   {% endif %}
+
+Rejections to the SDK from the user endpoint process look slightly different:
+
+.. code-block:: text
+
+   Function <function_id> not permitted on endpoint <user_endpoint_id>
+
+In the web-response, the task is not sent to the endpoint at all. In this second error
+message, the user endpoint process was started, received the task and rejected it; the
+mentioned endpoint is the internal user endpoint process identifier, not the parent
+endpoint identifier.
+
+.. attention::
+
+   If the template configuration sets ``allowed_functions`` and ``config.yaml`` also
+   specifies ``allowed_functions``, then the template configuration is ignored. The
+   only exception to this is if ``config.yaml`` does *not* restrict the functions,
+   as discussed above.
+
+
+AMQP Port
+=========
+
+Endpoints communcaite with the Globus Compute web services via the AMQP messaging protocol.
+As of v2.11.0, newly configured endpoints use AMQP over port 443 by default, since firewall
+rules usually leave that port open. In case 443 is not open on a particular cluster, the port
+can be changed in ``config.yaml`` via the ``amqp_port`` option:
+
+.. code-block:: yaml
+   :caption: ``config.yaml``
 
    amqp_port: 5671
    display_name: My Endpoint
-   engine: ...
 
 Note that only ports 5671, 5672, and 443 are supported with the Compute hosted services.
 Also note that when ``amqp_port`` is omitted from the config, the port is based on the
 connection URL the endpoint receives after registering itself with the services, which
 typically means port 5671.
 
-.. _endpoints_templating_configuration:
 
-Templating Endpoint Configuration
----------------------------------
+.. _tracing-a-task:
 
-A common experience for Compute users is a proliferation of their Compute Endpoints.
-After starting with a basic configuration, changing or conflicting requirements
-necessitate running multiple endpoints |nbsp| --- |nbsp| sometimes simultaneously |nbsp|
---- |nbsp| with different configurations.  For example, attributing work to different
-accounts, changing the size of the provisioned compute resource to match the demands of
-the problem, or changing the submission queue to the batch‑system.
+Tracing a Task to the Endpoint
+==============================
 
-This becomes a bit of an administrative mess for these users, who must constantly update
-their endpoint configurations, bring up and bring down different endpoints, and be aware
-of which endpoints have which configuration.
+The workflow for a task sent to an endpoint roughly follows these steps:
 
-As of May, 2024, Compute Endpoints may now be run as "multi‑user" endpoints.  Please
-ignore the name (:ref:`see the note, below <pardon-the-mess>`) and instead think of it
-as "template‑able".  This type of 'multi'‑user endpoint specifies a configuration
-*template* that will be filled in by SDK‑supplied user‑variables.  This configuration is
-then applied to sub‑processes of the multi‑user endpoint.  To disambiguate, we call the
-parent process the Multi‑User Endpoint and abbreviate it as MEP, and the child‑processes
-*of* the MEP the User Endpoints, or UEPs.
+#. The user obtains an endpoint ID either by starting (see :ref:`starting-the-endpoint`)
+   or from the administrator of a public endpoint.
 
-The UEP is exactly the same process and logic as discussed in previous sections.  The
-only difference is that the UEP always has a parent MEP process.  Conversely, MEPs *do
-not run tasks*.  They have exactly one job: start UEPs based on the passed
-configuration.
+#. The user submits a task to the endpoint with the SDK, specifying the ``endpoint_id``
+   and ``user_endpoint_config``:
 
-.. _create-templatable-endpoint:
+   .. code-block:: python
+      :emphasize-lines: 7, 8
 
-Create a MEP configuration by passing the ``--multi-user`` flag to the ``configure``
-subcommand:
+      from globus_compute_sdk import Executor
 
-.. code-block:: console
+      def some_task(*a, **k):
+          return 1
 
-   $ globus-compute-endpoint configure --multi-user my_second_endpoint
-   Created multi-user profile for endpoint named <my_second_endpoint>
+      with Executor() as ex:
+          ex.endpoint_id = "..."  # as acquired from step 1
+          ex.user_endpoint_config = {"worker_init": "source /path/to/venv/bin/activate"}
+          fut = ex.submit(some_task)
+          print("Result:", fut.result())  # Reminder: blocks until result received
 
-       Configuration file: /.../.globus_compute/my_second_endpoint/config.yaml
+#. After the ``ex.submit()`` call, the SDK `POSTs a REST request`_ to the Globus Compute
+   web service.
 
-       Example identity mapping configuration: /.../.globus_compute/my_second_endpoint/example_identity_mapping_config.json
+#. The Compute web-service generates a unique identifier for a new user endpoint process
+   using the following:
 
-       User endpoint configuration template: /.../.globus_compute/my_second_endpoint/user_config_template.yaml.j2
-       User endpoint configuration schema: /.../.globus_compute/my_second_endpoint/user_config_schema.json
-       User endpoint environment variables: /.../.globus_compute/my_second_endpoint/user_environment.yaml
+   - the ``endpoint_id``
+   - the Globus Auth identity ID of the user making the request
+   - the endpoint configuration in the request
+   - various user runtime information
 
-     Use the `start` subcommand to run it:
+   This identifier is simultaneously stable and unique. In other words, changing any of
+   these values *will result in a new user endpoint process*.
 
-       $ globus-compute-endpoint start my_second_endpoint
+#. The Compute web-service sends a message to the endpoint (via `AMQP`_) asking it to start
+   a user endpoint process as the user that initiated the REST request.
 
-The default configuration of the MEP, in its entirety, is:
+#. If running a :doc:`multi-user endpoint <multi_user>`, the manager endpoint process maps the
+   Globus Auth identity in the start request to a local POSIX username. If not, the manager
+   endpoint process skips identity mapping altogether.
 
-.. code-block:: console
+#. The manager endpoint process calls |fork(2)|_ to ceate a new process.
 
-   $ cat /.../.globus_compute/my_second_endpoint/config.yaml
-   display_name: null
-   identity_mapping_config_path: /.../.globus_compute/my_second_endpoint/example_identity_mapping_config.json
-   multi_user: true
+#. If running a :doc:`multi-user endpoint <multi_user>`, the manager endpoint process ascertains
+   the host-specific UID based on a |getpwnam(3)|_ call with the local username from the previous
+   step, then drops privileges.
 
-Unless this MEP will be run as a privileged user (e.g., ``root``) |nbsp| --- |nbsp| in
-which case, please read :doc:`the next section <multi_user>` |nbsp| --- |nbsp| the
-Identity Mapping pieces may be removed.  (If left in place, they will be ignored and a
-warning message will be emitted to the log.)
+#. The manager endpoint process validates the user-defined variables against the JSON schema, if
+   present, then renders the user endpoint configuration template.
 
-.. code-block:: console
+#. The manager endpoint process calls ``exec()`` to launch the user endpoint process and passes the
+   generated configuration over ``stdin``. Each user endpoint process creates a dedicated directory
+   in the local user's `$HOME/.globus_compute/` directory to store logs and other essential files.
 
-   $ rm /.../.globus_compute/my_second_endpoint/example_identity_mapping_config.json
-   $ sed -i '/identity_mapping/d' /.../.globus_compute/my_second_endpoint/config.yaml
+#. The just-started user endpoint process checks in with the Globus Compute web-services.
 
-The template file is ``user_config_template.yaml.j2``.  As implied by the ``.j2``
-extension, this file will be processed by `Jinja <https://jinja.palletsprojects.com/>`_
-before being used to start a child UEP.  For example, if the MEP might be utilized to
-send jobs to different allocations, one might write the template as:
-
-.. code-block:: yaml
-   :caption: ``/.../.globus_compute/my_second_endpoint/user_config_template.yaml.j2``
-
-   engine:
-     type: GlobusComputeEngine
-     provider:
-       type: SlurmProvider
-       partition: {{ PARTITION }}
-
-       launcher:
-           type: SrunLauncher
-
-       account: {{ ACCOUNT_ID }}
-
-   idle_heartbeats_soft: 2
-   idle_heartbeats_hard: 4
-
-After starting the MEP, this template will use the specified ``PARTITION`` and
-``ACCOUNT_ID`` variables to create the final configuration (i.e., ``config.yaml``) to
-start the UEP.  On the SDK-side, this uses the ``user_endpoint_config`` on the Executor:
-
-.. code-block:: python
-   :emphasize-lines: 2,5,8,9
-
-   mep_id = "<UUID_FOR_MY_SECOND_ENDPOINT>"
-   user_endpoint_config = {"ACCOUNT_ID": "ABCD-1234", "PARTITION": "debug"}
-   with Executor(
-       endpoint_id=mep_id,
-       user_endpoint_config=user_endpoint_config
-   ) as ex:
-       print(ex.submit(some_task, 1).result())
-       user_endpoint_config["ACCOUNT_ID"] = "WXYZ-7890"
-       ex.user_endpoint_config = user_endpoint_config
-       print(ex.submit(some_task, 2).result())
-
-Both ``.submit()`` calls will send tasks to the *same* endpoint, the one specified by
-``mep_id``, but the MEP will spawn two different UEPs, one for each unique
-``user_endpoint_config`` sent to the web services.
-
-.. tip::
-
-   Refer to :doc:`templates` for more information.
-
-.. _pardon-the-mess:
-
-.. note::
-
-   Pardon "the mess" while we build the product, but "multi‑user" is perhaps a misnomer
-   stemming from the initial development thrust of this feature.  For now, the name and
-   flag has stuck, but we will very likely evolve the implementation and thinking here
-   to be a more general concept.
+#. The web services detect the check-in, complete the original SDK request by accepting the task,
+   then send the task to the now-running user endpoint process.
 
 
 .. |nbsp| unicode:: 0xA0
    :trim:
 
+.. |rarr| unicode:: 0x2192
+   :trim:
+
 .. |Providers| replace:: ``Providers``
 .. _Providers: https://parsl.readthedocs.io/en/stable/reference.html#providers
-
+.. _LocalProvider: https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.LocalProvider.html
+.. |GlobusComputeEngine| replace:: ``GlobusComputeEngine``
+.. _GlobusComputeEngine: ../reference/engine.html#globus_compute_endpoint.engines.GlobusComputeEngine
+.. |HighThroughputExecutor| replace:: ``HighThroughputExecutor``
+.. _HighThroughputExecutor: https://parsl.readthedocs.io/en/latest/stubs/parsl.executors.HighThroughputExecutor.html
+.. |ManagerEndpointConfig| replace:: :class:`ManagerEndpointConfig <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
+.. |UserRuntime| replace:: :class:`UserRuntime <globus_compute_sdk.sdk.batch.UserRuntime>`
+.. _Web UI: https://app.globus.org/compute
+.. _Jinja template: https://jinja.palletsprojects.com/en/stable/
+.. _Globus Auth: https://www.globus.org/platform/services/auth
+.. _Globus Groups: https://www.globus.org/platform/services/groups
+.. _Globus authentication policy: https://docs.globus.org/api/auth/developer-guide/#authentication-policies
+.. _Authentication Policies documentation: https://docs.globus.org/api/auth/developer-guide/#authentication_policy_fields
+.. _Globus subscription: https://www.globus.org/subscriptions
+.. _conda: https://docs.conda.io/en/latest/
+.. _AMQP: https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol
+.. |getpwnam(3)| replace:: ``getpwnam(3)``
+.. _getpwnam(3): https://www.man7.org/linux/man-pages/man3/getpwnam.3.html
+.. |fork(2)| replace:: ``fork(2)``
+.. _fork(2): https://www.man7.org/linux/man-pages/man2/fork.2.html
 .. _deserializing untrusted data via pickle,: https://github.com/swisskyrepo/PayloadsAllTheThings/blob/4.1/Insecure%20Deserialization/Python.md
+.. _POSTs a REST request: https://compute.api.globus.org/redoc#tag/Endpoints/operation/submit_batch_v3_endpoints__endpoint_uuid__submit_post

--- a/docs/endpoints/index.rst
+++ b/docs/endpoints/index.rst
@@ -1,13 +1,29 @@
 Globus Compute Endpoints
-========================
+************************
+
+In the mental model of Globus Compute, Endpoints are the remote instance:
+
+- Globus Compute SDK |nbsp| --- |nbsp| i.e., the script a researcher writes to submit
+  functions to ...
+
+- Globus Compute Web Services |nbsp| --- |nbsp| the Globus‑provided cloud‑services that
+  authenticate and ferry functions and tasks
+
+- **Globus Compute Endpoint** |nbsp| --- |nbsp| a site-specific process, typically on a
+  cluster head node, that manages user‑accessible compute resources to run tasks
+  submitted by the SDK
 
 .. toctree::
    :maxdepth: 1
 
-   Compute Endpoints <endpoints>
+   installation
+   endpoints
    multi_user
    security_posture
-   installation
    templates
    endpoint_examples
    config_reference
+
+
+.. |nbsp| unicode:: 0xA0
+   :trim:

--- a/docs/endpoints/installation.rst
+++ b/docs/endpoints/installation.rst
@@ -1,5 +1,5 @@
-Installing the Compute Endpoint
-*******************************
+Installing the Endpoint
+***********************
 
 The Globus Compute Endpoint is available as a PyPI package or as a native system
 package (DEB and RPM).

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -1,12 +1,11 @@
-Multi-User Compute Endpoints
-****************************
+Multi-User Endpoints
+********************
 
-.. attention::
+This guide builds on the :doc:`endpoints` to cover the additional features and
+configuration steps needed to set up multi-user endpoints.
 
-  This chapter describes Multi-user Compute Endpoints (MEP) for site administrators.
-  For those not running MEPs with ``root`` privileges, please instead consult the
-  :ref:`endpoints_templating_configuration` section in the previous chapter.
-
+Multi-user endpoints use the same installation process as regular endpoints. See
+:doc:`installation` for more information.
 
 .. tip::
 
@@ -14,51 +13,17 @@ Multi-User Compute Endpoints
    below.
 
 
-Multi-user Compute Endpoints (MEP) enable administrators to securely offer compute
-resources to users without mandating the typical shell access (i.e., ssh).  The basic
-thrust is that the administrator of a MEP creates a configuration template that is
-populated by user data and passed to a user endpoint process, or UEP.  When a user
-sends a task to the MEP, it will start a UEP on their behalf as a local POSIX user
-account mapped from their Globus Auth identity.  In this manner, administrators may
-preset endpoint configuration options (e.g., Torque, PBS, Slurm) and offer
-user‑configurable items (e.g., account id, problem‑specific number of blocks), while at
-the same time lowering the barrier to use of the resource.
+Overview
+========
 
-.. note::
+Multi-user endpoints enable administrators to securely offer compute resources
+to users without requiring shell access (e.g., SSH). These endpoints support all
+features described in the :doc:`endpoints` page, plus the ability to map Globus Auth
+identities of function-submitting users to local POSIX user accounts, then launch
+user endpoint processes as those mapped users.
 
-   The only difference between a "normal" endpoint process and a UEP is a semantic one
-   for discussion so as to differentiate the two different starting contexts.  An
-   endpoint is started manually by a human, while a UEP will always have a
-   parent MEP process.
-
-
-User Endpoint Startup Overview
-==============================
-
-UEPs are initiated by tasks sent to the MEP id.  In REST-speak, that means that one or
-more tasks were |POSTed to the /v3/endpoints/<mep_uuid>/submit|_ Globus Compute
-route.  When the web service determines that the ``endpoint_uuid`` is for a MEP, it
-generates a UEP identifier specific to the tuple of the ``endpoint_uuid``, the Globus
-Auth identity of the user making the request, the endpoint configuration in the request,
-and various user runtime information (e.g., ``generate_identifier_from(site_id, user_id,
-conf, user_runtime)``) |nbsp| --- |nbsp| this identifier is simultaneously stable and
-unique.  After verifying that the generated ID is either new, or already belongs to the
-user, the web service then sends a start-UEP message to the MEP (via `AMQP
-<https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol>`_), asking it to start
-an endpoint on behalf of the Globus Auth identity making the REST request identified by
-the generated UEP id.
-
-At the other end of the AMQP queue, the MEP receives the start-UEP message, validates
-the basic structure, then attempts to map the Globus Auth identity.  If the mapping is
-successful and the POSIX username exists, the MEP will proceed to ``fork()`` a new
-process.  The child process will immediately and irreversibly become the user, and then
-``exec()`` a new ``globus-compute-endpoint`` instance.
-
-The new child process |nbsp| --- |nbsp| the UEP |nbsp| --- |nbsp| will receive AMQP
-connection credentials from the MEP (which received them as part of the start-UEP
-request), and immediately let the web service know it is ready to receive tasks.
-
-(For those who prefer lists over prose, please see :ref:`tracing-a-task-to-mep`.)
+For a detailed look at how a task makes its way to a user endpoint process, see
+:ref:`tracing-a-task`.
 
 
 Key Benefits
@@ -67,26 +32,25 @@ Key Benefits
 For Administrators
 ------------------
 
-This biggest benefit of a MEP setup is a lowering of the barrier for legitimate users of
-a site.  To date, knowledge of the command line has been critical to most users of High
-Performance Computing (HPC) systems, though only as a necessity of infrastructure rather
-than a legitimate scientific purpose.  A MEP allows a user to ignore many of the
-important-but-not-really details of plumbing, like logging in through SSH, restarting
-user-only daemons, or, in the case of Globus Compute, fine-tuning scheduler options by
-managing multiple endpoint configurations.  The only thing they need to do is run their
-scripts locally on their own workstation, and the rest "just works."
+The biggest benefit of a multi-user endpoint setup is a lowering of the barrier for
+legitimate users of a site.  To date, knowledge of the command line has been critical
+to most users of High Performance Computing (HPC) systems, though only as a necessity
+of infrastructure rather than a legitimate scientific purpose.  A multi-user endpoint
+allows a user to ignore many of the important-but-not-really details of plumbing, like
+logging in through SSH, restarting user-only daemons.  The only thing they need to do
+is run their scripts locally on their own workstation, and the rest "just works."
 
 Another boon for administrators is the ability to fine-tune and pre-configure what
-resources UEPs may utilize.  For example, many users struggle to discover which
+resources users may utilize.  For example, many users struggle to discover which
 interface is routed to a cluster's internal network; the administrator can preset that,
 completely bypassing the question.  Using `ALCF's Polaris
 <https://www.alcf.anl.gov/polaris>`_ as an example, the administrator could use the
 following user configuration template (``user_config_template.yaml.j2``) to place all
-jobs sent to this MEP on the ``debug-scaling`` queue, and pre-select the obvious
-defaults (`per the documentation <https://docs.alcf.anl.gov/polaris/running-jobs/>`_):
+jobs sent to this multi-user endpoint on the ``debug-scaling`` queue, and pre-select the
+obvious defaults (`per the documentation <https://docs.alcf.anl.gov/polaris/running-jobs/>`_):
 
 .. code-block:: yaml+jinja
-   :caption: ``/root/.globus_compute/mep_debug_scaling/user_config_template.yaml.j2``
+   :caption: ``/root/.globus_compute/debug_scaling_ep/user_config_template.yaml.j2``
 
    display_name: Polaris at ALCF - debug-scaling queue
    engine:
@@ -124,23 +88,16 @@ defaults (`per the documentation <https://docs.alcf.anl.gov/polaris/running-jobs
 
 The user must specify the ``ACCOUNT_ID``, and could optionally specify the
 ``WORKER_INIT_COMMAND`` and ``NODES_PER_BLOCK`` variables.  If the user's jobs finish
-and no more work comes in after ``max_idletime`` seconds (30s), the UEP will scale down
-and consume no more wall time.
-
-Another benefit is a cleaner process table on the login nodes.  Rather than having user
-endpoints sit idle on a login-node for days after a run has completed (perhaps until the
-next machine reboot), a MEP setup automatically shuts down idle UEPs (as defined in
-``user_config_template.yaml.j2``).  When the UEP has had no movement for 48h (by
-default; see ``idle_heartbeat_hard``), or has no outstanding work for 5m (by default;
-see ``idle_heartbeats_soft``), it will shut itself down.
+and no more work comes in after ``max_idletime`` seconds (30s), the user endpoint process
+will scale down and consume no more wall time.
 
 For Users
 ---------
 
-Under the MEP paradigm, users largely benefit from not having to be quite so aware of an
-endpoint and its configuration.  As the administrator will have taken care of most of
-the smaller details (c.f., installation, internal interfaces, queue policies), the user
-is able to write a consuming script, knowing only the endpoint id and their system
+Under the multi-user paradigm, users largely benefit from not having to be quite so aware
+of an endpoint and its configuration.  As the administrator will have taken care of most
+of the smaller details (c.f., installation, internal interfaces, queue policies), the user
+is able to write a consuming script, knowing only the endpoint ID and their system
 accounting username:
 
 .. code-block:: python
@@ -166,56 +123,56 @@ accounting username:
 
 It is a boon for the researcher to see the relevant configuration variables immediately
 adjacent to the code, as opposed to hidden in the endpoint configuration and behind an
-opaque endpoint id.  An MEP removes almost half of the infrastructure plumbing that the
-user must manage |nbsp| --- |nbsp| many users will barely even need to open their own
-terminal, much less an SSH terminal on a login node.
+opaque endpoint ID.  A multi-user endpoint removes almost half of the infrastructure
+plumbing that the user must manage |nbsp| --- |nbsp| many users will barely even need
+to open their own terminal, much less an SSH terminal on a login node.
 
 
 .. _multi-user-configuration:
 
-Configuration
-=============
+Configuring a Multi-User Endpoint
+=================================
 
-Creating a MEP starts with the ``--multi-user`` :ref:`command line flag
-<create-templatable-endpoint>` to the ``configure`` subcommand, which will generate the
-below five configuration files:
+The ``configure`` subcommand must be run as a privileged user (e.g., root) to properly
+generate the :ref:`multi-user-config-yaml` and :ref:`example-idmap-config` files, along
+with other default files in ``$HOME/.globus_compute/``:
 
 .. code-block:: console
 
-   # globus-compute-endpoint configure --multi-user mep_debug
-   Created multi-user profile for endpoint named <mep_debug>
+   # globus-compute-endpoint configure my_mu_ep
+   Created multi-user profile for endpoint named <my_mu_ep>
 
-       Configuration file: /root/.globus_compute/mep_debug/config.yaml
+       Configuration file: /root/.globus_compute/my_mu_ep/config.yaml
 
-       Example identity mapping configuration: /root/.globus_compute/mep_debug/example_identity_mapping_config.json
+       Example identity mapping configuration: /root/.globus_compute/my_mu_ep/example_identity_mapping_config.json
 
-       User endpoint configuration template: /root/.globus_compute/mep_debug/user_config_template.yaml.j2
-       User endpoint configuration schema: /root/.globus_compute/mep_debug/user_config_schema.json
-       User endpoint environment variables: /root/.globus_compute/mep_debug/user_environment.yaml
+       User endpoint configuration template: /root/.globus_compute/my_mu_ep/user_config_template.yaml.j2
+       User endpoint configuration schema: /root/.globus_compute/my_mu_ep/user_config_schema.json
+       User endpoint environment variables: /root/.globus_compute/my_mu_ep/user_environment.yaml
 
    Use the `start` subcommand to run it:
 
-   globus-compute-endpoint start mep_debug
+   globus-compute-endpoint start my_mu_ep
 
+
+.. _multi-user-config-yaml:
 
 ``config.yaml``
 ---------------
 
-The default MEP ``config.yaml`` file is:
+The default multi-user endpoint ``config.yaml`` file contains one additional field to
+specify the identity mapping file path:
 
 .. code-block:: yaml
    :caption: The default multi-user ``config.yaml`` configuration
+   :emphasize-lines: 3
 
    amqp_port: 443
    display_name: null
-   identity_mapping_config_path: /root/.globus_compute/mep_debug/example_identity_mapping_config.json
-   multi_user: true
+   identity_mapping_config_path: /root/.globus_compute/my_mu_ep/example_identity_mapping_config.json
 
-The ``multi_user`` flag is required, but the ``identity_mapping_config_path`` is only
-required if the MEP process will have privileges to change users (e.g., if ``$USER =
-root``).  ``display_name`` is optional, but if set, determines how the MEP will appear
-in the `Web UI`_.  (And as the MEP does *not execute tasks*, :ref:`there is no engine
-block <cea_configuration>`.)
+Please refer to :ref:`endpoint-manager-config` for details on each field.
+
 
 .. _example-idmap-config:
 
@@ -224,8 +181,8 @@ block <cea_configuration>`.)
 
 This is a valid-syntax-but-will-never-successfully-map example identity mapping
 configuration file.  It is a JSON list of identity mapping configurations that will be
-tried in order.  By implementation within the MEP code base, the first configuration to
-return a match "wins."  In this example, the first configuration is a call out to an
+tried in order.  By implementation within the endpoint code base, the first configuration
+to return a match "wins."  In this example, the first configuration is a call out to an
 external tool, as specified by the |idmap_external|_ DATA_TYPE.  The command is a list
 of arguments, with the first element as the actual executable.  In this case, the flags
 are strictly illustrative, as ``/bin/false`` always returns with a non-zero exit code
@@ -243,7 +200,7 @@ regex before searching, so the actual regular expression used would be
 output (i.e., ``{0}``).  If the ``username`` field contained ``mickey97@example.com``,
 then this configuration would return ``mickey97``, and the MEP would then use
 |getpwnam(3)|_ to look up ``mickey97``.  But if the username field(s) did not end with
-``@example.com``, then it would not match and the start-UEP request would fail.
+``@example.com``, then it would not match and the start request would fail.
 
 .. code-block:: json
    :caption: The default example identity mapping configuration; technically functional
@@ -281,18 +238,18 @@ implemented strategies to determine a mapping:
   external process, passing the input identity documents via ``stdin``, and reading the
   response from ``stdout``.
 
-.. note::
+.. tip::
 
    While developing this file, administrators may appreciate using the
    ``globus-idm-validator`` tool.  This script is installed as part of the
    |globus-identity-mapping|_ dependency.
 
-The MEP process watches this file for changes.  If an administrator needs to make a
-live change, simply update the content of the identity mapping file specified by the
-``config.yaml`` configuration.  The MEP server will note the change, and atomically
-apply it: if the new identity mapping configuration is invalid, the previously loaded
-configuration will remain in place.  In both cases (valid or invalid), the MEP will emit
-a message to the log.
+The manager endpoint process watches this file for changes.  If an administrator needs
+to make a live change, simply update the content of the identity mapping file specified
+by the ``config.yaml`` configuration.  The manager endpoint process will note the change,
+and atomically apply it: if the new identity mapping configuration is invalid, the
+previously loaded configuration will remain in place.  In both cases (valid or invalid),
+the endpoint will emit a message to the log.
 
 ``expression_identity_mapping#1.0.0``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -389,7 +346,7 @@ logic.  The script will be passed a ``identity_mapping_input#1.0.0`` JSON docume
 
 The executable must identify the successfully mapped identity in the output document by
 the ``id`` field.  For example, if an LDAP lookup of ``alicia@legal.your_institution.com``
-were to result in ``Alicia`` for this MEP host, then the output document might read:
+were to result in ``Alicia`` for this endpoint host, then the output document might read:
 
 .. code-block:: json
    :caption: Hypothetical ``identity_mapping_output#1.0.0`` document from an external
@@ -421,229 +378,42 @@ the Globus Connect Server's `Identity Mapping documentation`_.
 .. |idmap_output| replace:: ``identity_mapping_output#1.0.0``
 .. _idmap_output: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/#output_document
 
-.. _user-config-template-yaml-j2:
 
-``user_config_template.yaml.j2``
---------------------------------
+Starting the Multi-User Endpoint
+================================
 
-This file is the template that will be interpolated with user-specific variables for
-successful start-UEP requests.  More than simple interpolation, the MEP treats this file
-as a `Jinja template`_, so there is a good bit of flexibility available to the motivated
-administrator.
-
-Please refer to :doc:`templates` for more information.
-
-.. _user-config-schema-json:
-
-``user_config_schema.json``
----------------------------
-
-If this file exists, then the MEP will validate the user's input against the JSON
-schema.
-
-Please refer to the :ref:`template-variable-validation` section of :doc:`templates`
-for more information.
-
-``user_environment.yaml``
--------------------------
-
-Use this file to specify site-specific environment variables to export to the UEP
-process.  Though this is a YAML file, it is interpreted internally as a simple
-top-level-only set of key-value pairs.  Nesting of data structures will probably not
-behave as expected.  Example:
-
-.. code-block:: yaml
-
-   SITE_SPECIFIC_VAR: --additional_flag_for_frobnicator
-
-That will be injected into the UEP process as an environment variable.
-
-
-Running the MEP
-===============
-
-The MEP starts in the exact same way as a regular endpoint |nbsp| --- |nbsp| with the
-``start`` subcommand.  However, the MEP has no notion of the ``detach_endpoint``
-configuration item.  Once started, the MEP stays attached to the console, with a timer
-that updates every second:
-
-.. code-block:: text
-
-    globus-compute-endpoint start debug_queue
-        >>> Multi-User Endpoint ID: [endpoint_uuid] <<<
-    ----> Fri Apr 19 11:56:27 2024
-
-The timer is only displayed if the process is connected to the terminal, and is intended
-as a hint to the administrator that the MEP process is running, even if no start UEP
-requests are yet incoming.
-
-And |hellip| that's it.  The Multi-user endpoint is running, waiting for start UEP
-requests to come in.  (But see :ref:`mep-as-a-service` for automatic starting.)
-
-To stop the MEP, type ``Ctrl+\`` (SIGQUIT) or ``Ctrl+C`` (SIGINT).  Alternatively, the
-process also responds to SIGTERM.
-
-Checking the Logs
------------------
-
-If actively debugging or iterating, the two command line arguments ``--log-to-console``
-and ``--debug`` may be helpful as they increase the verbosity and color of the text to
-the console.  Meanwhile, the log is always available at
-``.globus_compute/<mt_endpoint_name>/endpoint.log``, and is the first place to look
-upon an unexpected behavior.  In a healthy MEP setup, there will be lots of lines about
-processes starting and stopping:
-
-.. code-block:: text
-
-   [...] Creating new user endpoint (pid: 3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint start uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a --die-with-parent]
-   [...] Command process successfully forked for 'harper' (Globus effective identity: b072d17b-08fd-4ada-8949-1fddca189b5e).
-   [...] Command stopped normally (3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint start uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a --die-with-parent]
-
-
-Advanced Environment Customization
-==================================
-
-There are some instances where static configuration is not enough.  For example, setting
-a user-specific environment variable or running arbitrary scripts prior to handing
-control over to the UEP.  For these cases, observe that
-``/usr/sbin/globus-compute-endpoint`` is actually a shell script wrapper:
-
-.. code-block:: shell
-
-   #!/bin/sh
-
-   VENV_DIR="/opt/globus-compute-agent/venv-py39"
-
-   if type deactivate 1> /dev/null 2> /dev/null; then
-   deactivate
-   fi
-
-   . "$VENV_DIR"/bin/activate
-
-   exec "$VENV_DIR"/bin/globus-compute-endpoint "$@"
-
-While we don't suggest modifying this wrapper (for ease of future maintenance), one
-might inject another wrapper into the process, by modifying the process PATH and writing
-a custom ``globus-compute-endpoint`` wrapper:
-
-.. code-block:: yaml
-   :caption: ``user_environment.yaml``
-
-   PATH: /usr/local/admin_scripts/
-
-.. code-block:: sh
-   :caption: ``/usr/local/admin_scripts/globus-compute-endpoint``
-
-   #!/bin/sh
-
-   /some/other/executable
-   . import/some/vars/script
-
-   # remove the `/usr/local/admin_scripts` entry from the PATH
-   export PATH=/usr/local/bin:/usr/bin:/REST/OF/PATH
-
-   exec /usr/sbin/globus-compute-endpoint "$@"
-
-(The use of ``exec`` is not critical, but keeps the process tree tidy.)
-
-
-.. _configure-multiple-python-versions:
-
-Configuring to Accept Multiple Python Versions
-==============================================
-
-Due to issues with cross-version serialization, we recommend :ref:`keeping the Python
-version running on Endpoint workers in sync <avoiding-serde-errors>` with the version
-that functions are first submitted from. However, this can be limiting for
-workflows where admins have little control over their users' SDK environments, such as
-locally run Jupyter notebooks.  This can sometimes be alleviated with :ref:`an alternate
-serialization strategy <specifying-serde-strategy>` (e.g. :class:`~globus_compute_sdk.serialize.JSONData`,
-which doesn't rely on bytecode), but not all serialization strategies work in all
-environments.  A more robust workaround is to use the ``user_runtime`` config template
-variable to detect what Python version was used to submit the task.
-
-Suppose an admin wants to accept the four most recent Python versions (3.10-3.13).
-Using `conda`_, they can create an environment for each Python version they want to
-support, and launch the UEP's workers with the correct environment depending on the
-user's Python version.  A config template for that might look like:
-
-.. code-block:: yaml+jinja
-
-   endpoint_setup: {{ endpoint_setup|default() }}
-   engine:
-     type: GlobusComputeEngine
-     provider:
-        type: LocalProvider
-     {% if '3.13' in user_runtime.python_version %}
-        worker_init: conda activate py313
-     {% elif '3.12' in user_runtime.python_version %}
-        worker_init: conda activate py312
-     {% elif '3.11' in user_runtime.python_version %}
-        worker_init: conda activate py311
-     {% else %}
-        worker_init: conda activate py310
-     {% endif %}
-
-This of course requires that there are conda environments named ``py313, ``py312``,
-``py311``, and ``py310`` with the appropriate Python versions and
-``globus-compute-endpoint`` installed.
-
-For more information on what an MEP knows about the user's runtime environment, see
-|UserRuntime|.
-
-
-Debugging User Endpoints
-========================
-
-During implementation, most users are accustomed to using the ``--debug`` flag (or
-equivalent) to get more information.  (And usually, caveat emptor, as the amount of
-information can be overwhelming.)  The ``globus-compute-endpoint`` executable similarly
-implements that flag.  However, if applied to the MEP, that flag will not carry-over to
-the child UEP instances.  In particular, the command executed by the MEP is:
-
-.. code-block:: python
-   :caption: arguments to ``os.execvpe``
-
-   proc_args = ["globus-compute-endpoint", "start", ep_name, "--die-with-parent"]
-
-Note the lack of the ``--debug`` flag; by default UEPs will not emit DEBUG level logs.
-To place UEPs into debug mode, use the ``debug`` top-level configuration directive:
-
-.. code-block:: yaml
-   :caption: ``user_config_template.yaml``
-   :emphasize-lines: 1
-
-   debug: true
-   display_name: Debugging template
-   idle_heartbeats_soft: 10
-   idle_heartbeats_hard: 5760
-   engine:
-      ...
-
-Note that this is *also* how to get the UEP to emit its configuration to the log, which
-may be helpful in determining which set of logs are associated with which configuration
-or just generally while implementing and debugging.  The configuration is written to the
-logs before the UEP boots; look for the following sentinel lines::
-
-   [TIMESTAMP] DEBUG ... Begin Compute endpoint configuration (5 lines):
-      ...
-   End Compute endpoint configuration
-
-To this end, the authors have found the following command line helpful for pulling out
-the configuration from the logs:
+A multi-user endpoint requires a privileged local user account (e.g., root)
+to start, enabling the manager endpoint process to perform identity mapping
+and drop privileges to mapped user accounts. Apart from this initial setup
+requirement, multi-user endpoints operate identically to regular endpoints
+for starting and stopping:
 
 .. code-block:: console
 
-   $ sed -n "/Begin Compute/,/End Compute/p" ~/.globus_compute/uep.[...]/endpoint.log | less
+   # globus-compute-endpoint start my_mu_ep
+         >>> Endpoint ID: [endpoint_uuid] <<<
+   ----> Wed Aug  6 20:03:02 2025
+
+Each user endpoint process runs as the mapped local user, ensuring secure
+isolation of execution environments:
+
+.. code-block:: text
+   :caption: Multi-user endpoint process hierarchy
+
+   Manager Endpoint Process (root)
+   ├── User Endpoint Process (alice, UID: 1001)
+   ├── User Endpoint Process (bob, UID: 1002)
+   └── User Endpoint Process (eve, UID: 1003)
+
 
 .. _mep-as-a-service:
 
-Installing the MEP as a Service
-===============================
+Installing as a Service
+=======================
 
-Installing the MEP as a service is the same :ref:`procedure as with a regular endpoint
-<enable_on_boot>`: use the ``enable-on-boot``.  This will dynamically create and
-install a systemd unit file.
+Installing the multi-user endpoint as a service is the same :ref:`procedure as with a
+regular endpoint <enable_on_boot>`: use the ``enable-on-boot``.  This will dynamically
+create and install a systemd unit file.
 
 
 .. _pam:
@@ -665,48 +435,46 @@ As a brief intro to PAM, the architecture is designed with four phases:
 - session management
 - password management
 
-The MEP implements *account* and *session management*.  If enabled, then the child
-process will create a PAM session, check the account (|pam_acct_mgmt(3)|_), and then
-open a session (|pam_open_session(3)|_).  If these two steps succeed, then the MEP will
-continue to drop privileges and become the UEP.  But in these two steps is where the
+The multi-user endpoint implements *account* and *session management*.  If enabled, then
+the child process will create a PAM session, check the account (|pam_acct_mgmt(3)|_), and
+then open a session (|pam_open_session(3)|_).  If these two steps succeed, then the manager
+endpoint process will continue to drop privileges.  But in these two steps is where the
 administrator can implement custom configuration.
 
-PAM is configured in two parts.  For the MEP, use the ``pam`` field:
+PAM is configured in two parts.  For the ``config.yaml`` file, use the ``pam`` field:
 
 .. code-block:: yaml
    :caption: ``config.yaml`` to show PAM
-   :emphasize-lines: 3,4
+   :emphasize-lines: 2,3
 
-   multi_user: true
    identity_mapping_config_path: .../some/idmap.json
    pam:
      enable: true
 
 This configuration will choose the default PAM service name,
 ``globus-compute-endpoint`` (see |PamConfiguration|).  The service name is the name of
-the PAM configuration file in ``/etc/pam.d/``.  Use ``service_name`` to tell the MEP
+the PAM configuration file in ``/etc/pam.d/``.  Use ``service_name`` to tell the endpoint
 to authorize users against a different PAM configuration:
 
 .. code-block:: yaml
    :caption: ``config.yaml`` with a custom PAM service name
-   :emphasize-lines: 7
+   :emphasize-lines: 6
 
-   multi_user: true
    identity_mapping_config_path: .../some/idmap.json
    pam:
      enable: true
 
-     # the PAM routines will look for `/etc/pam.d/gce-mep123-specific-requirements`
-     service_name: gce-mep123-specific-requirements
+     # the PAM routines will look for `/etc/pam.d/gce-ep123-specific-requirements`
+     service_name: gce-ep123-specific-requirements
 
 For clarity, note that the service name is simply passed to |pam_start(3)|_, to tell
 PAM which service configuration to apply.
 
 .. important::
 
-  If PAM is not enabled, then before starting user endpoints, the child process drops
-  all capabilities and sets the no-new-privileges flag with the kernel.  (See
-  |prctl(2)|_ and reference ``PR_SET_NO_NEW_PRIVS``).  In particular, this will
+  If PAM is not enabled, then before starting user endpoint processes, the child
+  process drops all capabilities and sets the no-new-privileges flag with the kernel.
+  (See |prctl(2)|_ and reference ``PR_SET_NO_NEW_PRIVS``).  In particular, this will
   preclude use of SETUID executables, which can break some schedulers.  If your site
   requires use of SETUID executables, then PAM must be enabled.
 
@@ -720,8 +488,8 @@ do.  For example, if the administrator were to implement a configuration of:
    account   requisite     pam_shells.so
    session   required      pam_limits.so
 
-then, per |pam_shells(8)|_, any UEP for a user whose shell is not listed in
-``/etc/shells`` will not start and the logs will have a line like:
+then, per |pam_shells(8)|_, any user endpoint process for a user whose shell is not
+listed in ``/etc/shells`` will not start and the logs will have a line like:
 
 .. code-block:: text
 
@@ -739,7 +507,7 @@ Similarly, for users who are administratively allowed (i.e., have a valid shell)
 .. hint::
 
    The Globus Compute Endpoint software implements the account management and session
-   phases of PAM.  As authentication is enacted via Globua Auth and
+   phases of PAM.  As authentication is enacted via Globus Auth and
    :ref:`Identity Mapping <identity-mapping>`, it does not use PAM's authentication
    (|pam_authenticate(3)|_) phase, nor does it attempt to manage the user's password.
    Functionally, this means that only PAM configuration lines that begin with
@@ -748,8 +516,8 @@ Similarly, for users who are administratively allowed (i.e., have a valid shell)
 Look to PAM for a number of tasks (which we tease here, but are similarly out of scope
 of this documentation):
 
-- Setting UEP process capabilities (|pam_cap(8)|_)
-- Setting UEP process limits (|pam_limits(8)|_)
+- Setting user endpoint process capabilities (|pam_cap(8)|_)
+- Setting user endpoint process limits (|pam_limits(8)|_)
 - Setting environment variables (|pam_env(8)|_)
 - Enforcing ``/var/run/nologin`` (|pam_nologin(8)|_)
 - Updating ``/var/log/lastlog`` (|pam_lastlog(8)|_)
@@ -790,484 +558,15 @@ custom module!  But sadly, that is also out of scope of this documentation; plea
 .. |prctl(2)| replace:: ``prctl(2)``
 .. _prctl(2): https://www.man7.org/linux/man-pages/man2/prctl.2.html
 
-.. _auth-policies:
 
 Authentication Policies
 =======================
 
-Administrators can limit access to a MEP via a `Globus authentication policy`_, which
-verifies that the user has appropriate identities linked to their Globus account and
-that the required identities have recent authentications. Authentication policies are
-stored within the Globus Auth service and can be shared among multiple MEPs.
-
-Please refer to the `Authentication Policies documentation`_ for a description of each
-policy field and other useful information.
-
-.. note::
-   The ``high_assurance`` and ``authentication_assurance_timeout`` policies are only
-   supported on MEPs with HA subscriptions.
-
-
-Create a New Authentication Policy
-----------------------------------
-
-Administrators can create new authentication policies via the `Globus Auth API
-<https://docs.globus.org/api/auth/reference/#create_policy>`_, or via the following
-``configure`` subcommand options:
-
-.. note::
-  The resulting policy will be automatically applied to the MEP's ``config.yaml``.
-
-``--auth-policy-project-id``
-  The id of a Globus Auth project that this policy will belong to. If not provided,
-  the user will be prompted to create one.
-
-``--auth-policy-display-name``
-  A user friendly name for the policy.
-
-``--allowed-domains``
-  A comma separated list of domains that can satisfy the policy. These may include
-  wildcards.  For example, ``*.edu, globus.org``.  For more details, see
-  ``domain_constraints_include`` in the `Authentication Policies documentation`_.
-
-``--excluded-domains``
-  A comma separated list of domains that will fail the policy.  These may include
-  wildcards.  For example, ``*.edu, globus.org``.  For more details, see
-  ``domain_constraints_exclude`` in the `Authentication Policies documentation`_.
-
-``--auth-timeout``
-  The maximum amount of time in seconds that a previous authentication must have
-  occurred to satisfy the policy.  Setting this will also set ``high_assurance`` to
-  ``true``.
-
-  .. attention::
-
-     For performance reasons, the web-service caches lookups for 60s.  Pragmatically,
-     this means that smallest timeout that Compute supports is 1 minute, even though it
-     is possible to set required authorizations for high assurance policies to smaller
-     time intervals.
-
-
-Apply an Existing Authentication Policy
----------------------------------------
-
-Administrators can apply an authentication policy directly in the MEP's ``config.yaml``:
-
-.. code-block:: yaml
-
-   multi_user: true
-   authentication_policy: 2340174a-1a0e-46d8-a958-7c3ddf2c834a
-
-... or via the ``--auth-policy`` option with the ``configure`` subcommand, which will
-make the necessary changes to ``config.yaml``:
-
-.. code-block:: bash
-
-   $ globus-compute-endpoint configure my-mep --multi-user --auth-policy 2340174a-1a0e-46d8-a958-7c3ddf2c834a
-
-
-.. _high-assurance-mep:
-
-High-Assurance
---------------
-
-Globus Compute endpoints may be designated as High-Assurance (HA) to meet stricter
-security, compliance, and operational requirements.  HA endpoints differ from non-HA
-endpoints in a few key ways:
-
-- in addition to running regular functions, HA endpoints may also run HA functions
-  (described below).
-
-- HA endpoints enable audit-logging, whereby the states of all tasks (whether HA or
-  not) are logged to a file.
-
-Consider deploying a High-Assurance endpoint where there is need for stronger identity
-verification and authentication controls, and for workloads that require elevated
-assurance levels, such as sensitive research or regulated data processing.
-
-.. note::
-
-   Once an endpoint has registered, the High-Assurance setting may not be toggled.
-   An endpoint may not become HA at a later date if it is not initially registered as
-   such.  The reverse ("downgrading" from HA) is similarly disallowed.
-
-
-Configuration
-^^^^^^^^^^^^^
-
-High-Assurance functionality requires a HA-enabled `Globus subscription`_, to be
-explicitly marked as HA, and to be associated with a HA `Auth policy`_.  In
-configuration form, that translates to ``subscription_id``, ``high_assurance``, and
-``authentication_policy``:
-
-.. code-block:: yaml
-   :caption: Example ``config.yaml`` of a HA endpoint
-
-   ...
-   subscription_id: 2c94f030-d346-11e9-939f-02ff96a5aa76
-   high_assurance: true
-   authentication_policy: 8e6529c8-a7ce-4310-b895-244e1b33702a
-   ...
-
-In this example, the ``subscription_id`` is associated with a HA-enabled subscription,
-and the ``authentication_policy`` has similarly been setup as HA.  Both of these values
-may be found in the Globus App `Web UI`_.  Find Subscriptions available to you via
-**Settings** |rarr| **Subscriptions**.
-
-Policies are associated with projects, so first navigate to **Settings**
-|rarr| **Developers** and select or create a project.  Within a project, navigate to
-the **Policies** tab.  If creating a policy, be sure to check the "High Assurance"
-checkbox.
-
-Alternatively, a new HA policy may be created at configuration time with an
-overly-specified command line:
-
-.. code-block:: console
-   :linenos:
-
-   # globus-compute-endpoint configure \
-       --multi-user \
-       --display-name "Example High-Assurance Compute Endpoint" \
-       --high-assurance \
-       --subscription-id 00000000-1111-...ffff \
-       --auth-policy-project-id 11111111-2222-...5555 \
-       --allowed-domains "example.edu,*.example.edu" \
-       --auth-timeout 1800 \
-      example_ha_compute_endpoint
-
-This example command line will
-
-- (Line 4) *create* a new HA (``--high-assurance``) policy ...
-- (Line 5) associated with the ``0000...`` subscription ...
-- (Line 6) under the ``1111...`` project ...
-- (Line 7) that will require users be from the ``example.edu`` domain or any subdomain ...
-- (Line 8) and that they authenticate every ``1800`` seconds.
-
-This example does not show all options; use ``configure --help`` to see what is
-available:
-
-.. code-block:: console
-
-   # globus-compute-endpoint configure --help
-   Usage: globus-compute-endpoint configure [OPT...
-
-
-High-Assurance Functions
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-A High-Assurance function is one that has been registered with the Globus Compute API
-as associated with a HA endpoint.  In other words, a HA function requires (exactly one)
-HA endpoint.  A HA function may not be run on any other endpoint and will be removed
-from all Globus-operated storage after 3 months of inactivity.
-
-To register a High-Assurance function, specify the ``ha_endpoint_id`` argument to
-``register_function()``:
-
-.. code-block:: python
-
-   from globus_compute_sdk import Client, Executor
-
-   def ha_func(pii: str):
-      from datetime import datetime
-      return f"ha_func: {datetime.now()} - processed pii: {pii}"
-
-   gc = Client()
-   ex = Executor()  # for illustrative purposes; strongly consider `with Executor() as ex:` style
-
-   # Registration works the same, whether via the Client or the Executor
-   ha_func_id_via_client = gc.register_function(ha_func, ha_endpoint_id='...')
-   ha_func_id_via_ex = ex.register_function(ha_func, ha_endpoint_id='...')
-
-   # Now save one of the registered ids (from this example, they point to the same
-   # function logic) for later use with `.submit_to_registered_function()`
-   print(ha_func_id_via_ex)
-
-Further, SDK usage of a HA function will require the SDK interaction to follow the HA
-requirements of the associated policy.  For example, a long running HA task (a task
-that uses an HA function) might require the SDK to login again before downloading the
-associated result:
-
-.. code-block:: python
-   :emphasize-lines: 6,15
-   :linenos:
-
-   >>> from globus_compute_sdk import Executor
-   >>> ha_endpoint_id = '...'
-   >>> ha_function_id = '...'
-   >>> with Executor(endpoint_id=ha_endpoint_id) as ex:
-   ...     fut = ex.submit_to_registered_function(ha_function_id, "ha-worthy-argument-to-function")
-   ...     print("\nResult:", fut.result())
-
-   Please authenticate with Globus here:
-   -------------------------------------
-   https://auth.globus.org/v2/oauth2/authorize?...
-   -------------------------------------
-
-   Enter the resulting Authorization Code here: ...
-
-   It is your responsibility to ensure disclosure of regulated data, such as Protected Health Information, resulting from the submission of this function and its arguments is legally authorized.
-
-   ha_func: 2025-04-29 13:39:57.888666 - processed pii: ha-worthy-argument-to-function
-
-On line 6, the script will wait until it receives notification from the AMQP server
-that the task result is ready.  Crucially, as the function is designated HA, the
-service does **not** send the result directly to the Executor instance, but instead
-simply sends notification that the task has completed.  To retrieve the result, the
-Executor will make a request to the Globus Compute API which will verify, at the time
-of retrieval, that all HA requirements are met.  If they are not, then the Executor
-will initiate the required login flow.
-
-Line 15 shows the standard disclaimer when working with an HA function.
-
-
-Audit Logging
-^^^^^^^^^^^^^
-
-Audit logging is available only to High-Assurance endpoints, and is enabled by the
-``audit_log_path`` |ManagerEndpointConfig| item:
-
-.. code-block:: yaml
-   :caption: Example ``config.yaml`` showing the ``audit_log_path`` configuration key
-   :emphasize-lines: 3,4
-
-   multi_user: true
-   ...
-   high_assurance: true
-   audit_log_path: /.../audit.log
-
-If this file does not exist, then it will be created with user-secure permissions
-(``umask=0o077``) when the endpoint starts.  It will not be checked thereafter, so it
-is incumbent on the administrator to ensure the file remains appropriately secured.
-
-When enabled, task events, if available, will be emitted one record per line:
-
-.. code-block:: text
-   :caption: Example ``audit.log`` content; the ``...`` fields are omitted for
-      documentation clarity
-
-   2025-04-10T14:44:58.742079-05:00 uid=0 pid=... eid=... Begin MEP session =====
-   ...
-   2025-04-10T14:45:30.906170-05:00 uid=... pid=... uep=... fid=... tid=... bid= RECEIVED
-   2025-04-10T14:45:30.906661-05:00 uid=... pid=... uep=... fid=... tid=... bid= EXEC_START
-   2025-04-10T14:45:37.401833-05:00 uid=... pid=... uep=... fid=... tid=... bid=4 jid=2477 RUNNING
-   2025-04-10T14:45:37.969570-05:00 uid=... pid=... uep=... fid=... tid=... bid=4 jid=2477 EXEC_END
-   ...
-   2025-04-10T14:46:39.689716-05:00 uid=0 pid=... eid=... End MEP session -----
-
-Each session begins when the MEP starts, and ends when the MEP stops (denoted with the
-sentinel lines ``Begin MEP session =====`` and ``End MEP session -----``).  Each record
-contains for the emitting process:
-
-- a local-timezone timestamp in ISO 8601 format
-- ``uid`` -- the POSIX user id
-- ``pid`` -- the POSIX process id
-- ``uep`` -- the internal UEP identifier, a UUID
-- ``fid`` -- the function identifier registered with the Compute service, a UUID
-- ``tid`` -- the task identifier registered with the Compute service, a UUID
-- ``bid`` -- the block identifier, if available, where the task was scheduled
-- ``jid`` -- the scheduler job identifier, if available
-- the task state (one of ``RECEIVED``, ``EXEC_START``, ``RUNNING``, ``EXEC_END``)
-
-The four task states describe where the task was in the execution process when the
-audit record was emitted:
-
-- ``RECEIVED`` -- denotes that the endpoint has received the task from the AMQP service
-
-- ``EXEC_START`` -- emitted when the engine has handed the task to the internal executor
-
-- ``RUNNING`` -- emitted if the engine shares this event; notably, the
-  GlobusComputeEngine does while the :ref:`ProcessPoolEngine and ThreadPoolEngines
-  <uep-conf>` do not.
-
-- ``EXEC_END`` -- emitted when the task has completed, just prior to sending the result
-  to the Compute AMQP service
-
-
-Additional High-Assurance Resources
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Globus Subscriptions:
-
-  https://www.globus.org/subscriptions
-
-- High Assurance Security Overview:
-
-  https://docs.globus.org/guides/overviews/security/high-assurance-overview/
-
-
-.. _function-allowlist:
-
-Function Allow Listing
-======================
-
-To require that UEPs only allow certain functions, specify the ``allowed_functions``
-top-level configuration item:
-
-.. code-block:: yaml
-   :caption: ``config.yaml``
-
-   multi_user: true
-   allowed_functions:
-      - 6d0ba55f-de15-4af2-827d-05c50c338aa7
-      - e552e7f2-c007-4671-8ca4-3a4fd84f3805
-
-At registration, the web service will be apprised of these function identifiers, and
-only tasks that invoke these functions will be sent to the UEPs of the MEP.  Any
-submission that specifies non-approved function identifiers will be rebuffed with
-HTTP 403 response like:
-
-.. code-block:: text
-   :caption: *Example HTTP invalid function error response via the SDK; edited for clarity*
-
-   403
-   FUNCTION_NOT_PERMITTED
-   Function <function_identifier> not permitted on endpoint <MEP_identifier>
-
-Additionally, UEPs of a function-restricted MEP will verify that tasks only use
-functions from the allow list.  Given the guarantees of the API, this is a redundant
-verification, but is performed locally as a precautionary measure.
-
-There are some instances where an administrator may want to restrict different users to
-different functions.  In this scenario, the administrator must specify the restricted
-functions within the :ref:`Jinja template logic for the UEP configuration
-<user-config-template-yaml-j2>`, and *specifically not specify any restrictions in the
-parent MEP*.  In this setup, the web-service will not verify task-requested functions
-as this check will be done locally by the UEP.  An example UEP configuration template
-snippet might be:
-
-.. code-block:: yaml+jinja
-   :caption: ``user_config_template.yaml.j2``
-
-   engine:
-      ...
-   allowed_functions:
-   {% if '3.13' in user_runtime.python_version %}
-     - c01ebede-06f5-4647-9712-e5649d0f573a
-     - 701fc11a-69b5-4e97-899b-58c3cb56334d
-   {% elif '3.12' in user_runtime.python_version %}
-     - 8dea796f-67cd-49ba-92b9-c9763d76a21d
-     - 0a6e8bed-ae93-4fd5-bb60-11c45bc1f42d
-   {% endif %}
-
-Rejections to the SDK from the UEP look slightly different:
-
-.. code-block:: text
-
-   Function <function_identifier> not permitted on endpoint <UEP_internal_identifier>
-
-In the web-response, the task is not sent to the MEP site at all and the listed
-endpoint identifier belongs to the MEP.  In this second error message, the UEP was
-started, received the task and rejected it; the mentioned endpoint is the internal UEP
-identifier, not the parent MEP identifier.
-
-.. attention::
-
-   By design, it is not possible to further restrict a UEP's set of allowed functions
-   if the MEP has specified ``allowed_functions``.  If the template configuration
-   sets ``allowed_functions`` and the MEP's ``config.yaml`` also specifies
-   ``allowed_functions``, then the UEP's configuration is ignored.  The only exception
-   to this is if the MEP does *not* restrict the functions, as discussed above.
-
-
-.. _tracing-a-task-to-mep:
-
-Tracing a Task to a MEP
-=======================
-
-A MEP might be thought of as an endpoint manager.  In a typical non-MEP paradigm, a
-user would log in (e.g., via SSH) to a compute resource (e.g., a cluster's login-node),
-create a Python virtual environment (e.g., `virtualenv`_, `pipx`_, `conda`_), and then
-install and run ``globus-compute-endpoint`` from their user-space.  By contrast, a MEP
-is a ``root``-installed and ``root``-run process that manages child processes for
-regular users.  Upon receiving a "start endpoint" request from the Globus Compute AMQP
-service, a MEP creates a user-process via the ``fork()`` |rarr| *drop privileges* |rarr|
-``exec()`` pattern, and then watches that child process until it stops.  At no point
-does the MEP attempt to execute tasks, nor does the MEP even see tasks |nbsp| --- |nbsp|
-those are handled the same as they have been to-date, by the UEPs.  The material
-difference between an endpoint started by a human and a UEP is a semantic one for
-clarity of discussion: MEPs start UEPs.
-
-The workflow for a task sent to a MEP roughly follows these steps:
-
-#. The user acquires a MEP endpoint id (perhaps as shared by the administrator via an
-   internal email, web page, or bulletin).
-
-#. The user uses the SDK to send the task to the MEP with the ``endpoint_id``:
-
-   .. code-block:: python
-      :emphasize-lines: 6, 8
-
-      from globus_compute_sdk import Executor
-
-      def some_task(*a, **k):
-          return 1
-
-      mep_site_id = "..."  # as acquired from step 1
-      with Executor() as ex:
-          ex.endpoint_id = mep_site_id
-          fut = ex.submit(some_task)
-          print("Result:", fut.result())  # Reminder: blocks until result received
-
-#. After the ``ex.submit()`` call, the SDK POSTs a REST request to the Globus Compute
-   web service.
-
-#. The Compute web-service identifies the endpoint in the request as belonging to a MEP.
-
-#. The Compute web-service generates a UEP id specific to the tuple of the
-   ``mep_site_id``, the id of the user making the request, and the endpoint
-   configuration in the request (e.g., ``tuple(site_id, user_id, conf)``) |nbsp| ---
-   |nbsp| this identifier is simultaneously stable and unique.
-
-#. The Compute web-service sends a start-UEP message to the MEP (via AMQP), asking it to
-   start an endpoint as the user that initiated the REST request and identified by the
-   id generated in the previous step.
-
-#. The MEP maps the Globus Auth identity in the start-UEP-request to a local (POSIX)
-   username.
-
-#. The MEP ascertains the host-specific UID based on a |getpwnam(3)|_ call with the
-   local username from the previous step.
-
-#. The MEP starts a UEP as the UID from the previous step.
-
-#. The just-started UEP checks in with the Globus Compute web-services.
-
-#. The web-services will see the check-in and then complete the original request to the
-   SDK, accepting the task and submitting it to the now-started UEP.
-
-The above workflow may be of interest to system administrators from a "How does this
-work in theory?" point of view, but will be of little utility to most users.  The part
-of interest to most end users is the on-the-fly custom configuration.  If the
-administrator has provided any hook-in points in ``user_config_template.yaml.j2`` (e.g.,
-an account id), then a user may specify that via the ``user_endpoint_config`` argument
-to the Executor constructor or for later submissions:
-
-.. code-block:: python
-   :caption: Utilizing the ``.user_endpoint_config`` via both a constructor call, and
-      an ad-hoc change
-   :emphasize-lines: 9, 13
-
-   from globus_compute_sdk import Executor
-
-   def jittery_multiply(a, b):
-       return a * b + (1 - random.random()) * (1 + abs(a - b))
-
-   mep_site_id = "..."  # as acquired from step 1
-   with Executor(
-       endpoint_id=mep_site_id,
-       user_endpoint_config={"account_id": "user_allocation_account_id"},
-   ) as ex:
-       futs = [ex.submit(jittery_multiply, 2, 7)]
-
-       ex.user_endpoint_config["account_id"] = "different_allocation_id"
-       futs = [ex.submit(jittery_multiply, 13, 11)]
-
-       # Reminder: .result() blocks until result received
-       results = list[f.result() for f in futs]
-       print("Result:", results)
-
-N.B. this is example code highlighting the ``user_endpoint_config`` attribute of the
-``Executor`` class; please generally consult the :doc:`../sdk/executor_user_guide` documentation.
+Administrators can use a `Globus authentication policy`_ to limit access to a multi-user
+endpoint by enforcing that the user has appropriate identities linked to their Globus
+account and that the required identities have recent authentications.
+
+Please refer to :ref:`auth-policies` for more information.
 
 
 Administrator Quickstart
@@ -1283,12 +582,12 @@ Administrator Quickstart
       # command -v globus-compute-endpoint
       /usr/sbin/globus-compute-endpoint
 
-#. Create a Multi-User Endpoint configuration with the ``--multi-user`` flag
-   to the ``configure`` subcommand:
+#. Create a Multi-User Endpoint configuration by running the ``configure`` subcommand
+   as a privileged user (e.g., root):
 
    .. code-block:: console
 
-      # globus-compute-endpoint configure --multi-user prod_gpu_large
+      # globus-compute-endpoint configure prod_gpu_large
       Created multi-user profile for endpoint named <prod_gpu_large>
 
           Configuration file: /root/.globus_compute/prod_gpu_large/config.yaml
@@ -1303,7 +602,7 @@ Administrator Quickstart
 
           $ globus-compute-endpoint start prod_gpu_large
 
-#. Setup the identity mapping configuration |nbsp| --- |nbsp| this depends on your
+#. Set up the identity mapping configuration |nbsp| --- |nbsp| this depends on your
    site's specific requirements and may take some trial and error.  The key point is to
    be able to take a Globus Auth Identity set, and map it to a local username *on this
    resource* |nbsp| --- |nbsp| this resulting username will be passed to |getpwnam(3)|_
@@ -1315,12 +614,11 @@ Administrator Quickstart
 
 #. Modify ``user_config_template.yaml.j2`` as appropriate for the resources to make
    available.  This file will be interpreted as a `Jinja template`_ and will be rendered
-   with user-provided variables to generate the final UEP configuration.  The default
-   configuration (as created in step 4) has a basic working configuration, but uses the
-   ``LocalProvider``.
+   with user-provided variables to generate the final user endpoint process configuration.
+   The default configuration (as created in step 4) has a basic working configuration, but
+   uses the ``LocalProvider``.
 
-   Please look to :doc:`endpoint_examples` (all written for single-user use) as a
-   starting point.
+   Please look to :doc:`endpoint_examples` as a starting point.
 
 #. Optionally modify ``user_config_schema.json``; the file, if it exists, defines the
    `JSON schema`_ against which user-provided variables are validated.  Writing JSON
@@ -1336,9 +634,9 @@ Administrator Quickstart
       SOME_SITE_SPECIFIC_ENV_VAR: a site specific value
       PATH: /site/specific:/path:/opt:/usr:/some/other/path
 
-#. Run MEP manually for testing and easier debugging, as well as to collect the
-   (Multi‑User) endpoint ID for sharing with users.  The first time through, the Globus
-   Compute endpoint will initiate a Globus Auth login flow, and present a long URL:
+#. Run multi-user endpoint manually for testing and easier debugging, as well as to collect
+   the endpoint ID for sharing with users.  The first time through, the endpoint will initiate
+   a Globus Auth login flow, and present a long URL:
 
    .. code-block:: console
 
@@ -1382,20 +680,7 @@ Administrator Quickstart
 .. |nbsp| unicode:: 0xA0
    :trim:
 
-.. |rarr| unicode:: 0x2192
-   :trim:
-
-.. |hellip| unicode:: 0x2026
-
-.. _`same Linux distributions as does Globus Connect Server`: https://docs.globus.org/globus-connect-server/v5/#supported_linux_distributions
-
-.. |POSTed to the /v3/endpoints/<mep_uuid>/submit| replace:: POSTed to the ``/v3/endpoints/<mep_uuid>/submit``
-.. _POSTed to the /v3/endpoints/<mep_uuid>/submit: https://compute.api.globus.org/redoc#tag/Endpoints/operation/submit_batch_v3_endpoints__endpoint_uuid__submit_post
-
-.. _Web UI: https://app.globus.org/compute
 .. _Identity Mapping documentation: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/
-.. _Authentication Policies documentation: https://docs.globus.org/api/auth/developer-guide/#authentication_policy_fields
-.. _Auth policy: https://docs.globus.org/api/auth/developer-guide/#authentication-policies
 .. |globus-identity-mapping| replace:: ``globus-identity-mapping``
 .. _globus-identity-mapping: https://pypi.org/project/globus-identity-mapping/
 .. |getpwnam(3)| replace:: ``getpwnam(3)``
@@ -1403,16 +688,8 @@ Administrator Quickstart
 .. _Jinja template: https://jinja.palletsprojects.com/en/3.1.x/
 .. _Globus authentication policy: https://docs.globus.org/api/auth/developer-guide/#authentication-policies
 .. _Globus Connect Server Identity Mapping Guide: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/#mapping_recipes
-.. _Globus subscription: https://www.globus.org/subscriptions
-.. _#help on the Globus Compute Slack: https://funcx.slack.com/archives/C017637NZFA
-.. |UserRuntime| replace:: :class:`UserRuntime <globus_compute_sdk.sdk.batch.UserRuntime>`
 .. _JSON schema: https://json-schema.org/
 
-.. |ManagerEndpointConfig| replace:: :class:`ManagerEndpointConfig <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
 .. |PamConfiguration| replace:: :class:`PamConfiguration <globus_compute_endpoint.endpoint.config.pam.PamConfiguration>`
 
-.. _virtualenv: https://pypi.org/project/virtualenv/
-.. _pipx: https://pypa.github.io/pipx/
-.. _conda: https://docs.conda.io/en/latest/
-.. _dill: https://pypi.org/project/dill/
 .. _Pluggable Authentication Modules: https://en.wikipedia.org/wiki/Linux_PAM

--- a/docs/endpoints/security_posture.rst
+++ b/docs/endpoints/security_posture.rst
@@ -1,12 +1,12 @@
 Security Posture
 ================
 
-There are multiple avenues to secure a Multi-User Compute Endpoint (MEP) installation.
-Administrators familiar with `Globus Connect Server`_ will recognize the concepts of
-identity mapping and authentication policies to limit access to resources.  (Notably,
-Globus Compute also implements the :ref:`High-Assurance <posture-ha>` aspect of Globus
-Auth policies.)  But more specifically for Compute, there is also the possibility to
-limit exactly which functions may be invoked, and how arguments may be serialized.
+There are multiple avenues to secure a Compute Endpoint installation. Administrators
+familiar with `Globus Connect Server`_ will recognize the concepts of identity mapping
+and authentication policies to limit access to resources.  (Notably, Globus Compute also
+implements the :ref:`High-Assurance <posture-ha>` aspect of Globus Auth policies.)  But
+more specifically for Compute, there is also the possibility to limit exactly which
+functions may be invoked, and how arguments may be serialized.
 
 Each of these concepts is outlined below.
 
@@ -16,51 +16,52 @@ Each of these concepts is outlined below.
 Identity Mapping
 ----------------
 
-The current security model of the Multi-User Compute Endpoint (MEP) relies heavily upon
-Identity Mapping and POSIX user support.  The only job of a MEP is to start user
-endpoint processes (UEP) for users on request from the Globus Compute web service.  The
-actual processing of tasks is left to the individual UEPs.  This is accomplished
-through the well-known ``fork()`` |rarr| *drop privileges* |rarr| ``exec()`` Unix
-workflow, mimicking the approach of many other services (including Secure Shell [ssh],
-Globus GridFTP, and the Apache Web server).  In this manner, all of the standard Unix
-administrative user controls can be enforced.
+The current security model of the Multi-User Compute Endpoint (i.e., running as the ``root``
+user) relies heavily upon Identity Mapping and POSIX user support.  The only job of an endpoint
+is to start user endpoint processes for users on request from the Globus Compute web service.
+The actual processing of tasks is left to the individual user endpoint processes.  This is
+accomplished through the well-known ``fork()`` |rarr| *drop privileges* |rarr| ``exec()`` Unix
+workflow, mimicking the approach of many other services (including Secure Shell [ssh], Globus
+GridFTP, and the Apache Web server).  In this manner, all of the standard Unix administrative
+user controls can be enforced.
 
 "Mapping an identity" is the site-specific process of verifying that one identity is
 equivalent to another for the purposes of a given action.  In the Globus Compute case,
 this means translating a Globus Auth identity set to a local POSIX user account on the
-MEP host for each start-UEP message.  For an administrator-run MEP (i.e., running as the
-``root`` user), an identity mapping configuration is required, and is the main
-difference from a :ref:`non-root MEP <endpoints_templating_configuration>` |nbsp| ---
-|nbsp| a ``root``-owned MEP first maps the Globus Auth identity set from each start-UEP
-message to a local POSIX user (i.e., a local username), before ``fork()``-ing a new
-process, dropping privileges to that user, and starting the requested UEP.
+endpoint host for each request to start a user endpoint process.  For a multi-user endpoint,
+an identity mapping configuration is required, and is the main difference from a
+:doc:`non-root endpoint <endpoints>` |nbsp| --- |nbsp| a ``root``-owned multi-user endpoint
+first maps the Globus Auth identity set from each start message to a local POSIX user
+(i.e., a local username), before ``fork()``-ing a new process, dropping privileges to that
+user, and starting the requested user endpoint process.
 
-See :ref:`MEP § Configuration <example-idmap-config>` for specifics and examples.
+See :ref:`Multi-User § Configuration <example-idmap-config>` for specifics and examples.
 
 
 Authentication Policies
 -----------------------
 
 In addition to the identity mapping access control, administrators may also use Globus
-authentication policies to narrow which identities can even send tasks to a MEP.  An
-authentication policy can enforce details such as that a user has an identity from a
-specific domain or has authenticated with the Globus Auth recently.  Refer to the
-`Authentication Policies documentation`_ for more background and specifics on what
-Globus authentication policies can do and how they fit in to a site's security posture.
+authentication policies to narrow which identities can even send tasks to a multi-user
+endpoint.  An authentication policy can enforce details such as that a user has an
+identity from a specific domain or has authenticated with the Globus Auth recently.
+Refer to the `Authentication Policies documentation`_ for more background and specifics
+on what Globus authentication policies can do and how they fit in to a site's security
+posture.
 
-Reference :ref:`MEP § Authentication Policies <auth-policies>` for more information.
+Reference :ref:`Authentication Policies <auth-policies>` for more information.
 
 
 Function Allow Listing
 ----------------------
 
-Administrators can narrow MEP usage by limiting what functions may be requested by
+Administrators can narrow endpoint usage by limiting what functions may be requested by
 tasks.  The web-service will reject any submissions that request functions not in the
-MEP's configured ``allowed_functions`` list, and user endpoint processes will again
+endpoint's configured ``allowed_functions`` list, and user endpoint processes will again
 verify each task against the same list |nbsp| --- |nbsp| a check at the web-service and
 a check on-site.
 
-Please reference :ref:`MEP § Function Allow Listing <function-allowlist>` for more
+Please reference :ref:`Function Allow Listing <function-allowlist>` for more
 detailed information.
 
 
@@ -75,7 +76,7 @@ may receive |nbsp| --- |nbsp| for example, a callable like another function coul
 be passed |nbsp| --- |nbsp| but is safe from arbitrary code execution during
 deserialization.
 
-See :ref:`Endpoint § Restricting Submission Serialization Methods
+See :ref:`Restricting Submission Serialization Methods
 <restrict-submission-serialization-methods>` for more information.
 
 
@@ -95,19 +96,18 @@ differences:
 - HA functions are cleared from all Globus-related storage (e.g., function name,
   definition, description) after 3 months of inactivity.
 
-Reference :ref:`MEP § High-Assurance <high-assurance-mep>` for details.
+Reference :ref:`High-Assurance <high-assurance>` for details.
 
 
-Multiple Administrators of a MEP
+Multiple Endpoint Administrators
 --------------------------------
 
-MEPs associated with a subscription may be administered by multiple Globus Auth
+Endpoints associated with a subscription may be administered by multiple Globus Auth
 identities.  The identities are stated in the ``admins`` key of the ``config.yaml``:
 
 .. code-block:: yaml
    :caption: ``config.yaml``
 
-   multi_user: true
    subscription_id: 600ba9ac-ef16-4387-30ad-60c6cc3a6853
    admins:
      # Peter Gibbons (software engineer)
@@ -122,7 +122,7 @@ manage and view the endpoint's status page in the `Globus Web app`_.
 
 .. important::
 
-   Note that changes to this list will not go into effect until the MEP is restarted
+   Note that changes to this list will not go into effect until the endpoint is restarted
    and registers afresh with the Globus Compute web services.
 
 

--- a/docs/endpoints/templates.rst
+++ b/docs/endpoints/templates.rst
@@ -1,86 +1,14 @@
-Configuration Templates
-***********************
+Working with Templates
+**********************
 
-Globus Compute endpoints often need different configurations for different users,
-environments, or workflows. Rather than maintaining multiple endpoints or configuration
-files, administrators can create a single `Jinja template`_ to generate customized
-configurations based on user-provided variables. Both :ref:`single-user
-<endpoints_templating_configuration>` (template-able) and :ref:`multi-user
-<user-config-template-yaml-j2>` endpoints support this feature.
+Globus Compute endpoints often need different configurations for different environments, workflows,
+or users (see :doc:`multi_user`). Rather than maintaining multiple endpoints or configuration
+files, endpoint administrators can create a single :ref:`configuration template <user-config-template-yaml-j2>`
+to generate customized configurations based on variables provided during task submission.
 
 Familiarity with `Jinja template`_ concepts is a prerequisite to this guide, which
-focuses on the unique features, capabilities and peculiarities of Globus Compute
-configuration templates.
-
-
-Default Template
-================
-
-The default template file is named ``user_config_template.yaml.j2`` and lives in the
-main endpoint directory. Admins can modify the file path via the ``user_config_template_path``
-variable in the :ref:`endpoint manager configuration <endpoint-manager-config>`.
-
-The initial template implements two user-defined variables: ``endpoint_setup`` and
-``worker_init``.  Both of these default to the empty string if not specified by the
-user (i.e., ``...|default()``).
-
-.. code-block:: yaml+jinja
-
-   endpoint_setup: {{ endpoint_setup|default() }}
-   engine:
-     ...
-     provider:
-       ...
-       worker_init: {{ worker_init|default() }}
-
-   idle_heartbeats_soft: 10
-   idle_heartbeats_hard: 5760
-
-Given the above template, users submitting to this endpoint would be able to specify the
-``endpoint_setup`` and ``worker_init`` values.  All other values will remain unchanged
-when the user endpoint process starts up.
-
-As linked on the left, :doc:`there are a number of example configurations
-<endpoint_examples>` to showcase the available options, but ``idle_heartbeats_soft`` and
-``idle_heartbeats_hard`` bear describing.
-
-- ``idle_heartbeats_soft``: if there are no outstanding tasks still processing, and the
-  endpoint has been idle for this many heartbeats, shutdown the endpoint
-
-- ``idle_heartbeats_hard``: if endpoint is *apparently* idle (e.g., there are
-  outstanding tasks, but they have not moved) for this many heartbeats, then shutdown
-  anyway.
-
-A heartbeat occurs every 30s; if ``idle_heartbeats_hard`` is set to 7, and no tasks
-or results move (i.e., tasks received from the web service or results received from
-workers), then the endpoint will shutdown after 3m30s (7 × 30s).
-
-
-Basic User Workflow
-===================
-
-After starting the endpoint, users can specify values for the template variables
-when submitting a task:
-
-.. code-block:: python
-   :emphasize-lines: 4,8,11
-
-   from globus_compute_sdk import Executor
-
-   ep_id = "..."
-   config = {"worker_init": "source /path/to/venv1/bin/activate"}
-
-   with Executor(
-       endpoint_id=ep_id,
-       user_endpoint_config=config
-   ) as ex:
-       print(ex.submit(some_task, 1).result())
-       ex.user_endpoint_config["worker_init"] = "source /path/to/venv2/bin/activate"
-       print(ex.submit(some_task, 2).result())
-
-The manager endpoint process will render the configuration template with the user-defined
-variables, then launch the user endpoint process. Any changes to these values will result
-in a new user endpoint process.
+focuses on the unique features and peculiarities of Globus Compute configuration
+templates.
 
 
 User Input Security
@@ -114,41 +42,6 @@ a user-defined ``environment`` variable:
 Note that we are using the full JSON-serialized string for the if-condition. The template
 would fail to render if we used ``'test'`` or ``"test"`` instead of ``'"test"'``.
 
-
-.. _template-variable-validation:
-
-User Input Validation
-=====================
-
-Admins can define a `JSON schema <https://json-schema.org/>`_ to validate user-defined
-variables. The default schema file is named ``user_config_schema.json`` and lives in the
-main endpoint directory. Admins can modify the file path via the ``user_config_schema_path``
-variable in the :ref:`endpoint manager configuration <endpoint-manager-config>`.
-
-The default schema is quite permissive, enforcing that the two default template variables
-are strings, then allowing any other user-defined properties:
-
-.. code-block:: json
-   :caption: Default ``user_config_schema.json``
-
-   {
-     "$schema": "https://json-schema.org/draft/2020-12/schema",
-     "type": "object",
-     "properties": {
-       "endpoint_setup": { "type": "string" },
-       "worker_init": { "type": "string" }
-     },
-     "additionalProperties": true
-   }
-
-.. important::
-
-   The default schema sets ``additionalProperties`` to ``true``, allowing properties
-   not explicitly defined in the schema. This enables the default template to work
-   without customization.
-
-   Endpoint administrators who require stricter input validation should consider
-   setting ``additionalProperties`` to ``false`` to reject unexpected properties.
 
 Reserved Variables
 ==================
@@ -191,9 +84,9 @@ Every template has access to reserved variables that cannot be overridden by the
 Combining Templates
 ===================
 
-Administrators can combine multiple templates with the ``extends``, ``include``, and
-``import`` Jinja tags.  However, since these templates are rendered in user space,
-the administrator must:
+Endpoint administrators can combine multiple templates with the ``extends``, ``include``,
+and ``import`` Jinja tags.  However, since these templates are rendered in user space, the
+administrator must:
 
 1. Move the template files to a directory that every mapped local user account has
    read access to.

--- a/docs/tutorials/dynamic_containers.rst
+++ b/docs/tutorials/dynamic_containers.rst
@@ -1,30 +1,23 @@
 Dynamic Container Configuration
 *******************************
 
-This tutorial demonstrates how to leverage a multi-user endpoint to enable dynamic
-container configuration at the point of task submission.
+This tutorial demonstrates how to enable dynamic container configuration at the
+point of task submission.
 
 For general information on how to specify container environments in an endpoint
 configuration, see :ref:`Containerized Environments <containerized-environments>`.
 
-.. note::
 
-   A multi-user endpoint functionally becomes a single-user "template-able" endpoint
-   when deployed as a non-privileged user. See :ref:`endpoints_templating_configuration`
-   for more information.
+Configure an Endpoint
+=====================
 
-
-Configure a Multi-User Endpoint
-===============================
-
-If you are starting from scratch, you will need to initialize a multi-user endpoint with
-the ``--multi-user`` flag. See :ref:`Multi-User Configuration <multi-user-configuration>`
-for more information.
+If you are starting from scratch, you will need to initialize an endpoint with
+the ``configure`` subcommand:
 
 
 .. code-block:: console
 
-   $ globus-compute-endpoint configure --multi-user my-mep
+   $ globus-compute-endpoint configure my-ep
 
 
 Modify the Configuration Template
@@ -94,7 +87,7 @@ Once the endpoint is configured, we can start it up.
 
 .. code-block:: console
 
-   $ globus-compute-endpoint start my-mep
+   $ globus-compute-endpoint start my-ep
 
 Take note of the endpoint ID emitted to the console; we will use it later in the tutorial.
 


### PR DESCRIPTION
# Description

Version 4 adopts a unified architecture where every Compute Endpoint consists of a manager endpoint process that uses configuration templates to launch and manage user endpoint processes. The former multi-user architecture is now the default, requiring an updated conceptual framework:

- Single-user endpoint: Started as a non-privileged user, thus does not support identity mapping

- Multi-user endpoint: Started as a privileged user (e.g., root), thus supports identity mapping

This refactoring incorporates most features that were formerly multi-user-specific into the main endpoint user guide, with the multi-user guide now focusing primarily on identity mapping features.

[sc-42857](https://app.shortcut.com/globus/story/42857/update-docs-to-redefine-uep-mep)

## Type of change

- Documentation update
