### PR TITLE
Handle null user values when rendering template

### DIFF
--- a/changelog.d/20250909_155630_30907815+rjmello_handle_null_user_values_sc_44820.rst
+++ b/changelog.d/20250909_155630_30907815+rjmello_handle_null_user_values_sc_44820.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Endpoints no longer raise an exception when attempting to render a template
+  with null values in ``user_endpoint_config`` or ``user_runtime``.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -214,6 +214,8 @@ def _sanitize_user_opts(data):
         return json.dumps(data)
     elif isinstance(data, (int, float)):
         return data
+    elif data is None:
+        return "null"
     else:
         # We do not expect to hit this because user options are passed
         # from the web service as JSON

--- a/compute_endpoint/tests/unit/test_config_utils.py
+++ b/compute_endpoint/tests/unit/test_config_utils.py
@@ -154,6 +154,32 @@ engine:
     assert loaded["engine"]["accelerators"] == user_opts["engine"]["accelerators"]
 
 
+def test_render_user_config_handles_null_user_values(
+    conf_no_exec, mapped_ident: MappedPosixIdentity
+):
+    template = """
+endpoint_setup: {{ some_var }}
+display_name: {{ user_runtime.some_var }}
+    """
+
+    user_opts = {"some_var": None}
+    user_runtime = {"some_var": None}
+    rendered_str = render_config_user_template(
+        conf_no_exec,
+        template,
+        pathlib.Path("/"),
+        mapped_ident,
+        {},
+        user_opts,
+        user_runtime,
+    )
+    loaded = yaml.safe_load(rendered_str)
+
+    assert len(loaded) == 2
+    assert loaded["endpoint_setup"] is None
+    assert loaded["display_name"] is None
+
+
 @pytest.mark.parametrize(
     "data",
     [


### PR DESCRIPTION
# Description

Our template rendering logic now handles null values in both the `user_endpoint_config` or `user_runtime` objects.

[sc-44820](https://app.shortcut.com/globus/story/44820/fix-handling-of-null-user-values-when-rendering-config-template)

## Type of change

- Bug fix (non-breaking change that fixes an issue)