### PR TITLE
Allow root users to run unmapped templatable EPs

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -15,7 +15,6 @@ from globus_compute_sdk.sdk.utils.uuid_like import (
     as_uuid,
 )
 
-from ..utils import is_privileged
 from .pam import PamConfiguration
 
 MINIMUM_HEARTBEAT: float = 5.0
@@ -513,24 +512,13 @@ class ManagerEndpointConfig(BaseConfig):
 
     @identity_mapping_config_path.setter
     def identity_mapping_config_path(self, val: os.PathLike | str | None):
-        self._identity_mapping_config_path: pathlib.Path | None
-        if is_privileged():
-            if not val:
-                raise ValueError(
-                    "Identity mapping required.  (Hint: identity_mapping_config_path)"
-                )
-
-            _p = pathlib.Path(val)
-            if not _p.exists():
-                raise ValueError(f"Identity mapping config path not found ({_p})")
-            self._identity_mapping_config_path = _p
-        else:
-            self._identity_mapping_config_path = None
-            if val:
-                log.warning(
-                    "Identity mapping specified, but process is not privileged;"
-                    " ignoring identity mapping configuration."
-                )
+        self._identity_mapping_config_path: pathlib.Path | None = None
+        if not val:
+            return
+        _p = pathlib.Path(val)
+        if not _p.exists():
+            raise ValueError(f"Identity mapping config path not found ({_p})")
+        self._identity_mapping_config_path = _p
 
     @property
     def audit_log_path(self) -> pathlib.Path | None:

--- a/compute_endpoint/tests/unit/test_config_utils.py
+++ b/compute_endpoint/tests/unit/test_config_utils.py
@@ -124,9 +124,7 @@ def test_load_manager_endpoint_config_full(get_random_of_datatype):
         for kw, tval in known_manager_config_opts.items()
     }
     serde_yaml = yaml.safe_dump(conf)
-    to_mock = "globus_compute_endpoint.endpoint.config.config.is_privileged"
-    with mock.patch(to_mock, return_value=True):
-        conf = load_config_yaml(serde_yaml)
+    conf = load_config_yaml(serde_yaml)
     assert isinstance(conf, ManagerEndpointConfig)
 
 

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -131,37 +131,16 @@ def test_mep_config_verifies_path_like_fields(config_dict_mep, field: str):
     )  # doesn't raise; conditional validation
 
 
-def test_mep_config_warns_idmapping_ignored(mock_log, config_dict_mep):
-    config_dict_mep["identity_mapping_config_path"] = "not exists file"
-    ManagerEndpointConfig(**config_dict_mep)
-
-    a, _k = mock_log.warning.call_args
-    assert "Identity mapping specified" in a[0]
-    assert "is not privileged" in a[0]
-
-
-def test_mep_config_privileged_requires_idmapping(config_dict_mep):
-    del config_dict_mep["identity_mapping_config_path"]
-    with mock.patch(f"{_MOCK_BASE}config.is_privileged", return_value=True):
-        with pytest.raises(ValueError) as pyt_e:
-            ManagerEndpointConfig(**config_dict_mep)
-
-    assert "identity mapping" in str(pyt_e).lower()
-    assert "required" in str(pyt_e).lower()
-    assert "Hint: identity_mapping_config_path" in str(pyt_e), "Expect config item hint"
-
-
 def test_mep_config_privileged_verifies_idmapping(config_dict_mep):
     p = config_dict_mep["identity_mapping_config_path"]
-    with mock.patch(f"{_MOCK_BASE}config.is_privileged", return_value=True):
-        ManagerEndpointConfig(**config_dict_mep)  # Verify for test: doesn't raise!
+    ManagerEndpointConfig(**config_dict_mep)  # Verify for test: doesn't raise!
 
-        p.unlink(missing_ok=True)
-        with pytest.raises(ValueError) as pyt_e:
-            ManagerEndpointConfig(**config_dict_mep)
+    p.unlink(missing_ok=True)
+    with pytest.raises(ValueError) as pyt_e:
+        ManagerEndpointConfig(**config_dict_mep)
 
-        assert "not found" in str(pyt_e)
-        assert str(p) in str(pyt_e), "Expect invalid path shared"
+    assert "not found" in str(pyt_e)
+    assert str(p) in str(pyt_e), "Expect invalid path shared"
 
 
 @pytest.mark.parametrize("public", (None, True, False, "a", 1))
@@ -229,11 +208,7 @@ def test_managerconfig_repr_nondefault_kwargs(
     if cls == os.PathLike:
         val = pathlib.Path(val)
 
-    if kw == "identity_mapping_config_path":
-        with mock.patch(f"{_MOCK_BASE}config.is_privileged", return_value=True):
-            repr_c = repr(ManagerEndpointConfig(**{kw: val}))
-    else:
-        repr_c = repr(ManagerEndpointConfig(**{kw: val}))
+    repr_c = repr(ManagerEndpointConfig(**{kw: val}))
 
     assert f"{kw}={repr(val)}" in repr_c
 


### PR DESCRIPTION
# Description

Previously, any user running a templatable EP as root was required to supply an identity mapping file, since there was no concept of a single- user templatable EP. Now that this concept exists, this commit removes the logic enforcing an ID mapping configuration file.

[[sc-44019]](https://app.shortcut.com/globus/story/44019/allow-privileged-users-to-run-unmapped-templatable-endpoints)

## Type of change

- New feature (non-breaking change that adds functionality)
