### PR TITLE
Replace 'GLOBUS_COMPUTE_USER_DIR' usage with constant

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -55,7 +55,11 @@ from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.auth.whoami import print_whoami_info
 from globus_compute_sdk.sdk.batch import create_user_runtime
-from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir, get_compute_dir
+from globus_compute_sdk.sdk.compute_dir import (
+    COMPUTE_DIR_ENV,
+    ensure_compute_dir,
+    get_compute_dir,
+)
 from globus_compute_sdk.sdk.utils.gare import gare_handler
 from globus_sdk import MISSING, AuthClient, GlobusAPIError, MissingType, NetworkError
 
@@ -106,7 +110,7 @@ class CommandState:
 def config_dir_callback(ctx, param, value) -> pathlib.Path:
     try:
         if value:
-            os.environ["GLOBUS_COMPUTE_USER_DIR"] = value
+            os.environ[COMPUTE_DIR_ENV] = value
         return ensure_compute_dir()
     except (FileExistsError, PermissionError) as e:
         raise ClickException(str(e))

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -15,6 +15,7 @@ from globus_compute_endpoint.endpoint.config import UserEndpointConfig
 from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.client import _ComputeWebClient
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_DIR_ENV
 from globus_sdk import GlobusAPIError, UserApp
 from pytest_mock import MockFixture
 
@@ -62,7 +63,7 @@ def patch_compute_client(mocker: MockFixture):
 
 
 def test_non_configured_endpoint(tmp_path):
-    env = {"GLOBUS_COMPUTE_USER_DIR": str(tmp_path)}
+    env = {COMPUTE_DIR_ENV: str(tmp_path)}
     with mock.patch.dict(os.environ, env):
         result = CliRunner().invoke(app, ["start", "newendpoint"])
         assert "newendpoint" in result.stderr

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -46,7 +46,7 @@ from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.auth.globus_app import UserApp
-from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_DIR_ENV, ensure_compute_dir
 from globus_sdk import MISSING, GlobusAPIError, NetworkError
 from pytest_mock import MockFixture
 
@@ -63,9 +63,7 @@ def reset_umask():
 
 @pytest.fixture
 def mock_user_dir_env(tmp_path):
-    with mock.patch.dict(
-        os.environ, {"GLOBUS_COMPUTE_USER_DIR": str(tmp_path.resolve())}
-    ):
+    with mock.patch.dict(os.environ, {COMPUTE_DIR_ENV: str(tmp_path.resolve())}):
         yield tmp_path
 
 
@@ -325,9 +323,7 @@ def test_init_config_dir(fs, dir_exists, user_dir):
 
     if user_dir is not None:
         config_dirname = pathlib.Path(user_dir)
-        with mock.patch.dict(
-            os.environ, {"GLOBUS_COMPUTE_USER_DIR": str(config_dirname)}
-        ):
+        with mock.patch.dict(os.environ, {COMPUTE_DIR_ENV: str(config_dirname)}):
             dirname = ensure_compute_dir()
     else:
         dirname = ensure_compute_dir()
@@ -353,9 +349,7 @@ def test_init_config_dir_permission_error(fs):
     os.chmod(parent_dirname, 0o000)
 
     with pytest.raises(ClickException) as exc:
-        with mock.patch.dict(
-            os.environ, {"GLOBUS_COMPUTE_USER_DIR": str(config_dirname)}
-        ):
+        with mock.patch.dict(os.environ, {COMPUTE_DIR_ENV: str(config_dirname)}):
             config_dir_callback(None, None, str(config_dirname))
 
     assert "Permission denied" in str(exc)

--- a/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
+++ b/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+COMPUTE_DIR_ENV = "GLOBUS_COMPUTE_USER_DIR"
+
 
 def get_compute_dir() -> Path:
     """
@@ -12,7 +14,7 @@ def get_compute_dir() -> Path:
     """
     # This is either set by the user via GLOBUS_COMPUTE_USER_DIR
     #  or by the cli argument --config-dir via overriding the env var
-    if env_dir := os.environ.get("GLOBUS_COMPUTE_USER_DIR"):
+    if env_dir := os.environ.get(COMPUTE_DIR_ENV):
         return Path(env_dir)
     else:
         return Path.home() / ".globus_compute"

