### PR TITLE
Add source code registration methods

### DIFF
--- a/changelog.d/20250918_131402_30907815+rjmello_reg_source_code_sc_42893.rst
+++ b/changelog.d/20250918_131402_30907815+rjmello_reg_source_code_sc_42893.rst
@@ -1,0 +1,43 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added new ``Client`` and ``Executor`` methods to enable registering arbitrary Python
+  source code:
+
+  - :meth:`Client.register_source_code <globus_compute_sdk.Client.register_source_code>`
+  - :meth:`Executor.register_source_code <globus_compute_sdk.Executor.register_source_code>`
+
+  The standard ``.register_function()`` methods expect callable function objects,
+  which they then serialize using the specified code serialization strategy. In
+  contrast, the ``.register_source_code()`` methods enable the user to directly
+  provide an arbitrary source code string and entrypoint function name, which are
+  then serialized using the :class:`globus_compute_sdk.serialize.PureSourceTextInspect`
+  strategy:
+
+  .. code-block:: python
+
+    from globus_compute_sdk import Client, Executor
+
+    source = 'def hello(name: str):\n    return f"Hello, {name}!"\n'
+    function_name = "hello"
+
+    client = Client(...)
+    func_id = client.register_source_code(source, function_name)
+
+    # or
+
+    executor = Executor(...)
+    func_id = executor.register_source_code(source, function_name)
+
+  Alternatively, when using the ``Executor`` interface, users can provide the path to a
+  file containing the source code:
+
+  .. code-block:: python
+
+    from globus_compute_sdk import Executor
+
+    executor = Executor(client=client, ...)
+    func_id = client.register_source_code(
+      source="/path/to/source.py",
+      function_name="main"
+    )

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import pathlib
 import platform
 import sys
 import threading
@@ -25,7 +26,11 @@ from globus_compute_sdk.sdk.web_client import (
     FunctionRegistrationData,
     FunctionRegistrationMetadata,
 )
-from globus_compute_sdk.serialize import ComputeSerializer, SerializationStrategy
+from globus_compute_sdk.serialize import (
+    ComputeSerializer,
+    PureSourceTextInspect,
+    SerializationStrategy,
+)
 from globus_compute_sdk.version import __version__, compare_versions
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.version import __version__ as __version_globus__
@@ -34,7 +39,7 @@ from .auth.auth_client import ComputeAuthClient
 from .auth.globus_app import get_globus_app
 from .batch import Batch, UserRuntime
 from .login_manager import LoginManagerProtocol
-from .utils import get_env_var_with_deprecation
+from .utils import get_env_var_with_deprecation, get_py_version_str
 from .web_client import WebClient
 
 logger = logging.getLogger(__name__)
@@ -862,6 +867,90 @@ class Client:
         with self._request_lock:
             r = self._compute_web_client.v3.register_function(data.to_dict())
 
