### PR TITLE
Fix failing test_engine_submit case

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
@@ -52,7 +52,7 @@ def test_engine_submit(
     f = GCFuture(task_uuid)
     with mock.patch.dict(os.environ):
         engine.submit(f, task_bytes, resource_specification={})
-    packed_result = f.result()
+        packed_result = f.result()
 
     # Confirm that the future got the right answer
     assert isinstance(packed_result, bytes)


### PR DESCRIPTION
# Description

After introducing an autouse fixture that catches any leaky env vars
hanging around after a test, test_engine_submit[ThreadPoolEngine]
started occasionally failing that autouse fixture. Engines are expected
to write env vars, and we already wrapped engine submit in a context
manager that mocks os.env, but since submit is async, there's a race
between when the task actually runs and when the context manager exits.

To fix, simply move all of the engine execution inside that wrapper by
indenting the `result` call by one level.
## Type of change

- Bug fix (non-breaking change that fixes an issue)
