### PR TITLE
Clear environment variables

### DIFF
--- a/changelog.d/20251006_162634_kevin_clear_environ_immediately_after_fork.rst
+++ b/changelog.d/20251006_162634_kevin_clear_environ_immediately_after_fork.rst
@@ -1,0 +1,10 @@
+Bug Fixes
+^^^^^^^^^
+
+- Clear environment immediately after ``fork()``, prior even to dropping
+  privileges.  (The environment was already cleared prior to ``exec()`` ing the
+  child UEP, but there's no sense in waiting during the pre-exec phase.)  For
+  the motivating behavior, ``GLOBUS_COMPUTE_USER_DIR`` will no longer be
+  transparently passed to the child process.  All UEP environment variables
+  must be set statically via the :ref:`user-environment-yaml` UEP configuration
+  file or using :ref:`pam`.

--- a/compute_endpoint/tests/unit/test_mep_audit_log.py
+++ b/compute_endpoint/tests/unit/test_mep_audit_log.py
@@ -16,7 +16,7 @@ from globus_compute_endpoint.endpoint.endpoint_manager import (
 from tests.utils import try_assert
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
-_GOOD_UNPRIVILEGED_EC = 85
+_GOOD_UNPRIVILEGED_EC = 84
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -41,6 +41,12 @@ def tell_fakefs_to_goaway():
 def mock_log():
     with mock.patch(f"{_MOCK_BASE}log", spec=logging.Logger) as m:
         m.getEffectiveLevel.return_value = logging.DEBUG
+        yield m
+
+
+@pytest.fixture
+def mock_close_fds():
+    with mock.patch(f"{_MOCK_BASE}close_all_fds") as m:
         yield m
 
 
@@ -194,7 +200,9 @@ def test_audit_log_shutsdown_on_general_error(
     assert em._time_to_stop is True, "Expect shutdown, no matter the error"
 
 
-def test_audit_log_pipe_hookup(mock_log, tmp_path, ep_uuid, conf, reg_info, mock_os):
+def test_audit_log_pipe_hookup(
+    mock_log, tmp_path, ep_uuid, conf, reg_info, mock_os, mock_close_fds
+):
     em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
 
     m = mock.Mock()

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -444,6 +444,8 @@ schema.
 Please refer to the :ref:`template-variable-validation` section of :doc:`templates`
 for more information.
 
+.. _user-environment-yaml:
+
 ``user_environment.yaml``
 -------------------------
 


### PR DESCRIPTION
Even though the final `exec()` call specifies a new environment, there's no need to keep the preexec environ the same as the parent environ.  While not a security bug, keeping the environ for longer than necessary can lead to confusing log messages and has caused concern with at least one user.

Remedy the concern by clearing the environment immediately.  Similarly, also close file descriptors immediately after fork().

Finally, implement an eager `gc.collect()` in an attempt to avoid a later-on traceback log in the pre-exec phase.  The traceback is only scary when user's go looking in the logs (so, "not professional"), but is inconsequential as the memory-space is wiped by the `exec()` call.  (And move some logic into an ad-hoc function for a similar reason: collectability.)

[sc-43531]

## Type of change

- Bug fix (non-breaking change that fixes an issue)