--- a/compute_sdk/tests/unit/conftest.py
+++ b/compute_sdk/tests/unit/conftest.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 import requests
-from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_DIR_ENV, ensure_compute_dir
 from globus_sdk import GlobusHTTPResponse
 
 
@@ -42,7 +42,7 @@ def run_in_tmp_dir(tmp_path):
 @pytest.fixture
 def mock_gc_home(tmp_path):
     env = os.environ.copy()
-    env["GLOBUS_COMPUTE_USER_DIR"] = str(tmp_path / "home/mock_gc")
+    env[COMPUTE_DIR_ENV] = str(tmp_path / "home/mock_gc")
     with mock.patch.dict(os.environ, env):
         yield ensure_compute_dir().absolute()
 
@@ -52,7 +52,7 @@ def mock_gc_home_other(tmp_path):
     def _mock_base_dir(base_dir: str):
         env = os.environ.copy()
         base_absolute_dir = str((tmp_path / base_dir).absolute())
-        env["GLOBUS_COMPUTE_USER_DIR"] = base_absolute_dir
+        env[COMPUTE_DIR_ENV] = base_absolute_dir
         with mock.patch.dict(os.environ, env):
             return ensure_compute_dir().absolute()
 

--- a/compute_sdk/tests/unit/test_compute_dir.py
+++ b/compute_sdk/tests/unit/test_compute_dir.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 
 import pytest
-from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_DIR_ENV, ensure_compute_dir
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 
@@ -26,10 +26,10 @@ def test_ensure_compute_dir(
     if env_dir is not None:
         # Override ~/.globus_compute if env var is set
         dirname = pathlib.Path(env_dir)
-        monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(dirname))
+        monkeypatch.setenv(COMPUTE_DIR_ENV, str(dirname))
         expected_dirname = pathlib.Path(env_dir)
     else:
-        monkeypatch.delenv("GLOBUS_COMPUTE_USER_DIR", raising=False)
+        monkeypatch.delenv(COMPUTE_DIR_ENV, raising=False)
 
     actual_compute_dir = ensure_compute_dir()
 
@@ -46,9 +46,9 @@ def test_conflicting_compute_file(
 
     with pytest.raises(FileExistsError) as exc:
         if user_dir_defined:
-            monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(filename))
+            monkeypatch.setenv(COMPUTE_DIR_ENV, str(filename))
         else:
-            monkeypatch.delenv("GLOBUS_COMPUTE_USER_DIR", raising=False)
+            monkeypatch.delenv(COMPUTE_DIR_ENV, raising=False)
         ensure_compute_dir()
 
     assert "Error creating directory" in str(exc)
@@ -62,7 +62,7 @@ def test_restricted_user_dir(fs: FakeFilesystem, monkeypatch: pytest.MonkeyPatch
     os.chmod(parent_dirname, 0o000)
 
     with pytest.raises(PermissionError) as exc:
-        monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(compute_dirname))
+        monkeypatch.setenv(COMPUTE_DIR_ENV, str(compute_dirname))
         ensure_compute_dir()
 
     assert "Permission denied" in str(exc)

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -11,6 +11,7 @@ import sys
 from unittest import mock
 
 import pytest
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_DIR_ENV
 from globus_compute_sdk.sdk.diagnostic import (
     cat,
     do_diagnostic_base,
@@ -489,7 +490,7 @@ def test_diagnostic_base_dir_GC_HOME_or_config_param(
         compute_dir = "home/gc_home"
     base_dir_absolute = (tmp_path / compute_dir).absolute()
     env = os.environ.copy()
-    env["GLOBUS_COMPUTE_USER_DIR"] = str(base_dir_absolute)
+    env[COMPUTE_DIR_ENV] = str(base_dir_absolute)
     with mock.patch.dict(os.environ, env):
         test_config = mock_endpoint_config_dir_data(base_dir_absolute, ep_names)
         print(f"test_config base={test_config.values()}")


### PR DESCRIPTION
# Description

"GLOBUS_COMPUTE_USER_DIR" is used as a string in many places in our code and tests.  Defining it as a constant one one place and referencing it is obviously the better practice.  Remaining occurrences are now only in documentation and comments.

This is extracted from and is a pre-cursor to the log_dir PR.

## Type of change

- Code maintenance/cleanup
