### PR TITLE
Ensure tests don't leak env vars

### DIFF
--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -71,6 +71,17 @@ def reset_signals():
         signal.signal(sig, sigh)
 
 
+@pytest.fixture(autouse=True)
+def verify_all_tests_reset_environ():
+    orig_environ = dict(os.environ)
+    yield
+    assert set(orig_environ.keys()) == set(os.environ.keys())
+    for k in os.environ:
+        if k.startswith("PYTEST_"):
+            continue
+        assert os.environ[k] == orig_environ[k], f"Environ {k} not reset"
+
+
 @pytest.fixture(scope="session")
 def endpoint_uuid():
     return str(uuid.UUID(int=0))

--- a/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
@@ -1,3 +1,4 @@
+import os
 import random
 import typing as t
 from unittest import mock
@@ -49,7 +50,8 @@ def test_engine_submit(
     arg = random.randint(0, 10000)
     task_bytes = ez_pack_task(double, arg)
     f = GCFuture(task_uuid)
-    engine.submit(f, task_bytes, resource_specification={})
+    with mock.patch.dict(os.environ):
+        engine.submit(f, task_bytes, resource_specification={})
     packed_result = f.result()
 
     # Confirm that the future got the right answer
@@ -80,12 +82,13 @@ def test_engine_working_dir(
     task_args: tuple = (ez_pack_task(get_cwd), {})
 
     fut1 = GCFuture(task_uuid)
-    engine.submit(fut1, *task_args)
-    unpacked1 = messagepack.unpack(fut1.result())  # blocks; avoid race condition
-
     fut2 = GCFuture(task_uuid)
-    engine.submit(fut2, *task_args)  # exact same task
-    unpacked2 = messagepack.unpack(fut2.result())
+    with mock.patch.dict(os.environ):
+        engine.submit(fut1, *task_args)
+        unpacked1 = messagepack.unpack(fut1.result())  # blocks; avoid race condition
+
+        engine.submit(fut2, *task_args)  # exact same task
+        unpacked2 = messagepack.unpack(fut2.result())
 
     # data is enough for test, but in error case, be kind to dev
     assert isinstance(unpacked1, Result)

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import importlib
+import os
 import random
 import uuid
 from unittest import mock
@@ -77,7 +78,8 @@ def test_success_after_fails(mock_gce, serde, ez_pack_task, fail_count):
 
     engine.executor.fail_count = fail_count
     f = GCFuture(task_id)
-    engine.submit(f, task_bytes, resource_specification={})
+    with mock.patch.dict(os.environ):
+        engine.submit(f, task_bytes, resource_specification={})
 
     packed_result: bytes = f.result()
     result = messagepack.unpack(packed_result)

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -1283,8 +1283,9 @@ def test_name_or_uuid_decorator(tmp_path, mocker, run_line, name, uuid):
 
     mock__start_epm = mocker.patch(f"{_MOCK_BASE}_start_endpoint_manager")
 
-    run_line(f"-c {gc_conf_dir} start {name}")
-    run_line(f"-c {gc_conf_dir} start {uuid}")
+    with mock.patch.dict(os.environ):
+        run_line(f"-c {gc_conf_dir} start {name}")
+        run_line(f"-c {gc_conf_dir} start {uuid}")
 
     assert mock__start_epm.call_count == 2
 

--- a/compute_endpoint/tests/unit/test_execute_task.py
+++ b/compute_endpoint/tests/unit/test_execute_task.py
@@ -62,11 +62,12 @@ def sleeper(t: float):
 
 @pytest.mark.parametrize("run_dir", ("", ".", "./", "../", "tmp", "$HOME"))
 def test_bad_run_dir(endpoint_uuid, task_uuid, run_dir):
-    with pytest.raises(ValueError):  # not absolute
-        execute_task(task_uuid, b"", endpoint_uuid, run_dir=run_dir)
+    with mock.patch.dict(os.environ):
+        with pytest.raises(ValueError):  # not absolute
+            execute_task(task_uuid, b"", endpoint_uuid, run_dir=run_dir)
 
-    with pytest.raises(TypeError):  # not anything, allow-any-type language
-        execute_task(task_uuid, b"", endpoint_uuid, run_dir=None)
+        with pytest.raises(TypeError):  # not anything, allow-any-type language
+            execute_task(task_uuid, b"", endpoint_uuid, run_dir=None)
 
 
 def test_happy_path(serde, caplog, task_uuid, ez_pack_task, execute_task_runner):
@@ -75,8 +76,9 @@ def test_happy_path(serde, caplog, task_uuid, ez_pack_task, execute_task_runner)
 
     task_bytes = ez_pack_task(divide, divisor * out, divisor)
 
-    with caplog.at_level(logging.DEBUG):
-        packed_result = execute_task_runner(task_bytes)
+    with mock.patch.dict(os.environ):
+        with caplog.at_level(logging.DEBUG):
+            packed_result = execute_task_runner(task_bytes)
     assert isinstance(packed_result, bytes)
 
     result = messagepack.unpack(packed_result)
@@ -103,14 +105,15 @@ def test_happy_path(serde, caplog, task_uuid, ez_pack_task, execute_task_runner)
 
 
 def test_sandbox(task_10_2, execute_task_runner, task_uuid, tmp_path):
-    packed_result = execute_task_runner(task_10_2, run_in_sandbox=True)
-    result = messagepack.unpack(packed_result)
-    assert result.task_id == task_uuid
-    assert result.error_details is None, "Verify test setup: execution successful"
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task_runner(task_10_2, run_in_sandbox=True)
+        result = messagepack.unpack(packed_result)
+        assert result.task_id == task_uuid
+        assert result.error_details is None, "Verify test setup: execution successful"
 
-    exp_dir = tmp_path / str(task_uuid)
-    assert os.environ.get("GC_TASK_SANDBOX_DIR") == str(exp_dir), "Share dir w/ func"
-    assert os.getcwd() == str(exp_dir), "Expect sandbox dir entered"
+        exp_dir = tmp_path / str(task_uuid)
+        assert os.environ.get("GC_TASK_SANDBOX_DIR") == str(exp_dir), "Shared w/ func"
+        assert os.getcwd() == str(exp_dir), "Expect sandbox dir entered"
 
 
 def test_nested_run_dir(task_10_2, task_uuid, tmp_path):
@@ -118,7 +121,8 @@ def test_nested_run_dir(task_10_2, task_uuid, tmp_path):
     nested_path = nested_root / "b/c/d"
     assert not nested_root.exists(), "Verify test setup"
 
-    packed_result = execute_task(task_10_2, task_uuid, run_dir=nested_path)
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task(task_10_2, task_uuid, run_dir=nested_path)
 
     result = messagepack.unpack(packed_result)
     assert result.error_details is None, "Verify test setup: execution successful"
@@ -134,16 +138,17 @@ def test_result_size_limit(serde, task_10_2, execute_task_runner, size_limit):
 
     with mock.patch(f"{_MOCK_BASE}ComputeSerializer.serialize_from_list") as mock_ser:
         with mock.patch(f"{_MOCK_BASE}log.exception"):  # silence tests
-            mock_ser.return_value = res_data_good
-            res_bytes = execute_task_runner(task_10_2, result_size_limit=size_limit)
-            result = messagepack.unpack(res_bytes)
-            assert result.data == res_data_good
+            with mock.patch.dict(os.environ):
+                mock_ser.return_value = res_data_good
+                res_bytes = execute_task_runner(task_10_2, result_size_limit=size_limit)
+                result = messagepack.unpack(res_bytes)
+                assert result.data == res_data_good
 
-            mock_ser.return_value = res_data_bad
-            res_bytes = execute_task_runner(task_10_2, result_size_limit=size_limit)
-            result = messagepack.unpack(res_bytes)
-            assert exp_data == result.data
-            assert result.error_details.code == "MaxResultSizeExceeded"
+                mock_ser.return_value = res_data_bad
+                res_bytes = execute_task_runner(task_10_2, result_size_limit=size_limit)
+                result = messagepack.unpack(res_bytes)
+                assert exp_data == result.data
+                assert result.error_details.code == "MaxResultSizeExceeded"
 
 
 def test_default_result_size_limit(task_10_2, execute_task_runner):
@@ -154,29 +159,32 @@ def test_default_result_size_limit(task_10_2, execute_task_runner):
 
     with mock.patch(f"{_MOCK_BASE}ComputeSerializer.serialize_from_list") as mock_ser:
         with mock.patch(f"{_MOCK_BASE}log.exception"):  # silence tests
-            mock_ser.return_value = res_data_good
-            res_bytes = execute_task_runner(task_10_2)
-            result = messagepack.unpack(res_bytes)
-            assert result.data == res_data_good
+            with mock.patch.dict(os.environ):
+                mock_ser.return_value = res_data_good
+                res_bytes = execute_task_runner(task_10_2)
+                result = messagepack.unpack(res_bytes)
+                assert result.data == res_data_good
 
-            mock_ser.return_value = res_data_bad
-            res_bytes = execute_task_runner(task_10_2)
-            result = messagepack.unpack(res_bytes)
-            assert exp_data == result.data
-            assert result.error_details.code == "MaxResultSizeExceeded"
+                mock_ser.return_value = res_data_bad
+                res_bytes = execute_task_runner(task_10_2)
+                result = messagepack.unpack(res_bytes)
+                assert exp_data == result.data
+                assert result.error_details.code == "MaxResultSizeExceeded"
 
 
 @pytest.mark.parametrize("size_limit", (-5, 0, 1, 65, 127))
 def test_invalid_result_size_limit(size_limit):
     with pytest.raises(ValueError) as pyt_e:
-        execute_task("test_tid", b"", run_dir="/", result_size_limit=5)
+        with mock.patch.dict(os.environ):
+            execute_task("test_tid", b"", run_dir="/", result_size_limit=5)
     assert "must be at least" in str(pyt_e.value)
 
 
 def test_task_excepts(ez_pack_task, execute_task_runner, mock_log):
     task_bytes = ez_pack_task(divide, 10, 0)
 
-    packed_result = execute_task_runner(task_bytes)
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task_runner(task_bytes)
 
     assert mock_log.exception.called
     a, _k = mock_log.exception.call_args
@@ -218,13 +226,14 @@ def test_deserializers_enforced(mock_log, execute_task_runner, task_uuid, ser, d
 
     task_bytes = pack_task(divide, 10, 2)
 
-    packed_result = execute_task_runner(
-        task_bytes,
-        task_deserializers=[
-            f"{des.__module__}.{des.__qualname__}",
-            "globus_compute_sdk.serialize.JSONData",
-        ],
-    )
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task_runner(
+            task_bytes,
+            task_deserializers=[
+                f"{des.__module__}.{des.__qualname__}",
+                "globus_compute_sdk.serialize.JSONData",
+            ],
+        )
 
     result = messagepack.unpack(packed_result)
     assert isinstance(result, messagepack.message_types.Result)
@@ -234,9 +243,10 @@ def test_deserializers_enforced(mock_log, execute_task_runner, task_uuid, ser, d
 
 
 def test_result_serializers(task_10_2, execute_task_runner, task_uuid):
-    packed_result = execute_task_runner(
-        task_10_2, result_serializers=["globus_compute_sdk.serialize.JSONData"]
-    )
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task_runner(
+            task_10_2, result_serializers=["globus_compute_sdk.serialize.JSONData"]
+        )
 
     result = messagepack.unpack(packed_result)
     assert isinstance(result, messagepack.message_types.Result)
@@ -252,10 +262,11 @@ def test_result_serializers(task_10_2, execute_task_runner, task_uuid):
 def test_bad_result_serializer_list(
     task_10_2, execute_task_runner, task_uuid, unknown_strategy
 ):
-    packed_result = execute_task_runner(
-        task_10_2,
-        result_serializers=["not a strategy", unknown_strategy, CombinedCode],
-    )
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task_runner(
+            task_10_2,
+            result_serializers=["not a strategy", unknown_strategy, CombinedCode],
+        )
 
     result = messagepack.unpack(packed_result)
     assert isinstance(result, messagepack.message_types.Result)
@@ -276,7 +287,8 @@ def test_bad_result_serializer_list(
 
 def test_not_a_task_handled_gracefully(tmp_path, mock_log, task_uuid):
     task_bytes = messagepack.pack(TaskCancel(task_id=task_uuid))
-    raw = execute_task(task_bytes, task_uuid, run_dir=tmp_path)
+    with mock.patch.dict(os.environ):
+        raw = execute_task(task_bytes, task_uuid, run_dir=tmp_path)
     res = messagepack.unpack(raw)
 
     assert res.task_id == task_uuid, "Sanity check"

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -124,7 +124,10 @@ def test_execute_task_working_dir(
 ):
     assert os.getcwd() != str(tmp_path)
     task_bytes = ez_pack_task(get_cwd)
-    packed_result = execute_task(task_bytes, task_uuid, endpoint_uuid, run_dir=tmp_path)
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task(
+            task_bytes, task_uuid, endpoint_uuid, run_dir=tmp_path
+        )
 
     message = messagepack.unpack(packed_result)
     assert message.task_id == task_uuid
@@ -139,13 +142,14 @@ def test_sandbox(tmp_path, reset_cwd, serde, endpoint_uuid, task_uuid, ez_pack_t
     os.chdir(tmp_path)
 
     task_bytes = ez_pack_task(get_cwd)
-    packed_result = execute_task(
-        task_bytes,
-        task_uuid,
-        endpoint_uuid,
-        run_dir=tmp_path,
-        run_in_sandbox=True,
-    )
+    with mock.patch.dict(os.environ):
+        packed_result = execute_task(
+            task_bytes,
+            task_uuid,
+            endpoint_uuid,
+            run_dir=tmp_path,
+            run_in_sandbox=True,
+        )
 
     message = messagepack.unpack(packed_result)
     assert message.task_id == task_uuid


### PR DESCRIPTION
Add a fixture to detect when a test is misbehaving; the tests should not leave the environment in a dirty state.

An alternative approach might be to ensure the environment isn't leaked by simply resetting it between tests, but I opted to error instead as a clue to test authors to ensure they're cleaning up after themselves as a matter of "good habit."

To the reviewer: the core change is the new `autouse=True` fixture in the top-level `conftest.py`.  The rest of the changes are basically adding a mock of `os.environ` where the fixture identified.

## Type of change

- Code maintenance/cleanup