### PR TITLE
MEPs get PID files too

### DIFF
--- a/changelog.d/20250813_113742_kevin_gce_pid_file.rst
+++ b/changelog.d/20250813_113742_kevin_gce_pid_file.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Template-capable endpoints are no longer ignored by the ``list`` and ``stop``
+  commands.


### PR DESCRIPTION
Move some of the logic out of the `Endpoint.start_endpoint` method.  This is not a complete solution&nbsp;&mdash;&nbsp;should move most of the PID logic *out* of the Endpoint class.  But not a task for today.

Motivated to "just do this" given @rjmello's recent documentation work.

[sc-43651]

## Type of change

- Bug fix (non-breaking change that fixes an issue)