### PR TITLE
Add migrate-to-template-capable command

### DIFF
--- a/changelog.d/20250923_152715_chris_migrate_template_capable_sc_42253.rst
+++ b/changelog.d/20250923_152715_chris_migrate_template_capable_sc_42253.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Existing endpoints that do not support configuration templates can be migrated using
+  the new ``migrate-to-template-capable`` command in the ``globus-compute-endpoint``
+  CLI.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -997,7 +997,7 @@ class EndpointManager:
             if uname == p_uname or uid == os.getuid():
                 raise InvalidUserError(
                     "Requested UID is same as Manager Endpoint UID on a user-mapped"
-                    " Manager Endpoint. To allow the same UID to run tasks, consider: "
+                    " Manager Endpoint. To allow the same UID to run tasks, consider:"
                     "\n * using a non-root user,"
                     "\n * removing privileges from the UID, or"
                     "\n * removing the identity mapping configuration file"

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -18,8 +18,12 @@ from unittest import mock
 
 import pytest
 import requests
+import yaml
 from globus_compute_endpoint.endpoint import endpoint
-from globus_compute_endpoint.endpoint.config import UserEndpointConfig
+from globus_compute_endpoint.endpoint.config import (
+    ManagerEndpointConfig,
+    UserEndpointConfig,
+)
 from globus_compute_endpoint.endpoint.config.utils import serialize_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.engines import (
@@ -70,6 +74,12 @@ def mock_launch():
 
 
 @pytest.fixture
+def mock_get_config():
+    with mock.patch(f"{_mock_base}get_config") as m:
+        yield m
+
+
+@pytest.fixture
 def conf():
     _conf = UserEndpointConfig(engine=ThreadPoolEngine)
     _conf.source_content = "# test source content"
@@ -97,6 +107,14 @@ def mock_ep_buf():
         Endpoint.print_endpoint_table, conf_dir="unused", ofile=buf
     )
     yield buf
+
+
+@pytest.fixture
+def mock_ep_dir(fs, mock_ep_data, mock_get_config):
+    ep, ep_dir, *_, conf = mock_ep_data
+    mock_get_config.return_value = conf
+    ep._config_file_path(ep_dir).write_text(conf.source_content)
+    yield ep, ep_dir
 
 
 @pytest.fixture
@@ -831,3 +849,131 @@ def test_update_config_file_retains_order(fs):
 
     target_config = target_path.read_text()
     assert original_config == target_config
+
+
+@pytest.mark.parametrize(
+    "config_keys",
+    (
+        (
+            "admins",
+            "display_name",
+            "allowed_functions",
+            "authentication_policy",
+            "subscription_id",
+            "debug",
+            "amqp_port",
+            "heartbeat_period",
+        ),
+        (
+            "admins",
+            "display_name",
+            "allowed_functions",
+            "authentication_policy",
+            "subscription_id",
+        ),
+        ("foo", "bar", "baz"),
+        ("debug", "amqp_port", "heartbeat_period"),
+        ("admins", "foo", "debug", "bar"),
+    ),
+)
+def test_migrate_to_template_capable_success(
+    fs, mock_ep_data, mock_get_config, config_keys
+):
+    ep, ep_dir, *_ = mock_ep_data
+    config_dict = {k: "some value" for k in config_keys}
+    mock_get_config.return_value = SimpleNamespace(
+        source_content=yaml.dump(config_dict)
+    )
+    ep._config_file_path(ep_dir).write_text(yaml.safe_dump(config_dict))
+
+    ep.migrate_to_template_capable(ep_dir)
+
+    assert ep._config_file_path(ep_dir).exists()
+    assert ep.user_config_template_path(ep_dir).exists()
+
+    new_conf = yaml.safe_load(ep._config_file_path(ep_dir).open())
+    for k in new_conf:
+        assert k in config_dict
+
+    new_templ = yaml.safe_load(ep.user_config_template_path(ep_dir).open())
+    for k in new_templ:
+        assert k in config_dict
+
+    config_only_keys = {
+        "admins",
+        "display_name",
+        "allowed_functions",
+        "authentication_policy",
+        "subscription_id",
+    }
+
+    shared_keys = {
+        "debug",
+        "amqp_port",
+        "heartbeat_period",
+    }
+
+    for k in config_dict:
+        assert k in new_conf or k in new_templ
+        if k in config_only_keys:
+            assert k in new_conf
+            assert k not in new_templ
+            v = new_conf[k]
+        elif k in shared_keys:
+            assert k in new_conf
+            assert k in new_templ
+            v = new_conf[k]
+            assert v == new_templ[k]
+        else:
+            assert k not in new_conf
+            assert k in new_templ
+            v = new_templ[k]
+        assert v == config_dict[k]
+
+
+def test_migrate_to_template_capable_already_template_capable(mock_get_config):
+    mock_config_path = pathlib.Path("some/config/dir")
+    mock_get_config.return_value = mock.Mock(spec=ManagerEndpointConfig)
+
+    with pytest.raises(ValueError) as pyt_exc:
+        Endpoint.migrate_to_template_capable(mock_config_path)
+
+    assert mock_config_path.name in str(pyt_exc)
+    assert "already template capable" in str(pyt_exc)
+
+
+def test_migrate_to_template_capable_endpoint_running(mock_ep_dir, mocker):
+    _, ep_dir = mock_ep_dir
+    mocker.patch(f"{_mock_base}Endpoint.check_pidfile").return_value = {"active": True}
+
+    with pytest.raises(ValueError) as pyt_exc:
+        Endpoint.migrate_to_template_capable(ep_dir)
+
+    assert ep_dir.name in str(pyt_exc)
+    assert "currently running" in str(pyt_exc)
+
+
+def test_migrate_to_template_capable_backs_up(mock_ep_dir):
+    ep, ep_dir = mock_ep_dir
+
+    ep.migrate_to_template_capable(ep_dir)
+
+    config_backup = ep._config_file_path(ep_dir)
+    config_backup = config_backup.with_name(config_backup.name + ".backup")
+
+    assert config_backup.exists()
+
+
+def test_migrate_to_template_capable_backup_exists(mock_ep_dir):
+    ep, ep_dir = mock_ep_dir
+
+    backup_path = ep._config_file_path(ep_dir)
+    backup_path = backup_path.with_name(backup_path.name + ".backup")
+    backup_path.touch()
+
+    with pytest.raises(FileExistsError) as pyt_exc:
+        ep.migrate_to_template_capable(ep_dir)
+
+    assert backup_path.name in str(pyt_exc)
+    assert "back up" in str(pyt_exc)
+    assert "already exists" in str(pyt_exc)


### PR DESCRIPTION
# Description

Adds a command users can run to migrate existing, non-template-capable endpoints to become template capable. Warns users if they run a non-template-capable endpoint and informs them of the new command.

[[sc-42253]](https://app.shortcut.com/globus/story/42253/create-default-management-config-file-for-existing-single-user-endpoints)

## Type of change

- New feature (non-breaking change that adds functionality)
