### PR TITLE
Bump parsl dependency to 2025.9.15

### DIFF
--- a/changelog.d/20250916_144323_30907815+rjmello_bump_parsl_2025_09_15.rst
+++ b/changelog.d/20250916_144323_30907815+rjmello_bump_parsl_2025_09_15.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency  from `2025.3.31 <https://pypi.org/project/parsl/2025.3.31/>`_
+  to `2025.9.15 <https://pypi.org/project/parsl/2025.9.15/>`_

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -415,7 +415,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         """
         if managers is None:
             managers = self.get_connected_managers()
-        total_task_count = self.executor.outstanding
+        total_task_count = self.executor.outstanding()
         breakdown = [(m["manager"], m["tasks"], m["active"]) for m in managers]
         total_count_managers = sum([m["tasks"] for m in managers])
         task_count_interchange = total_task_count - total_count_managers
@@ -428,7 +428,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         -------
         Dict of type {str_task_type: count_tasks}
         """
-        return {"RAW": self.executor.outstanding}
+        return {"RAW": self.executor.outstanding()}
 
     def get_total_tasks_pending(self, managers: t.List[t.Dict[str, t.Any]]) -> int:
         """

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2025.3.31",
+    "parsl==2025.9.15",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
[sc-31360](https://app.shortcut.com/globus/story/31360/remove-check-in-parsl-for-version-mismatches-between-interchange-and-executor)

## Type of change

- Code maintenance/cleanup
