### PR TITLE
Allow EP and workers to run different Python

### DIFF
--- a/changelog.d/20250916_151835_30907815+rjmello_python_mismatch_sc_31360.rst
+++ b/changelog.d/20250916_151835_30907815+rjmello_python_mismatch_sc_31360.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- The endpoint and worker Python versions no longer have to be in sync.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -151,6 +151,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.executor.interchange_launch_cmd = self._get_compute_ix_launch_cmd()
         self.executor.launch_cmd = self._get_compute_launch_cmd()
 
+        # This flag serves as a temporary workaround to support different
+        # Python versions at the endpoint and worker layers. We can drop
+        # the flag once Parsl supports modular internal message protocols.
+        self.executor._check_python_mismatch = False
+
         self.run_in_sandbox = run_in_sandbox
         if strategy is None:
             strategy = "simple"


### PR DESCRIPTION
# Description

As a temporary workaround to support different Python versions at the endpoint and worker layers, we will set the `_check_python_mismatch` flag on Parsl's `HighThroughputExecutor` to `False`. We can drop this once Parsl supports modular internal message protocols.

[sc-31360](https://app.shortcut.com/globus/story/31360/remove-check-in-parsl-for-version-mismatches-between-interchange-and-executor)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