+        self._raise_ha_warning(r.data)
+
+        return r.data["function_uuid"]
+
+    @_client_gares_handler
+    def register_source_code(
+        self,
+        source: str | pathlib.Path,
+        function_name: str,
+        description: str | None = None,
+        metadata: dict | None = None,
+        public: bool = False,
+        group: UUID_LIKE_T | None = None,
+        ha_endpoint_id: UUID_LIKE_T | None = None,
+    ) -> str:
+        """Register arbitrary Python source code with entrypoint function
+
+        The standard ``.register_function()`` method expects a callable function object,
+        which it then serializes using the specified code serialization strategy. In
+        contrast, this method enables the user to directly provide an arbitrary source
+        code string and entrypoint function name.
+
+        .. important::
+
+            This method will ignore the current code serialization strategy and use
+            ``PureSourceTextInspect`` instead.
+
+        Parameters
+        ----------
+        source
+            The source code string or path to a file that contains the source code
+        function_name
+            The name of the entrypoint function within the source code
+        description
+            Description of the function source code
+        metadata
+            Function source code metadata (e.g., Python version)
+        public
+            Whether the function source code is publicly accessible
+        group
+            A globus group UUID to share this function source code with
+        ha_endpoint_id
+            Users will only be able to run this function source code on the specified
+            HA endpoint. Since HA functions cannot be shared, this argument is mutually
+            exclusive with the ``group`` and ``public`` arguments.
+
+        Returns
+        -------
+        function_id
+            UUID string of the registered function
+        """
+        filepath = pathlib.Path(source)
+        if filepath.is_file():
+            source = filepath.read_text()
+
+        # Simulate PureSourceTextInspect strategy
+        serde_iden = PureSourceTextInspect.identifier
+        serde_sep = PureSourceTextInspect._separator
+        serialized = f"{serde_iden}{function_name}{serde_sep}{source}"
+        packed = ComputeSerializer.pack_buffers([serialized])
+
+        if metadata:
+            metadata["serde_identifier"] = serde_iden.strip()
+            reg_meta = FunctionRegistrationMetadata(**metadata)
+        else:
+            reg_meta = FunctionRegistrationMetadata(
+                python_version=get_py_version_str(),
+                sdk_version=__version__,
+                serde_identifier=serde_iden.strip(),
+            )
+        data = FunctionRegistrationData(
+            function_code=packed,
+            function_name=function_name,
+            description=description,
+            metadata=reg_meta,
+            public=public,
+            group=group,
+            ha_endpoint_id=ha_endpoint_id,
+        )
+        logger.info("Registering function: %s", data.function_name)
+        logger.debug("Function data: %s", data)
+
+        with self._request_lock:
+            r = self._compute_web_client.v3.register_function(data.to_dict())
         self._raise_ha_warning(r.data)
 
         return r.data["function_uuid"]

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -5,6 +5,7 @@ import copy
 import json
 import logging
 import os
+import pathlib
 import queue
 import random
 import sys
@@ -504,7 +505,7 @@ class Executor(concurrent.futures.Executor):
             self._validated_result_serializers = [validate_strategylike(v) for v in val]
             self._result_serializers = val
 
