### PR TITLE
Address errant timeout at authorization

### DIFF
--- a/changelog.d/20250916_140213_kevin_fix_timeout_issue.rst
+++ b/changelog.d/20250916_140213_kevin_fix_timeout_issue.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address 3.13-introduced bug that killed the endpoint if it failed to start up
+  within 15s.  (This was most easily identified when the endpoint prompted for
+  a Globus Auth authorization code.)

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -737,8 +737,6 @@ def _do_start_endpoint(
                 ep_config.detach_endpoint = False
                 log.debug("The --die-with-parent flag has set detach_endpoint to False")
 
-            # special case until daemon.DaemonContext logic removed:
-            Endpoint.pid_path(ep_dir).unlink()
             get_cli_endpoint(ep_config).start_endpoint(
                 ep_dir,
                 endpoint_uuid,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from http import HTTPStatus
 
 import daemon
-import daemon.pidfile
 import psutil
 import setproctitle
 import texttable
@@ -416,7 +415,6 @@ class Endpoint:
             context = daemon.DaemonContext(
                 working_directory=endpoint_dir,
                 umask=0o002,
-                pidfile=daemon.pidfile.PIDLockFile(Endpoint.pid_path(endpoint_dir)),
                 stdout=stdout,
                 stderr=stderr,
                 detach_process=endpoint_config.detach_endpoint,


### PR DESCRIPTION
A case of mistaken "who's got control" of the PID file.  Answer: the CLI's logic wins.  DaemonContext only uses the PID file if specified, so we can gracefully take over that responsibility.

[sc-45029]

## Type of change

- Bug fix (non-breaking change that fixes an issue)