### PR TITLE
Add ignore to pip-audit to fix build for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,12 +27,14 @@ jobs:
         run: |
           cd compute_sdk
           tox -e mypy
-          tox -e pip-audit
+          # Temporary ignore see https://github.com/pypa/pip/issues/13607
+          tox -e pip-audit -- --ignore GHSA-4xh5-x5gv-qwph
       - name: mypy and pip-audit (endpoint)
         run: |
           cd compute_endpoint
           tox -e mypy
-          tox -e pip-audit
+          # Temporary ignore see https://github.com/pypa/pip/issues/13607
+          tox -e pip-audit -- --ignore GHSA-4xh5-x5gv-qwph
 
   # ensure docs can build, imitating the RTD build as best we can
   check-docs:


### PR DESCRIPTION
A new vulnerability/issue in ``pip`` Noted [here](https://github.com/pypa/pip/issues/13522#issuecomment-3353955654) with issue tracked [here](https://github.com/pypa/pip/issues/13607) is breaking all builds that use pip-audit.

This PR adds an ignore while we figure out a medium term solution - upgrade python versions/packages if necessary, wait for a decision/change w.r.t. pip 25.2, or wait for 25.3.

globus-python (GCS/Transfer) is 3.9.18, and the tutorial EP Dockerfile pins 3.11.8, which are the only related specific pins I can find.  They are both above the list of secure, can-ignore PY versions as stated in the issue, ``Python >=3.9.17, >=3.10.12, >=3.11.4, or >=3.12``