-    def _fn_cache_key(self, fn: t.Callable):
+    def _fn_cache_key(self, fn: t.Callable | int):
         return fn, self.container_id
 
     def register_function(
@@ -578,6 +579,72 @@ class Executor(concurrent.futures.Executor):
         self._function_registry[fn_cache_key] = func_reg_id
         log.debug("Function registered with id: %s", func_reg_id)
         return func_reg_id
+
+    def register_source_code(
+        self,
+        source: str | pathlib.Path,
+        function_name: str,
+        **registration_kwargs,
+    ) -> str:
+        """Register arbitrary Python source code with entrypoint function
+
+        The standard ``.register_function()`` method expects a callable function object,
+        which it then serializes using the specified code serialization strategy. In
+        contrast, this method enables the user to directly provide an arbitrary source
+        code string and entrypoint function name.
+
+        As with ``.register_function()``, this method will store the registered function
+        source code and ``function_id`` in the ``Executor``'s cache. If a function is
+        already in the cache, this method raise a ``ValueError`` to help track down the
+        errant double registration attempt.
+
+        .. important::
+
+            This method will ignore the current code serialization strategy and use
+            ``PureSourceTextInspect`` instead.
+
+        Parameters
+        ----------
+        source
+            The source code string or path to a file that contains the source code
+        function_name
+            The name of the entrypoint function within the source code
+        registration_kwargs
+            Additional keyword arguments passed to ``Client.register_source_code()``
+
+        Returns
+        -------
+        function_id
+            UUID string of the registered function
+        """
+        if self._stopped:
+            raise RuntimeError(f"{self!r} is shutdown; refusing to register function")
+
+        filepath = pathlib.Path(source)
+        if filepath.is_file():
+            source = filepath.read_text()
+
+        fn_cache_key = self._fn_cache_key(hash(source))
+        if fn_cache_key in self._function_registry:
+            cached_fn_id = self._function_registry[fn_cache_key]
+            msg = f"Function already registered as function id: {cached_fn_id}"
+            log.error(msg)
+            raise ValueError(msg)
+
+        log.debug(f"Function not registered. Registering: {function_name}")
+
+        try:
+            fn_id = self.client.register_source_code(
+                source, function_name, **registration_kwargs
+            )
+        except Exception:
+            log.error(f"Unable to register function: {function_name}")
+            self.shutdown(wait=False, cancel_futures=True)
+            raise
+
+        self._function_registry[fn_cache_key] = fn_id
+        log.debug(f"Function registered with id: {fn_id}")
+        return fn_id
 
     def submit(self, fn, *args, **kwargs):
         """

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -50,7 +50,7 @@ class FunctionRegistrationData:
         description: t.Optional[str] = None,
         metadata: t.Optional[FunctionRegistrationMetadata] = None,
         public: bool = False,
-        group: t.Optional[str] = None,
+        group: t.Optional[UUID_LIKE_T] = None,
         serializer: t.Optional[ComputeSerializer] = None,
         ha_endpoint_id: t.Optional[UUID_LIKE_T] = None,
     ):

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -27,7 +27,7 @@ from globus_compute_sdk.sdk.web_client import (
     FunctionRegistrationMetadata,
     WebClient,
 )
-from globus_compute_sdk.serialize import ComputeSerializer
+from globus_compute_sdk.serialize import ComputeSerializer, DillCode
 from globus_compute_sdk.serialize.concretes import SELECTABLE_STRATEGIES
 from globus_sdk import ComputeClientV2, ComputeClientV3, GlobusAPIError, UserApp
 from globus_sdk import __version__ as __version_globus__
@@ -61,6 +61,7 @@ client_api_reqs = {
     gc.Client.delete_function: ("some func id",),
     gc.Client.register_endpoint: ("ep name", None),
     gc.Client.register_function: (lambda: "some function",),
+    gc.Client.register_source_code: ("some source", "some func name"),
     gc.Client.register_container: ("some loc", "some container type"),
     gc.Client.stop_endpoint: ("some ep id",),
 }
@@ -552,6 +553,57 @@ def test_function_registration_data_data_function(serde):
     assert frd.metadata.python_version == get_py_version_str()
     assert frd.metadata.sdk_version == __version__
     assert frd.metadata.serde_identifier == serde.code_serializer.identifier.strip()
+
+
+def test_register_source_code(gcc: gc.Client):
+    gcc._compute_web_client.v3.register_function.return_value = mock.MagicMock()
+    gcc.fx_serializer.code_serializer = DillCode()  # Set the stage
+
+    def hello(name: str):
+        return f"Hello, {name}!"
+
+    source = inspect.getsource(hello)
+    entrypoint = hello.__name__
+    description = "A warm greeting."
+    metadata = {
+        "python_version": platform.python_version(),
+        "sdk_version": __version__,
+        "serde_identifier": "st",  # PureSourceTextInspect
+    }
+
+    gcc.register_source_code(
+        source=source,
+        function_name=entrypoint,
+        description=description,
+    )
+
+    # Simulate PureSourceTextInspect strategy
+    serialized = f"st\n{entrypoint}:{source}"
+    function_code = ComputeSerializer.pack_buffers([serialized])
+
+    (data,), _ = gcc._compute_web_client.v3.register_function.call_args
+    assert data["function_code"] == function_code
+    assert data["function_name"] == entrypoint
+    assert data["description"] == description
+    assert data["meta"] == metadata
+
+
+def test_register_source_code_metadata_override(gcc: gc.Client):
+    gcc._compute_web_client.v3.register_function.return_value = mock.MagicMock()
+    metadata = {
+        "python_version": "3.11.5",
+        "sdk_version": "3.11.0",
+        "serde_identifier": "foo",
+    }
+
+    gcc.register_source_code(
+        source="def noop():\n    return\n", function_name="noop", metadata=metadata
+    )
+
+    (data,), _ = gcc._compute_web_client.v3.register_function.call_args
+    assert data["meta"]["python_version"] == metadata["python_version"]
+    assert data["meta"]["sdk_version"] == metadata["sdk_version"]
+    assert data["meta"]["serde_identifier"] == "st", "serde iden should always be 'st'"
 
 
 @pytest.mark.parametrize("desc", ("some desc", None))

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import concurrent.futures
+import inspect
+import pathlib
 import random
 import threading
 import typing as t
@@ -60,6 +62,7 @@ class MockedExecutor(Executor):
         # Unless test overrides, set default response:
         fn_id = str(uuid.uuid4())
         mock_client.register_function.return_value = fn_id
+        mock_client.register_source_code.return_value = fn_id
         mock_client.batch_run.return_value = {
             "tasks": {fn_id: [str(uuid.uuid4())]},
             "task_group_id": str(uuid.uuid4()),
@@ -521,6 +524,91 @@ def test_failed_registration_shuts_down_executor(gce, randomstring):
     e_str = str(pyt_e.value)
     assert "is shutdown" in e_str
     assert "refusing to register function" in e_str
+
+
+def test_register_source_code(gce: Executor, mock_log, randomstring):
+    source = inspect.getsource(noop)
+    function_name = noop.__name__
+    reg_kwargs = {randomstring(): randomstring() for _ in range(random.randint(2, 5))}
+
+    fn_id = gce.register_source_code(source, function_name, **reg_kwargs)
+
+    a, _ = mock_log.debug.call_args
+    assert "Function registered" in a[0]
+    assert fn_id in a[0]
+
+    a, k = gce.client.register_source_code.call_args
+    assert source in a
+    assert function_name in a
+    for key, val in reg_kwargs.items():
+        assert k[key] == val
+
+
+def test_register_source_code_filepath(gce: Executor, fs):
+    source = inspect.getsource(noop)
+    function_name = noop.__name__
+
+    path = pathlib.Path("/path/to/source.py")
+    fs.create_file(path)
+    path.write_text(source)
+
+    gce.register_source_code(path, function_name)
+
+    a, _ = gce.client.register_source_code.call_args
+    assert source in a
+
+
+def test_multiple_register_source_code_fails(gce: Executor, mock_log):
+    source = inspect.getsource(noop)
+    function_name = noop.__name__
+    fn_id = gce.register_source_code(source, function_name)
+
+    with pytest.raises(ValueError) as pyt_e:
+        gce.register_source_code(source, function_name)
+
+    a, _ = mock_log.error.call_args
+    assert "Function already registered" in a[0]
+    assert fn_id in a[0]
+
+    e_str = str(pyt_e.value)
+    assert "Function already registered" in e_str
+    assert fn_id in e_str
+    assert "attempted" not in e_str
+    assert not gce._stopped
+
+
+def test_failed_source_code_registration_shuts_down_executor(
+    gce: Executor, randomstring
+):
+    exc = RuntimeError(randomstring())
+    gcc = gce.client
+    gcc.register_source_code.side_effect = exc
+
+    source = inspect.getsource(noop)
+    function_name = noop.__name__
+    with pytest.raises(Exception) as pyt_exc:
+        gce.register_source_code(source, function_name)
+
+    assert pyt_exc.value is exc, "Expected raw exception raised"
+    try_assert(lambda: gce._stopped)
+
+    with pytest.raises(RuntimeError) as pyt_e:
+        gce.register_source_code(source, function_name)
+
+    e_str = str(pyt_e.value)
+    assert "is shutdown" in e_str
+    assert "refusing to register function" in e_str
+
+
+def test_register_source_code_executor_stopped(gce: Executor, fs):
+    source = inspect.getsource(noop)
+    function_name = noop.__name__
+
+    gce.shutdown()
+    with pytest.raises(RuntimeError) as pyt_e:
+        gce.register_source_code(source, function_name)
+
+    assert "refusing to register function" in str(pyt_e)
 
 
 def test_container_id_deprecated(gce: Executor):


### PR DESCRIPTION
# Description

Added new `Client` and `Executor` methods to enable registering arbitrary Python source code:

- `Client.register_source_code()`
- `Executor.register_source_code()`

The standard `.register_function()` methods expect callable function objects, which they then serialize using the specified code serialization strategy. In contrast, the `.register_source_code()` methods enable the user to directly provide an arbitrary source code string and entrypoint function name, which are then serialized using the `PureSourceTextInspect` strategy.

[sc-42893](https://app.shortcut.com/globus/story/42893/add-plain-string-serialization-strategy)

## Type of change

- New feature (non-breaking change that adds functionality)
