### PR TITLE
Reorganize and augment diagnostic output

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -5,7 +5,6 @@ import glob
 import gzip
 import io
 import os
-import platform
 import shlex
 import shutil
 import socket
@@ -262,7 +261,6 @@ def general_commands_list():
         "whoami",
         "pip freeze",
         print_openssl_version,
-        platform.processor,
         ifconfig_wrapper(),
         if_supported_on_os("ip addr"),
         if_supported_on_os("ip route"),

--- a/compute_sdk/globus_compute_sdk/sdk/hardware_report.py
+++ b/compute_sdk/globus_compute_sdk/sdk/hardware_report.py
@@ -8,25 +8,64 @@ import shutil
 import subprocess
 import sys
 
-from globus_compute_sdk.sdk.utils import display_name
+import psutil
+from globus_compute_sdk.sdk.utils import display_name, simple_humanize
+
+
+def _format_psmem(psdata: psutil.svmem | psutil.sswap) -> str:
+    data = psdata._asdict()
+    max_name_len = max(map(len, data.keys()))
+    max_val_len = max(map(len, map(str, data.values())))
+    lines = []
+    for fname, fval in data.items():
+        fname = fname.capitalize()
+        if fname == "Percent":
+            val = f"{fval:>6} % (used)"
+        else:
+            v, u = simple_humanize(fval)
+            val = f"{v:>6} {u + 'B':<3} ({fval:>{max_val_len}})"
+        lines.append(f"{fname:>{max_name_len}}: {val}")
+
+    return "\n".join(lines)
 
 
 @display_name("psutil.virtual_memory()")
 def mem_info() -> str:
     import psutil  # import here bc psutil is installed with endpoint but not sdk
 
-    svmem = psutil.virtual_memory()
-    return "\n".join(f"{k}: {v}" for k, v in svmem._asdict().items())
+    return _format_psmem(psutil.virtual_memory())
 
 
-@display_name("Python version")
-def python_version() -> str:
-    return str(sys.version)
+@display_name("psutil.swap_memory()")
+def swap_info() -> str:
+    import psutil  # import here bc psutil is installed with endpoint but not sdk
+
+    return _format_psmem(psutil.swap_memory())
 
 
-@display_name("Python interpreter location")
-def python_location() -> str:
-    return str(sys.executable)
+@display_name("python_runtime_host_info")
+def python_runtime_host_info() -> str:
+    return (
+        f"          Version: {sys.version}"
+        f"\n     Version info: {sys.version_info}"
+        f"\n Interpreter path: {sys.executable}"
+        "\n"
+        f"\n CPU architecture: {platform.processor()}"
+        f"\n   CPU core count: {os.cpu_count()}"
+        "\n"
+        f"\n        Node name: {platform.node()}"
+        f"\n         Platform: {platform.platform()}"
+        "\n"
+        f"\n             HOME: {os.getenv('HOME')}"
+        f"\n             USER: {os.getenv('USER')}"
+        f"\n         USERNAME: {os.getenv('USERNAME')}"
+        f"\n             LANG: {os.getenv('LANG')}"
+        f"\n  XDG_RUNTIME_DIR: {os.getenv('XDG_RUNTIME_DIR')}"
+        f"\n             PATH: {os.getenv('PATH')}"
+        f"\n      VIRTUAL_ENV: {os.getenv('VIRTUAL_ENV')}"
+        "\n"
+        f"\n              uid: {os.getuid()}"
+    )
 
 
 def cpu_info() -> str | None:
@@ -76,14 +115,12 @@ def hardware_commands_list() -> list:
     Commands that can also be useful in globus-compute-diagnostic
     """
     return [
-        platform.processor,
-        os.cpu_count,
+        python_runtime_host_info,
+        mem_info,
+        swap_info,
         cpu_info(),
         "nvidia-smi",
-        mem_info,
-        "df",
-        platform.node,
-        platform.platform,
+        "df -h",
     ]
 
 
@@ -102,8 +139,6 @@ def run_hardware_report(env: str | None = None) -> str:
     # SDK diagnostics or that we only want to run here
     commands.extend(
         [
-            python_version,
-            python_location,
             "lshw -C display",
             "globus-compute-endpoint version",
         ]

--- a/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
@@ -134,3 +134,12 @@ def display_name(name: str):
         return func
 
     return decorator
+
+
+def simple_humanize(num: int | float) -> tuple[str, str]:
+    unit = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei")
+    i = 0
+    while num >= 1024:
+        i += 1
+        num /= 1024.0
+    return f"{round(num, 1)}", unit[i]

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -7,10 +7,16 @@ import io
 import os
 import pathlib
 import platform
+import sys
 from unittest import mock
 
 import pytest
 from globus_compute_sdk.sdk.diagnostic import cat, do_diagnostic_base
+from globus_compute_sdk.sdk.hardware_report import (
+    mem_info,
+    python_runtime_host_info,
+    swap_info,
+)
 from globus_compute_sdk.sdk.web_client import WebClient
 from pytest_mock import MockFixture
 
@@ -453,3 +459,35 @@ def test_diagnostic_base_dir_GC_HOME_or_config_param(
                 do_diagnostic_base(diag_args)
             assert se.type == SystemExit
             assert se.value.code == os.EX_NOINPUT
+
+
+def test_python_host_info():
+    info = python_runtime_host_info()
+
+    assert f"Version: {sys.version}" in info
+    assert f"Version info: {sys.version_info}" in info
+    assert f"Interpreter path: {sys.executable}" in info
+
+    assert f"CPU architecture: {platform.processor()}" in info
+    assert f"CPU core count: {os.cpu_count()}" in info
+
+    assert f"Node name: {platform.node()}" in info
+    assert f"Platform: {platform.platform()}" in info
+
+    assert f"HOME: {os.getenv('HOME')}" in info
+    assert f"USER: {os.getenv('USER')}" in info
+    assert f"USERNAME: {os.getenv('USERNAME')}" in info
+    assert f"LANG: {os.getenv('LANG')}" in info
+    assert f"XDG_RUNTIME_DIR: {os.getenv('XDG_RUNTIME_DIR')}" in info
+    assert f"PATH: {os.getenv('PATH')}" in info
+    assert f"VIRTUAL_ENV: {os.getenv('VIRTUAL_ENV')}" in info
+
+    assert f"uid: {os.getuid()}" in info
+
+
+def test_mem_swap_info():
+    minfo = mem_info()
+    sinfo = swap_info()
+
+    assert "iB " in minfo, "Expect humanization of output"
+    assert "iB " in sinfo, "Expect humanization of output"


### PR DESCRIPTION
The main motivation was to add Python version information (`sys.version_info`).  While here, implement a mild reorganization of the output, mostly to consolidate some of the high-level info into a single section, and also format the memory output (humanize the numbers).

[sc-45335]

## Type of change

- New feature (non-breaking change that adds functionality) [Python version info, swap info, updated formatting, consolidation]