### PR TITLE
Rename endpoint manager to core endpoint

### DIFF
--- a/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
+++ b/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
@@ -1,0 +1,11 @@
+Changed
+^^^^^^^
+
+- The Compute "parent" endpoint process responsible for maintaining the lifecycle
+  of individual user endpoints has been renamed from the ``Manager Endpoint``
+  (MEP) to the ``Core Endpoint`` (CEP).
+
+   This change merely renames classes, variables and updates documentation and
+   log output.  No underlying functionality is affected.
+
+   For more information, please see |CoreEndpoint|_.

--- a/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
+++ b/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
@@ -11,4 +11,4 @@ Changed
    *NOTE* As log output now refer to Core Endpoints instead of Manager Endpoints, any
    scripts that looked for/monitored the exact spelling in logs will have to be updated.
 
-   For more information, please see |CoreEndpoint|_.
+   For more information, please see the :ref:`Endpoint User Guide <endpoint_user_guide_overview>`

--- a/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
+++ b/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
@@ -1,8 +1,8 @@
 Changed
 ^^^^^^^
 
-- The Compute "parent" endpoint process responsible for maintaining the lifecycle
-  of individual user endpoints has been renamed from the ``Manager Endpoint``
+- The Compute "parent" endpoint process, responsible for maintaining the lifecycle
+  of individual user endpoints, has been renamed from the ``Manager Endpoint``
   (MEP) to the ``Core Endpoint`` (CEP).
 
    This change merely renames classes, variables and updates documentation and

--- a/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
+++ b/changelog.d/20260720_140231_lei_endpoint_core_naming_sc_50197.rst
@@ -8,4 +8,7 @@ Changed
    This change merely renames classes, variables and updates documentation and
    log output.  No underlying functionality is affected.
 
+   *NOTE* As log output now refer to Core Endpoints instead of Manager Endpoints, any
+   scripts that looked for/monitored the exact spelling in logs will have to be updated.
+
    For more information, please see |CoreEndpoint|_.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -28,7 +28,7 @@ from daemon.pidfile import PIDLockFile
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.boot_persistence import disable_on_boot, enable_on_boot
 from globus_compute_endpoint.endpoint.config import (
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     UserEndpointConfig,
 )
 from globus_compute_endpoint.endpoint.config.utils import (
@@ -38,8 +38,8 @@ from globus_compute_endpoint.endpoint.config.utils import (
     load_user_config_template,
     render_config_user_template,
 )
+from globus_compute_endpoint.endpoint.core_endpoint import CoreEndpoint
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_compute_endpoint.endpoint.endpoint_manager import EndpointManager
 from globus_compute_endpoint.endpoint.identity_mapper import MappedPosixIdentity
 from globus_compute_endpoint.endpoint.utils import has_pyprctl as _has_multi_user
 from globus_compute_endpoint.endpoint.utils import (
@@ -67,7 +67,7 @@ if not _has_multi_user and "--debug" in sys.argv and sys.stderr.isatty():
     # We haven't set up logging yet so manually print for now
     _e = pyprctl_import_error
     print(
-        f"(DEBUG) {__file__}: pyprctl not available; MEPs will not work"
+        f"(DEBUG) {__file__}: pyprctl not available; CEPs will not work"
         "\n(DEBUG) (Hints: Is pyprctl installed? Is this a Linux system?)"
         f"\n(DEBUG) [{type(_e).__name__}] {_e}",
         file=sys.stderr,
@@ -353,10 +353,10 @@ def version_command():
     ),
 )
 @optgroup.option(
-    "--manager-config",
+    "--core-config",
     type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
     default=None,
-    help="Specify a custom manager configuration (config.yaml)",
+    help="Specify a custom core endpoint configuration (config.yaml)",
 )
 @optgroup.option(
     "--template-config",
@@ -387,7 +387,7 @@ def version_command():
 @optgroup.option(
     "--endpoint-config",
     default=None,
-    help="DEPRECATED: use --manager-config or --template-config",
+    help="DEPRECATED: use --core-config or --template-config",
 )
 @optgroup.group(
     "Authentication Policy Creation",
@@ -471,13 +471,13 @@ def configure_endpoint(
     """
     if not _has_multi_user:
         raise ClickException(
-            "Unable to configure new endpoints; Manager Endpoint Processes are not"
+            "Unable to configure new endpoints; Core Endpoint Processes are not"
             " supported on this system"
         )
 
     if endpoint_config is not None:
         warnings.warn(
-            "--endpoint-config is deprecated; use --manager-config instead."
+            "--endpoint-config is deprecated; use --core-config instead."
             " If you want to configure user endpoint processes, use --template-config.",
             DeprecationWarning,
             stacklevel=2,
@@ -487,7 +487,7 @@ def configure_endpoint(
             manager_config = pathlib.Path(endpoint_config)
         else:
             warnings.warn(
-                "Both --endpoint-config and --manager-config were provided;"
+                "Both --endpoint-config and --core-config were provided;"
                 " --endpoint-config will be ignored.",
                 UserWarning,
                 stacklevel=2,
@@ -594,7 +594,7 @@ def configure_endpoint(
 )
 def start_endpoint(*, ep_dir: pathlib.Path, die_with_parent: bool, **_kwargs):
     state = CommandState.ensure()
-    # for backward compatibility with EndpointManager versions that run
+    # for backward compatibility with CoreEndpoint versions that run
     # `gce start --die-with-parent` instead of `gce _start-user-endpoint`.
     # deprecated; to be removed in 6 months (roughly Oct 2026)
     if die_with_parent:
@@ -603,7 +603,7 @@ def start_endpoint(*, ep_dir: pathlib.Path, die_with_parent: bool, **_kwargs):
             endpoint_uuid=state.endpoint_uuid,
         )
     else:
-        _start_endpoint_manager(
+        _start_core_endpoint(
             ep_dir=ep_dir,
             endpoint_uuid=state.endpoint_uuid,
         )
@@ -806,7 +806,7 @@ class _SendMessageOnErrorExit(contextlib.AbstractContextManager):
 
 
 def _do_register_endpoint(
-    ep_dir: pathlib.Path, ep_config: ManagerEndpointConfig, ep_uuid: str | None
+    ep_dir: pathlib.Path, ep_config: CoreEndpointConfig, ep_uuid: str | None
 ) -> dict:
     gcc = Client(
         local_compute_services=ep_config.local_compute_services,
@@ -818,7 +818,7 @@ def _do_register_endpoint(
         reg_info = gcc.register_endpoint(
             name=ep_dir.name,
             endpoint_id=ep_uuid or Endpoint.get_endpoint_id(ep_dir),
-            metadata=EndpointManager.get_metadata(ep_dir, ep_config),
+            metadata=CoreEndpoint.get_metadata(ep_dir, ep_config),
             public=ep_config.public,
             multi_user=is_privileged(),
             display_name=ep_config.display_name,
@@ -863,7 +863,7 @@ def _do_register_endpoint(
     return reg_info
 
 
-def _start_endpoint_manager(
+def _start_core_endpoint(
     *,
     ep_dir: pathlib.Path,
     endpoint_uuid: str | None,
@@ -913,7 +913,7 @@ def _start_endpoint_manager(
         pid_stale_after_s = ep_config.heartbeat_period * 3
         _pidfile_check(pid_path, pid_stale_after_s)
 
-        if not isinstance(ep_config, ManagerEndpointConfig):
+        if not isinstance(ep_config, CoreEndpointConfig):
             raise ClickException(
                 f"Configuration for endpoint {ep_dir.name} contains an `engine` field;"
                 " endpoint will not start. (Hint: move the `engine` block to"
@@ -953,7 +953,7 @@ def _start_endpoint_manager(
         pid_path = Endpoint.pid_path(ep_dir)
         stk.enter_context(_pidfile(pid_path, ep_config.heartbeat_period * 3))
 
-        epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
+        epm = CoreEndpoint(ep_dir, endpoint_uuid, ep_config, reg_info)
         epm.start()
 
 
@@ -996,7 +996,7 @@ def _start_user_endpoint(
             raise ClickException(
                 "Missing or invalid endpoint information from stdin. (Hint: this"
                 " command is not meant to be invoked manually; it should only be run"
-                " by an endpoint manager process.)"
+                " by a core endpoint process.)"
             ) from e
 
     with contextlib.ExitStack() as stk:
@@ -1077,7 +1077,7 @@ def restart_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
     """Restarts an endpoint"""
     state = CommandState.ensure()
     _do_stop_endpoint(ep_dir=ep_dir)
-    _start_endpoint_manager(
+    _start_core_endpoint(
         ep_dir=ep_dir,
         endpoint_uuid=state.endpoint_uuid,
     )
@@ -1410,14 +1410,14 @@ def _do_render_user_config(
     if parent_ep_dir is None and template_file is None:
         raise ClickException("Must provide at least one of --endpoint or --template.")
 
-    parent_config = ManagerEndpointConfig()
+    parent_config = CoreEndpointConfig()
     user_config_template: str
     user_config_template_path: pathlib.Path
     user_config_schema = {}
 
     if parent_ep_dir is not None:
         parent_config = get_config(parent_ep_dir)  # type: ignore[assignment]
-        if not isinstance(parent_config, ManagerEndpointConfig):
+        if not isinstance(parent_config, CoreEndpointConfig):
             raise ClickException(
                 f"Endpoint {parent_ep_dir.name} does not support templating."
             )
@@ -1438,7 +1438,7 @@ def _do_render_user_config(
             raise ClickExceptionWithContext(
                 f"Invalid parent config data in {parent_config_file.name}."
             ) from e
-        if not isinstance(parent_config, ManagerEndpointConfig):
+        if not isinstance(parent_config, CoreEndpointConfig):
             raise ClickException("Provided parent config does not support templating.")
 
     if template_file is not None:

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -67,7 +67,7 @@ if not _has_multi_user and "--debug" in sys.argv and sys.stderr.isatty():
     # We haven't set up logging yet so manually print for now
     _e = pyprctl_import_error
     print(
-        f"(DEBUG) {__file__}: pyprctl not available; CEPs will not work"
+        f"(DEBUG) {__file__}: pyprctl not available; endpoint may fail to start"
         "\n(DEBUG) (Hints: Is pyprctl installed? Is this a Linux system?)"
         f"\n(DEBUG) [{type(_e).__name__}] {_e}",
         file=sys.stderr,
@@ -471,7 +471,7 @@ def configure_endpoint(
     """
     if not _has_multi_user:
         raise ClickException(
-            "Unable to configure new endpoints; Core Endpoint Processes are not"
+            "Unable to configure new endpoints; Compute endpoints are not"
             " supported on this system"
         )
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/__init__.py
@@ -1,7 +1,7 @@
 from .config import (  # noqa: F401
     BaseConfig,
     Config,
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     UserEndpointConfig,
 )
 from .dispatch import (  # noqa: F401

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -12,7 +12,7 @@ from globus_compute_sdk.sdk.utils.uuid_like import (
     as_optional_uuid,
     as_uuid,
 )
-from pydantic import ConfigDict, validate_call
+from pydantic import BaseModel, ConfigDict, validate_call
 
 from .pam import PamConfiguration
 
@@ -191,12 +191,11 @@ class UserEndpointConfig(BaseConfig):
            max_blocks: 1
 
     Please see the |BaseConfig| class for a list of options that both
-    |ManagerEndpointConfig| and |UserEndpointConfig| classes share.
+    |CoreEndpointConfig| and |UserEndpointConfig| classes share.
 
     :param engine: The GlobusComputeEngine for this endpoint to execute functions.
         The currently known engines are ``GlobusComputeEngine``, ``ProcessPoolEngine``,
         and ``ThreadPoolEngine``.  See :ref:`uep-conf` for more information.
-
 
     :param heartbeat_threshold: Seconds since the last heartbeat message from the
         Globus Compute web service after which the connection is assumed to be
@@ -243,10 +242,6 @@ class UserEndpointConfig(BaseConfig):
         idle_heartbeats_hard: int = 5760,  # Two days, divided by `heartbeat_period`
         endpoint_setup: str | None = None,
         endpoint_teardown: str | None = None,
-        # Logging info
-        log_dir: str | None = None,
-        stdout: str = "./endpoint.log",
-        stderr: str = "./endpoint.log",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -260,7 +255,6 @@ class UserEndpointConfig(BaseConfig):
 
         self.endpoint_setup = endpoint_setup
         self.endpoint_teardown = endpoint_teardown
-
         # Logging info
         self.log_dir = log_dir
         self.stdout = stdout
@@ -303,8 +297,8 @@ class UserEndpointConfig(BaseConfig):
 Config = UserEndpointConfig
 
 
-class ManagerEndpointConfig(BaseConfig):
-    """Holds the configuration items for an endpoint manager.
+class CoreEndpointConfig(BaseConfig):
+    """Holds the configuration items for a core endpoint.
 
     Typically, one does not instantiate this configuration directly, but specifies
     the relevant options in the endpoint's ``config.yaml`` file.  In fact, the way that
@@ -312,13 +306,13 @@ class ManagerEndpointConfig(BaseConfig):
     whether there is an ``engine`` block in its ``config.yaml`` file:
 
     .. code-block:: yaml
-       :caption: ``config.yaml`` for Managers
+       :caption: ``config.yaml`` for Core endpoints
 
        # this file left empty; with no engine block, Compute interprets this
-       # as a manager endpoint
+       # as a core endpoint
 
     .. code-block:: yaml
-       :caption: ``config.yaml`` for task-processing endpoints (i.e., non-Managers)
+       :caption: ``config.yaml`` for task-processing endpoints (i.e., non-Core)
 
        engine:
          ...
@@ -326,7 +320,7 @@ class ManagerEndpointConfig(BaseConfig):
        # with an engine block, Compute will instantiate a task-processing endpoint
        # (i.e., a user-endpoint process, or UEP)
 
-    Note that for manager endpoints that will not be run with privileges, identity
+    Note that for core endpoints that will not be run with privileges, identity
     mapping is disabled (hence not specified above).  Conversely, if the process will
     have elevated privileges (e.g., run by ``root`` user or has |setuid(2)|_
     privileges) then identity mapping is required:
@@ -338,7 +332,7 @@ class ManagerEndpointConfig(BaseConfig):
        identity_mapping_config_path: /path/to/this/idmap_conf.json
 
     Please see the |BaseConfig| class for a list of options that both
-    |ManagerEndpointConfig| and |UserEndpointConfig| classes share.
+    |CoreEndpointConfig| and |UserEndpointConfig| classes share.
 
     :param public: Whether all users can discover this endpoint via the `Globus
         Compute web user interface <https://app.globus.org/compute>`_ and API.
@@ -361,7 +355,7 @@ class ManagerEndpointConfig(BaseConfig):
         does not exist.
 
     :param audit_log_path: Path to the audit log.  If specified, and the endpoint is
-        marked as High-Assurance (HA), then the MEP will write auditing records here.
+        marked as High-Assurance (HA), then the CEP will write auditing records here.
         An auditing record is a single-line of text, received from child endpoints at
         "interesting" points in a task lifetime.  For example, when the UEP interchange
         first receives a task, it will emit an auditing record of ``RECEIVED`` for that
@@ -377,14 +371,14 @@ class ManagerEndpointConfig(BaseConfig):
         specified, PAM authorization defaults to disabled.
 
     :param mu_child_ep_grace_period_s: The web-services send a start-user-endpoint to
-        the endpoint manager ahead of tasks for the target user endpoint.  If the
+        the core endpoint ahead of tasks for the target user endpoint.  If the
         user-endpoint is already running, these requests are ignored.  To account for
         the inherent race-condition of receiving a start request just before the
-        user-endpoint shuts down, the endpoint manager will hold on to the most recent
+        user-endpoint shuts down, the core endpoint will hold on to the most recent
         start request for the user-endpoint for this grace period.
 
     .. |BaseConfig| replace:: :class:`BaseConfig <globus_compute_endpoint.endpoint.config.config.BaseConfig>`
-    .. |ManagerEndpointConfig| replace:: :class:`ManagerEndpointConfig <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
+    .. |CoreEndpointConfig| replace:: :class:`CoreEndpointConfig <globus_compute_endpoint.endpoint.config.config.CoreEndpointConfig>`
     .. |UserEndpointConfig| replace:: :class:`UserEndpointConfig <globus_compute_endpoint.endpoint.config.config.UserEndpointConfig>`
     .. |PamConfiguration| replace:: :class:`PamConfiguration <globus_compute_endpoint.endpoint.config.pam.PamConfiguration>`
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/pam.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/pam.py
@@ -12,7 +12,7 @@ class PamConfiguration:
         session.  If a particular MEP has different requirements, define those PAM
         requirements in ``/etc/pam.d/``, and specify the service name with this field.
 
-        See :ref:`MEP § PAM <pam>` for more information
+        See :ref:`Multi-user § PAM <pam>` for more information
     """
 
     enable: bool = True

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml.j2
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml.j2
@@ -5,7 +5,7 @@
 #
 # As an optional security and user-debugging aid, consider also specifying a
 # JSON schema for the user-provided variables.  If `user_config_schema.json`
-# exists within the same directory, then before starting the UEP, the MEP will
+# exists within the same directory, then before starting the UEP, the CEP will
 # validate the variables against the schema before rendering.  This provides
 # an administrative peace of mind that users cannot specify invalid arguments.
 # From a usability standpoint, however, it also can make invalid values

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -13,7 +13,7 @@ import yaml
 from click import ClickException
 from globus_compute_endpoint.endpoint.identity_mapper import MappedPosixIdentity
 
-from .config import ManagerEndpointConfig, UserEndpointConfig
+from .config import CoreEndpointConfig, UserEndpointConfig
 from .dispatch import EngineDispatcher
 
 log = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ def _read_config_file(config_path: pathlib.Path) -> str:
 
 def _load_config_py(
     conf_path: pathlib.Path,
-) -> UserEndpointConfig | ManagerEndpointConfig | None:
+) -> UserEndpointConfig | CoreEndpointConfig | None:
     if not conf_path.exists():
         return None
 
@@ -79,13 +79,13 @@ def _load_config_py(
             raise Exception(f"Unable to import configuration (no config): {conf_path}")
         spec.loader.exec_module(config)
         config.config.source_content = _read_config_file(conf_path)
-        if not isinstance(config.config, (UserEndpointConfig, ManagerEndpointConfig)):
+        if not isinstance(config.config, (UserEndpointConfig, CoreEndpointConfig)):
             tname = type(config.config).__name__
             exp = ", ".join(
                 f"`{type(cls).__name__}`"
                 for cls in (
                     UserEndpointConfig,
-                    ManagerEndpointConfig,
+                    CoreEndpointConfig,
                 )  # no hard-code in str
             )
             raise AttributeError(f"Received type `{tname}`; expected one of: {exp}")
@@ -116,14 +116,14 @@ def _load_config_py(
         raise
 
 
-def load_config_yaml(config_str: str) -> UserEndpointConfig | ManagerEndpointConfig:
+def load_config_yaml(config_str: str) -> UserEndpointConfig | CoreEndpointConfig:
     try:
         config_dict = dict(yaml.safe_load(config_str) or {})
     except Exception as err:
         raise ClickException(f"Invalid config syntax: {str(err)}") from err
 
     engine_dict = config_dict.pop("engine", None)
-    ConfigClass = ManagerEndpointConfig if engine_dict is None else UserEndpointConfig
+    ConfigClass = CoreEndpointConfig if engine_dict is None else UserEndpointConfig
 
     try:
         if engine_dict is not None:
@@ -149,7 +149,7 @@ def load_config_yaml(config_str: str) -> UserEndpointConfig | ManagerEndpointCon
 
 def get_config(
     endpoint_dir: pathlib.Path,
-) -> UserEndpointConfig | ManagerEndpointConfig:
+) -> UserEndpointConfig | CoreEndpointConfig:
     config_py_path = endpoint_dir / "config.py"
     config_yaml_path = endpoint_dir / "config.yaml"
 
@@ -210,7 +210,7 @@ def _validate_user_opts(user_opts: dict, schema: dict | None) -> None:
     if not schema:
         return
 
-    import jsonschema  # Only load package when called by EP manager
+    import jsonschema  # Only load package when called by Core EP
 
     try:
         jsonschema.validate(instance=user_opts, schema=schema)
@@ -293,7 +293,7 @@ def load_user_config_template(template_path: pathlib.Path) -> str:
 
 
 def render_config_user_template(
-    parent_config: ManagerEndpointConfig,
+    parent_config: CoreEndpointConfig,
     user_config_template: str,
     user_config_template_path: pathlib.Path,
     mapped_identity: MappedPosixIdentity,
@@ -304,7 +304,7 @@ def render_config_user_template(
     # N.B. Performing rendering, a mildly complicated action, *after*
     # having dropped privileges.  Take security seriously ...
 
-    import jinja2  # Only load package when called by EP manager
+    import jinja2  # Only load package when called by Core Endpoint
     from jinja2.sandbox import SandboxedEnvironment
 
     _user_opts = user_opts or {}
@@ -315,6 +315,8 @@ def render_config_user_template(
         "parent_config": parent_config,
         "mapped_identity": _parse_mapped_identity(mapped_identity),
         "user_runtime": _sanitize_user_json(user_runtime or {}),
+        # Inject all env vars into UEP, already sanitized if CEP was privileged
+        "env": os.environ,
     }
     reserved_template_vars = {
         "_GC": R,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/core_endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/core_endpoint.py
@@ -1167,7 +1167,7 @@ class CoreEndpoint:
                 env.setdefault("GC_USER_PYTHON_VERSION", py_version)
             if gce_version := user_runtime.get("globus_compute_sdk_version"):
                 env.setdefault("GC_USER_SDK_VERSION", gce_version)
-                # assuming (as in the TMEP case) that if this env var is set, the UEP
+                # assuming (as in the TEP case) that if this env var is set, the UEP
                 # will run on this version of GCE. therefore, update proc args here
                 # for backward compatibility with UEP code that expects
                 # `gce start --die-with-parent` instead of `gce _start-user-endpoint`.
@@ -1207,10 +1207,11 @@ class CoreEndpoint:
             exit_code += 1
             _conf = yaml.safe_load(user_config)
 
+            contact_msg = "Error generating template; contact endpoint administrator"
             _ha_key = "high_assurance"
             if _ha_key in _conf:
                 log.error(f"`{_ha_key}` may not be specified in template")
-                raise ValueError("Error generating template; contact EP administrator")
+                raise ValueError(contact_msg)
 
             if self._config.high_assurance:
                 user_config = f"{_ha_key}: true\n{user_config}"
@@ -1218,7 +1219,7 @@ class CoreEndpoint:
             if bool(_conf.get(_ha_key)) ^ self._config.high_assurance:
                 # final check that the configuration HAness aligns
                 log.error(f"Unknown error generating correct template: `{_ha_key}`")
-                raise ValueError("Error generating template; contact EP administrator")
+                raise ValueError(contact_msg)
 
             ep_info: dict = {"posix_ppid": os.getppid()}
             if ident.matched_identity:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/core_endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/core_endpoint.py
@@ -32,7 +32,7 @@ from globus_compute_common.messagepack import pack
 from globus_compute_common.messagepack.message_types import EPStatusReport
 from globus_compute_endpoint import __version__
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
-from globus_compute_endpoint.endpoint.config import ManagerEndpointConfig
+from globus_compute_endpoint.endpoint.config import CoreEndpointConfig
 from globus_compute_endpoint.endpoint.config.config import MINIMUM_HEARTBEAT
 from globus_compute_endpoint.endpoint.config.utils import (
     load_user_config_schema,
@@ -118,15 +118,15 @@ T_CMD_START_ARGS = t.Tuple[
 ]
 
 
-class EndpointManager:
+class CoreEndpoint:
     def __init__(
         self,
         conf_dir: pathlib.Path,
         endpoint_uuid: str | None,
-        config: ManagerEndpointConfig,
+        config: CoreEndpointConfig,
         reg_info: dict,
     ):
-        log.debug("Endpoint Manager initialization")
+        log.debug("Core Endpoint initialization")
 
         self.conf_dir = conf_dir
         self._config = config
@@ -267,7 +267,7 @@ class EndpointManager:
         json_file.write_text(json.dumps(ep_info))
         log.debug(f"Registration info written to {json_file}")
 
-        # * == "manager endpoint"; not important until it is, so let it be subtle
+        # * == "core endpoint"; not important until it is, so let it be subtle
         ptitle = f"Globus Compute Endpoint *({endpoint_uuid}, {conf_dir.name})"
         if config.environment:
             ptitle += f" - {config.environment}"
@@ -283,7 +283,7 @@ class EndpointManager:
         self._heartbeat_publisher = ResultPublisher(queue_info=hbq_info)
 
     @staticmethod
-    def get_metadata(ep_dir: pathlib.Path, config: ManagerEndpointConfig) -> dict:
+    def get_metadata(ep_dir: pathlib.Path, config: CoreEndpointConfig) -> dict:
         user_config_template = load_user_config_template(
             Endpoint.user_config_template_path(ep_dir, config)
         )
@@ -377,7 +377,7 @@ class EndpointManager:
         try:
             with open(self._config.audit_log_path, "ab", buffering=0) as audit_f:
                 nowtz = datetime.now().astimezone().isoformat()
-                msg = f"{nowtz} uid={uid} pid={pid} eid={eid} Begin MEP session =====\n"
+                msg = f"{nowtz} uid={uid} pid={pid} eid={eid} Begin CEP session =====\n"
                 audit_f.write(msg.encode())
                 del msg, nowtz
                 while not self._audit_log_handler_stop:
@@ -392,7 +392,7 @@ class EndpointManager:
                         cb(key.fd, audit_f)
 
                 nowtz = datetime.now().astimezone().isoformat()
-                msg = f"{nowtz} uid={uid} pid={pid} eid={eid} End MEP session -----\n"
+                msg = f"{nowtz} uid={uid} pid={pid} eid={eid} End CEP session -----\n"
                 audit_f.write(msg.encode())
         finally:
             self._time_to_stop = True
@@ -472,7 +472,7 @@ class EndpointManager:
         return f
 
     def start(self):
-        log.info(f"\n\n========== Endpoint Manager begins: {self._endpoint_uuid_str}")
+        log.info(f"\n\n========== Core Endpoint begins: {self._endpoint_uuid_str}")
 
         msg_out = None
         if sys.stdout.isatty():
@@ -559,7 +559,7 @@ class EndpointManager:
 
         log.info(
             "Shutdown complete."
-            f"\n---------- Endpoint Manager ends: {self._endpoint_uuid_str}\n\n"
+            f"\n---------- Core Endpoint ends: {self._endpoint_uuid_str}\n\n"
         )
         if msg_out:
             # re-enable cursor visibility
@@ -978,8 +978,8 @@ class EndpointManager:
             p_uname = self._mu_user.pw_name
             if uname == p_uname or uid == os.getuid():
                 raise InvalidUserError(
-                    "Requested UID is same as Manager Endpoint UID on a user-mapped"
-                    " Manager Endpoint. To allow the same UID to run tasks, consider:"
+                    "Requested UID is same as Core Endpoint UID on a user-mapped"
+                    " Core Endpoint. To allow the same UID to run tasks, consider:"
                     "\n * using a non-root user,"
                     "\n * removing privileges from the UID, or"
                     "\n * removing the identity mapping configuration file"
@@ -1141,7 +1141,7 @@ class EndpointManager:
                 default_path = ("/usr/local/bin", "/usr/bin", "/bin", pybindir)
                 upath = ":".join(map(str, default_path))
 
-            # only set if env cleared / MEP privileged
+            # only set if env cleared / CEP privileged
             env.setdefault("HOME", udir)
             env.setdefault("USER", uname)
             env.setdefault("PATH", upath)
@@ -1210,7 +1210,7 @@ class EndpointManager:
             _ha_key = "high_assurance"
             if _ha_key in _conf:
                 log.error(f"`{_ha_key}` may not be specified in template")
-                raise ValueError("Error generating template; contact MEP administrator")
+                raise ValueError("Error generating template; contact EP administrator")
 
             if self._config.high_assurance:
                 user_config = f"{_ha_key}: true\n{user_config}"
@@ -1218,7 +1218,7 @@ class EndpointManager:
             if bool(_conf.get(_ha_key)) ^ self._config.high_assurance:
                 # final check that the configuration HAness aligns
                 log.error(f"Unknown error generating correct template: `{_ha_key}`")
-                raise ValueError("Error generating template; contact MEP administrator")
+                raise ValueError("Error generating template; contact EP administrator")
 
             ep_info: dict = {"posix_ppid": os.getppid()}
             if ident.matched_identity:
@@ -1278,9 +1278,9 @@ class EndpointManager:
                 if os.dup2(log_f.fileno(), 2) != 2:
                     raise OSError(f"Unable to redirect stderr to {ep_log}")
 
-            # After the last os.dup2(), std* streams are sent to user's EP log file
-            # and not the MEP's logs.  Use the exit_code as an avenue to share "what
-            # went wrong where" to the parent process (the MEP).
+            # After the last os.dup2(), std* streams are sent to the user EP log file
+            # and not the Core EP log.  Use the exit_code as an avenue to share "what
+            # went wrong where" to the parent process (the CEP).
             exit_code += 1
 
             if _conf.get("debug") is True:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -20,7 +20,7 @@ import yaml
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.endpoint.config import (
     BaseConfig,
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     UserEndpointConfig,
 )
 from globus_compute_endpoint.endpoint.config.utils import get_config
@@ -59,7 +59,7 @@ class Endpoint:
 
     @staticmethod
     def user_config_template_path(
-        endpoint_dir: pathlib.Path, config: ManagerEndpointConfig | None = None
+        endpoint_dir: pathlib.Path, config: CoreEndpointConfig | None = None
     ) -> pathlib.Path:
         if config and config.user_config_template_path:
             return pathlib.Path(config.user_config_template_path)
@@ -67,7 +67,7 @@ class Endpoint:
 
     @staticmethod
     def user_config_schema_path(
-        endpoint_dir: pathlib.Path, config: ManagerEndpointConfig | None = None
+        endpoint_dir: pathlib.Path, config: CoreEndpointConfig | None = None
     ) -> pathlib.Path:
         if config and config.user_config_schema_path:
             return pathlib.Path(config.user_config_schema_path)
@@ -75,7 +75,7 @@ class Endpoint:
 
     @staticmethod
     def identity_mapping_config_path(
-        endpoint_dir: pathlib.Path, config: ManagerEndpointConfig
+        endpoint_dir: pathlib.Path, config: CoreEndpointConfig
     ) -> pathlib.Path:
         return (
             config.identity_mapping_config_path
@@ -319,7 +319,7 @@ class Endpoint:
 
         if id_mapping:
             config = get_config(conf_dir)
-            assert isinstance(config, ManagerEndpointConfig)  # mypy...
+            assert isinstance(config, CoreEndpointConfig)  # mypy...
             idmap_conf_path = Endpoint.identity_mapping_config_path(conf_dir, config)
             print(f"\n\tIdentity mapping configuration: {idmap_conf_path}")
 
@@ -334,7 +334,7 @@ class Endpoint:
     @staticmethod
     def migrate_to_template_capable(conf_dir: pathlib.Path):
         og_config_obj = get_config(conf_dir)
-        if isinstance(og_config_obj, ManagerEndpointConfig):
+        if isinstance(og_config_obj, CoreEndpointConfig):
             raise ValueError(f"Endpoint '{conf_dir.name}' is already template capable.")
 
         if Endpoint.check_pidfile(conf_dir)["active"]:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
@@ -146,7 +146,7 @@ def send_endpoint_startup_failure_to_amqp(amqp_creds: dict, msg: str | None = No
     Non-exhaustive possible exceptions:
       - ``ImportError`` - for example, expects ``pika``
       - ``KeyError`` - If the ``amqp_creds`` data structure does not match; see, for
-           example, ``endpoint_manager.py`` for the expected data structure.
+           example, ``core_endpoint.py`` for the expected data structure.
       - pika connection errors, if unable to open a connection or send a message
     """
     import pika

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -218,6 +218,7 @@ class GlobusComputeEngineBase(ABC, RepresentationMixin):
         current configuration, complies with Globus's High Assurance policies. This
         must be evaluated on a case-by-case basis. Some example criteria:
 
+        # TODO rename this manager instance?
         * All manager-worker communication happens within one host machine
         * Network traffic is encrypted
         """

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -375,6 +375,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         """
         return self.executor.connected_managers()
 
+    # TODO Rename these 'manager' instances?
     def get_connected_managers_packages(self) -> t.Dict[str, t.Dict[str, str]]:
         """
         Returns

--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -13,6 +13,8 @@ import sys
 from collections import defaultdict
 from datetime import datetime
 
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_EP_DIR_ENV
+
 log = logging.getLogger(__name__)
 
 LOG_TS_FMT = "%Y-%m-%d %H:%M:%S,%f"
@@ -21,6 +23,7 @@ DEFAULT_FORMAT = (
     "%(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s "
     "%(message)s"
 )
+LOG_PATH_ENV = "GLOBUS_COMPUTE_LOG_PATH"
 
 _und = "\033[4m"
 _ital = "\033[3m"

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -72,6 +72,7 @@ def test_engine_submit_init_0(gc_engine_scaling):
     assert isinstance(future, concurrent.futures.Future)
     assert future.result() == param * 2
 
+    # TODO rename these manager instances?
     assert num_outstanding() == 2, "Expected 1 manager + interchange"
 
     # With 0 tasks and excess workers we should expect scale_down

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import inspect
 import os
@@ -8,7 +10,12 @@ import uuid
 from unittest import mock
 
 import pytest
-from globus_compute_endpoint.endpoint.config import PamConfiguration
+from globus_compute_endpoint.endpoint import endpoint
+from globus_compute_endpoint.endpoint.config import (
+    PamConfiguration,
+    UserEndpointConfig,
+)
+from globus_compute_endpoint.engines import ThreadPoolEngine
 from globus_compute_endpoint.engines.helper import execute_task
 from parsl import HighThroughputExecutor
 from parsl.executors import MPIExecutor
@@ -17,10 +24,10 @@ from tests.conftest import randomstring_impl
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "no_mock_pim: In test_endpointmanager_unit, disable autouse fixture"
+        "markers", "no_mock_pim: In test_core_endpoint_unit, disable autouse fixture"
     )
     config.addinivalue_line(
-        "markers", "no_mock_shutil: In test_endpointmanager_unit, disable autouse"
+        "markers", "no_mock_shutil: In test_core_endpoint_unit, disable autouse"
     )
 
 
@@ -38,16 +45,13 @@ known_user_config_opts = {
     "idle_heartbeats_hard": int,
     "endpoint_setup": str,
     "endpoint_teardown": str,
-    "log_dir": str,
-    "stdout": str,
-    "stderr": str,
     "local_compute_services": True,
     "environment": str,
     "high_assurance": False,
     "engine": None,
 }
 
-known_manager_config_opts = {
+known_core_config_opts = {
     "display_name": str,
     "allowed_functions": t.Iterable[uuid.UUID],
     "authentication_policy": uuid.UUID,

--- a/compute_endpoint/tests/unit/test_cep_audit_log.py
+++ b/compute_endpoint/tests/unit/test_cep_audit_log.py
@@ -3,19 +3,20 @@ import io
 import json
 import logging
 import os
+import pathlib
 import textwrap
 import threading
 from unittest import mock
 
 import pytest
-from globus_compute_endpoint.endpoint.config import ManagerEndpointConfig
-from globus_compute_endpoint.endpoint.endpoint_manager import (
-    EndpointManager,
+from globus_compute_endpoint.endpoint.config import CoreEndpointConfig
+from globus_compute_endpoint.endpoint.core_endpoint import (
+    CoreEndpoint,
     MappedPosixIdentity,
 )
 from tests.utils import try_assert
 
-_MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
+_MOCK_BASE = "globus_compute_endpoint.endpoint.core_endpoint."
 _GOOD_UNPRIVILEGED_EC = 84
 
 
@@ -64,7 +65,7 @@ def conf_tmpl():
 @pytest.fixture
 def conf(tmp_path):
     (tmp_path / "user_config_template.yaml.j2").write_text(conf_tmpl())
-    mec = ManagerEndpointConfig(high_assurance=True)
+    mec = CoreEndpointConfig(high_assurance=True)
     mec.audit_log_path = tmp_path / "audit.log"
     test_environ = {
         "HOME": str(tmp_path),
@@ -92,7 +93,7 @@ def reg_info(ep_uuid):
 
 
 @pytest.fixture
-def mock_os():
+def mock_os_log():
     with mock.patch(f"{_MOCK_BASE}os") as m:
         m.O_DIRECT = os.O_DIRECT
         m.fork.return_value = 0
@@ -106,12 +107,18 @@ def mock_os():
         m.dup2.side_effect = (0, 1, 2, AssertionError("dup2: unexpected?"))
         m.open.side_effect = (4, 5, AssertionError("open: unexpected?"))
 
-        with mock.patch.object(fcntl, "fcntl", return_value=8192):
+        with (
+            mock.patch.object(fcntl, "fcntl", return_value=8192),
+            mock.patch(
+                f"{_MOCK_BASE}ensure_log_path",
+                side_effect=lambda: pathlib.Path("/a/b/some_endpoint_name"),
+            ),
+        ):
             yield m
 
 
 def test_audit_log_write(tmp_path, conf, ep_uuid, reg_info):
-    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    em = CoreEndpoint(tmp_path, ep_uuid, conf, reg_info)
 
     r, w = os.pipe2(os.O_DIRECT)
     os.write(w, b"Test1")
@@ -131,7 +138,7 @@ def test_audit_log_write(tmp_path, conf, ep_uuid, reg_info):
 
 
 def test_audit_log_write_unknown_fd(mock_log, tmp_path, conf, ep_uuid, reg_info):
-    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    em = CoreEndpoint(tmp_path, ep_uuid, conf, reg_info)
 
     assert not em._audit_pipes, "Verify test setup"
     r, w = os.pipe2(os.O_DIRECT)
@@ -147,7 +154,7 @@ def test_audit_log_write_unknown_fd(mock_log, tmp_path, conf, ep_uuid, reg_info)
 def test_audit_log_write_close_on_closed_pipe(
     mock_log, tmp_path, conf, ep_uuid, reg_info
 ):
-    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    em = CoreEndpoint(tmp_path, ep_uuid, conf, reg_info)
 
     r, w = os.pipe2(os.O_DIRECT)
     os.write(w, b"Test")
@@ -169,7 +176,7 @@ def test_audit_log_write_close_on_closed_pipe(
 def test_audit_log_shutsdown_on_write_error(
     mock_log, tmp_path, conf, ep_uuid, reg_info
 ):
-    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    em = CoreEndpoint(tmp_path, ep_uuid, conf, reg_info)
 
     r, w = os.pipe2(os.O_DIRECT)
     os.write(w, b"Test1")
@@ -186,9 +193,9 @@ def test_audit_log_shutsdown_on_write_error(
 
 
 def test_audit_log_shutsdown_on_general_error(
-    tmp_path, ep_uuid, conf, reg_info, mock_os, randomstring
+    tmp_path, ep_uuid, conf, reg_info, mock_os_log, randomstring
 ):
-    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    em = CoreEndpoint(tmp_path, ep_uuid, conf, reg_info)
 
     exc_text = randomstring()
     with mock.patch(f"{_MOCK_BASE}open", side_effect=MemoryError(exc_text)):
@@ -199,13 +206,13 @@ def test_audit_log_shutsdown_on_general_error(
 
 
 def test_audit_log_pipe_hookup(
-    mock_log, tmp_path, ep_uuid, conf, reg_info, mock_os, mock_close_fds
+    mock_log, tmp_path, ep_uuid, conf, reg_info, mock_os_log, mock_close_fds
 ):
-    em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    em = CoreEndpoint(tmp_path, ep_uuid, conf, reg_info)
 
     m = mock.Mock()
-    mock_os.fdopen.return_value.__enter__.return_value = m
-    mock_os.pipe2.side_effect = os.pipe2  # need actual pipes ...
+    mock_os_log.fdopen.return_value.__enter__.return_value = m
+    mock_os_log.pipe2.side_effect = os.pipe2  # need actual pipes ...
 
     mpi = MappedPosixIdentity(em._mu_user, [], ep_uuid)
     kwargs = {

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -36,7 +36,7 @@ from globus_compute_endpoint.cli import (
     create_or_choose_auth_project,
 )
 from globus_compute_endpoint.endpoint.config import (
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     UserEndpointConfig,
 )
 from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
@@ -115,7 +115,7 @@ def mock_ep(gc_dir, ep_name):
 
 @pytest.fixture
 def mock_mep():
-    with mock.patch(f"{_MOCK_BASE}EndpointManager") as m:
+    with mock.patch(f"{_MOCK_BASE}CoreEndpoint") as m:
         m.return_value = m
         yield m
 
@@ -146,7 +146,7 @@ def mock_get_config():
 
 @pytest.fixture
 def mock_load_config_yaml_mep():
-    conf = ManagerEndpointConfig()
+    conf = CoreEndpointConfig()
     with mock.patch(f"{_MOCK_BASE}load_config_yaml") as m:
         m.return_value = conf
         yield m
@@ -154,7 +154,7 @@ def mock_load_config_yaml_mep():
 
 @pytest.fixture
 def mock_get_config_mep():
-    conf = ManagerEndpointConfig()
+    conf = CoreEndpointConfig()
     with mock.patch(f"{_MOCK_BASE}get_config") as m:
         m.return_value = conf
         yield m
@@ -392,7 +392,7 @@ def test_start_endpoint_already_running(
     mock_command_ensure.detach = detach
     with redirect_stderr(f):
         with pytest.raises(MessageSystemExit) as pyt_e:
-            cli._start_endpoint_manager(ep_dir=ep_dir, endpoint_uuid=None)
+            cli._start_core_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
     pid_path.unlink()
 
     serr = f.getvalue()
@@ -415,7 +415,7 @@ def test_start_endpoint_stale(
     os.utime(pid_path, (stale_time, stale_time))
     f = io.StringIO()
     with redirect_stderr(f):
-        cli._start_endpoint_manager(ep_dir=ep_dir, endpoint_uuid=None)
+        cli._start_core_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
 
     serr = f.getvalue()
     assert "Previous endpoint instance" in serr, "Expect 'who' in warning"
@@ -549,7 +549,7 @@ def test__do_register_endpoint_data_passthrough(
     mock_client.register_endpoint.side_effect = FakeGlobusAPIError(HTTPStatus.CONFLICT)
 
     ep_dir = make_manager_endpoint_dir()
-    ep_conf = ManagerEndpointConfig()
+    ep_conf = CoreEndpointConfig()
     ep_conf.allowed_functions = [uuid.uuid4() for _ in range(random.randint(1, 10))]
     ep_conf.authentication_policy = str(uuid.uuid4())
     ep_conf.subscription_id = str(uuid.uuid4())
@@ -630,7 +630,7 @@ def test__do_register_endpoint_registration_blocked(
     f = io.StringIO()
     with redirect_stdout(f):
         with pytest.raises((GlobusAPIError, MessageSystemExit)) as pyexc:
-            cli._do_register_endpoint(ep_dir, ManagerEndpointConfig(), ep_uuid)
+            cli._do_register_endpoint(ep_dir, CoreEndpointConfig(), ep_uuid)
         stdout_msg = f.getvalue()
 
     assert mock_log.warning.called
@@ -655,7 +655,7 @@ def test__do_register_endpoint_provided_endpoint_id(
 ):
     ep_dir = make_manager_endpoint_dir(ep_uuid=ep_uuid if with_json else None)
 
-    cli._do_register_endpoint(ep_dir, ManagerEndpointConfig(), ep_uuid)
+    cli._do_register_endpoint(ep_dir, CoreEndpointConfig(), ep_uuid)
 
     _a, k = mock_client.register_endpoint.call_args
     assert k["endpoint_id"] == ep_uuid
@@ -672,7 +672,7 @@ def test__do_register_endpoint_sends_data_during_registration(
 ):
     conf_dir = make_manager_endpoint_dir()
 
-    mock_conf = ManagerEndpointConfig()
+    mock_conf = CoreEndpointConfig()
     mock_conf.public = public
     mock_conf.source_content = "foo: bar"
 
@@ -728,7 +728,7 @@ def test__do_register_endpoint_handles_network_error_scriptably(
     mock_client.register_endpoint.side_effect = NetworkError(some_err, Exception())
 
     with pytest.raises(MessageSystemExit) as pyexc:
-        cli._do_register_endpoint(conf_dir, ManagerEndpointConfig(), ep_uuid)
+        cli._do_register_endpoint(conf_dir, CoreEndpointConfig(), ep_uuid)
 
     assert pyexc.value.code == os.EX_TEMPFAIL, "Expecting meaningful exit code"
     assert mock_log.debug.called
@@ -1009,19 +1009,19 @@ def test_configure_ep_manager_config_precedence(
 ):
     ep_config_arg = randomstring(5)
     gc_dir.mkdir(parents=True, exist_ok=True)
-    manager_config_arg = gc_dir / randomstring(4)
-    manager_config_arg.touch()
+    core_config_arg = gc_dir / randomstring(4)
+    core_config_arg.touch()
 
     with pytest.warns(UserWarning, match="--endpoint-config will be ignored"):
         run_line(
-            f"configure {randomstring()} --manager-config {manager_config_arg}"
+            f"configure {randomstring()} --core-config {core_config_arg}"
             f" --endpoint-config {ep_config_arg}",
             assert_exit_code=0,
         )
 
     assert (
         mock_ep.configure_endpoint.call_args.kwargs["endpoint_config"]
-        == manager_config_arg
+        == core_config_arg
     )
 
 
@@ -1047,7 +1047,7 @@ def test_configure_ep_config_options(
     if manager_config:
         manager_config = gc_dir / manager_config
         manager_config.touch()
-        cmd += f" --manager-config {manager_config}"
+        cmd += f" --coer-config {manager_config}"
     if template_config:
         template_config = gc_dir / template_config
         template_config.touch()
@@ -1112,7 +1112,7 @@ def test_start_ep_handles_die_with_parent(
     run_line, make_endpoint_dir, ep_name, die_with_parent, mocker
 ):
     mock__start_user_endpoint = mocker.patch(f"{_MOCK_BASE}_start_user_endpoint")
-    mock__start_endpoint_manager = mocker.patch(f"{_MOCK_BASE}_start_endpoint_manager")
+    mock__start_core_endpoint = mocker.patch(f"{_MOCK_BASE}_start_core_endpoint")
 
     make_endpoint_dir()
 
@@ -1121,10 +1121,10 @@ def test_start_ep_handles_die_with_parent(
 
     if die_with_parent:
         assert mock__start_user_endpoint.called, "Only the UEP should start"
-        assert not mock__start_endpoint_manager.called, "Only the UEP should start"
+        assert not mock__start_core_endpoint.called, "Only the UEP should start"
     else:
         assert not mock__start_user_endpoint.called, "Only the manager should start"
-        assert mock__start_endpoint_manager.called, "Only the manager should start"
+        assert mock__start_core_endpoint.called, "Only the manager should start"
 
 
 def test_start_ep_incorrect_config_yaml(
@@ -1166,8 +1166,8 @@ def test_start_ep_config_py_takes_precedence(
 ):
     conf_py = make_manager_endpoint_dir() / "config.py"
     conf_py.write_text(
-        "from globus_compute_endpoint.endpoint.config import ManagerEndpointConfig"
-        "\nconfig = ManagerEndpointConfig()"
+        "from globus_compute_endpoint.endpoint.config import CoreEndpointConfig"
+        "\nconfig = CoreEndpointConfig()"
     )
 
     run_line(f"start {ep_name}")
@@ -1281,7 +1281,7 @@ def test_name_or_uuid_decorator(tmp_path, mocker, run_line, name, uuid):
         # dummy config.yaml so that Endpoint._get_ep_dirs finds this
         (ep_conf_dir / "config.yaml").write_text("")
 
-    mock__start_epm = mocker.patch(f"{_MOCK_BASE}_start_endpoint_manager")
+    mock__start_epm = mocker.patch(f"{_MOCK_BASE}_start_core_endpoint")
 
     with mock.patch.dict(os.environ):
         run_line(f"-c {gc_conf_dir} start {name}")
@@ -1936,7 +1936,7 @@ def test_render_user_config_file_options(
                 out += json.dumps(v)
             elif isinstance(v, str):
                 out += v
-            elif isinstance(v, ManagerEndpointConfig):
+            elif isinstance(v, CoreEndpointConfig):
                 out += yaml.safe_dump({"display_name": v.display_name})
             elif isinstance(v, MappedPosixIdentity):
                 out += json.dumps(
@@ -2059,8 +2059,8 @@ def test__do_render_user_config_checks_template_capable(
     mock_load_config_yaml, mock_get_config, parent_ep_dir, parent_config_file
 ):
     e = "test setup: mocked config should never be template capable"
-    assert not isinstance(mock_get_config.return_value, ManagerEndpointConfig), e
-    assert not isinstance(mock_load_config_yaml.return_value, ManagerEndpointConfig), e
+    assert not isinstance(mock_get_config.return_value, CoreEndpointConfig), e
+    assert not isinstance(mock_load_config_yaml.return_value, CoreEndpointConfig), e
 
     with pytest.raises(ClickException, match="does not support templating"):
         _do_render_user_config(

--- a/compute_endpoint/tests/unit/test_config_utils.py
+++ b/compute_endpoint/tests/unit/test_config_utils.py
@@ -15,7 +15,7 @@ import pytest
 import yaml
 from click import ClickException
 from globus_compute_endpoint.endpoint.config import (
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     UserEndpointConfig,
 )
 from globus_compute_endpoint.endpoint.config.utils import (
@@ -30,7 +30,7 @@ from globus_compute_endpoint.endpoint.config.utils import (
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.endpoint.identity_mapper import MappedPosixIdentity
 from tests.conftest import randomstring_impl
-from tests.unit.conftest import known_manager_config_opts, known_user_config_opts
+from tests.unit.conftest import known_core_config_opts, known_user_config_opts
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.config.utils."
 
@@ -101,8 +101,8 @@ def _get_cls_kwds(cls: type) -> set[str]:
 def test_config_opts_accounted_for_in_tests():
     kwds = _get_cls_kwds(UserEndpointConfig)
     assert set(known_user_config_opts) == kwds
-    kwds = _get_cls_kwds(ManagerEndpointConfig)
-    assert set(known_manager_config_opts) == kwds
+    kwds = _get_cls_kwds(CoreEndpointConfig)
+    assert set(known_core_config_opts) == kwds
 
 
 def test_extra_opts_disallowed():
@@ -133,26 +133,28 @@ def test_load_user_endpoint_config_full(get_random_of_datatype):
         kw: get_random_of_datatype(tval) for kw, tval in known_user_config_opts.items()
     }
     conf["engine"] = {"type": "ThreadPoolEngine"}
+    conf["paths"] = {"endpoint_dir": "/my/dir", "endpoint_log": "/other/t.log"}
     serde_yaml = yaml.safe_dump(conf)
     conf = load_config_yaml(serde_yaml)
     assert isinstance(conf, UserEndpointConfig)
+    assert conf.paths.endpoint_dir == "/my/dir"
+    assert conf.paths.endpoint_log == "/other/t.log"
 
 
 def test_load_manager_endpoint_config_minimal():
     conf = {}
     serde_yaml = yaml.safe_dump(conf)
     conf = load_config_yaml(serde_yaml)
-    assert isinstance(conf, ManagerEndpointConfig)
+    assert isinstance(conf, CoreEndpointConfig)
 
 
 def test_load_manager_endpoint_config_full(get_random_of_datatype):
     conf = {
-        kw: get_random_of_datatype(tval)
-        for kw, tval in known_manager_config_opts.items()
+        kw: get_random_of_datatype(tval) for kw, tval in known_core_config_opts.items()
     }
     serde_yaml = yaml.safe_dump(conf)
     conf = load_config_yaml(serde_yaml)
-    assert isinstance(conf, ManagerEndpointConfig)
+    assert isinstance(conf, CoreEndpointConfig)
 
 
 def test_load_config_yaml_shutdowns_engine_on_user_config_error(

--- a/compute_endpoint/tests/unit/test_core_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_core_endpoint_unit.py
@@ -23,8 +23,8 @@ import yaml
 from globus_compute_common.messagepack import unpack
 from globus_compute_common.messagepack.message_types import EPStatusReport
 from globus_compute_endpoint.endpoint.config import (
+    CoreEndpointConfig,
     EngineDispatcher,
-    ManagerEndpointConfig,
     UserEndpointConfig,
 )
 from globus_compute_endpoint.endpoint.config.config import MINIMUM_HEARTBEAT
@@ -35,6 +35,8 @@ from globus_compute_endpoint.endpoint.rabbit_mq import (
 )
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds
 from globus_compute_endpoint.exceptions import MessageSystemExit
+from globus_compute_endpoint.logging_config import LOG_PATH_ENV
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_EP_DIR_ENV
 from globus_sdk import UserApp
 from pytest_mock import MockFixture
 
@@ -44,14 +46,14 @@ except AttributeError:
     pytest.skip(allow_module_level=True)
 else:
     # these imports also import pyprctl later
-    from globus_compute_endpoint.endpoint.endpoint_manager import (
-        EndpointManager,
+    from globus_compute_endpoint.endpoint.core_endpoint import (
+        CoreEndpoint,
         InvalidUserError,
         MappedPosixIdentity,
     )
 
 
-_MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
+_MOCK_BASE = "globus_compute_endpoint.endpoint.core_endpoint."
 
 # SPoA for "good/happy-path" exit codes
 _GOOD_EC = 88
@@ -88,6 +90,10 @@ def mock_ensure_compute_dir():
     return pathlib.Path(_mock_localuser_rec.pw_dir) / ".globus_compute"
 
 
+def mock_ensure_log_path():
+    return mock_ensure_compute_dir() / "some_ep_name" / "endpoint.log"
+
+
 @pytest.fixture
 def mock_log():
     with mock.patch(f"{_MOCK_BASE}log", spec=logging.Logger) as m:
@@ -116,12 +122,12 @@ def identity_map_path(conf_dir):
 
 @pytest.fixture
 def mock_conf(identity_map_path):
-    yield ManagerEndpointConfig()
+    yield CoreEndpointConfig()
 
 
 @pytest.fixture
 def mock_conf_root(identity_map_path):
-    yield ManagerEndpointConfig(identity_mapping_config_path=identity_map_path)
+    yield CoreEndpointConfig(identity_mapping_config_path=identity_map_path)
 
 
 @pytest.fixture(autouse=True)
@@ -227,7 +233,7 @@ def mock_props():
 
 
 @pytest.fixture
-def epmanager_as_user(
+def core_ep_as_user(
     mocker,
     conf_dir,
     mock_close_fds,
@@ -248,6 +254,8 @@ def epmanager_as_user(
     mock_os.open.side_effect = (4, 5, AssertionError("open: unexpected?"))
 
     mock_os.waitpid.return_value = (0, 0)
+
+    mocker.patch(f"{_MOCK_BASE}ensure_log_path", side_effect=mock_ensure_log_path)
 
     mock_pwd = mocker.patch(f"{_MOCK_BASE}pwd")
     mock_pwd.getpwnam.side_effect = AssertionError(
@@ -270,7 +278,7 @@ def epmanager_as_user(
     mock_auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
     mock_conf.identity_mapping_config_path = None
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     assert em.identity_mapper is None
 
     em._command_queue = mock.Mock()
@@ -282,7 +290,7 @@ def epmanager_as_user(
 
 
 @pytest.fixture
-def epmanager_as_root(
+def core_ep_as_root(
     mocker,
     conf_dir,
     mock_close_fds,
@@ -321,6 +329,7 @@ def epmanager_as_root(
 
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=True)
     mocker.patch(f"{_MOCK_BASE}ensure_compute_dir", side_effect=mock_ensure_compute_dir)
+    mocker.patch(f"{_MOCK_BASE}ensure_log_path", side_effect=mock_ensure_log_path)
 
     ep_uuid, _ = mock_client
 
@@ -330,7 +339,7 @@ def epmanager_as_root(
     ident = "epmanager_some_identity"
     mock_auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf_root, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf_root, mock_reg_info)
     em._command = mock.Mock(spec=CommandQueueSubscriber)
     em._heartbeat_publisher = mock.Mock(spec=ResultPublisher)
 
@@ -368,14 +377,14 @@ def command_payload(ident):
 
 @pytest.fixture
 def successful_exec_from_mocked_root(
-    epmanager_as_root,
+    core_ep_as_root,
     mock_auth_client,
     user_conf_template,
     mock_props,
     ident,
     command_payload,
 ):
-    conf_dir, mock_conf, mock_client, mock_os, mock_pwd, em = epmanager_as_root
+    conf_dir, mock_conf, mock_client, mock_os, mock_pwd, em = core_ep_as_root
 
     mock_auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
@@ -394,14 +403,14 @@ def successful_exec_from_mocked_root(
 
 @pytest.fixture
 def successful_exec_from_mocked_user(
-    epmanager_as_user,
+    core_ep_as_user,
     mock_auth_client,
     user_conf_template,
     mock_props,
     ident,
     command_payload,
 ):
-    conf_dir, mock_conf, mock_client, mock_os, mock_pwd, em = epmanager_as_user
+    conf_dir, mock_conf, mock_client, mock_os, mock_pwd, em = core_ep_as_user
 
     mock_auth_client.userinfo.return_value = {"identity_set": [{"sub": ident}]}
 
@@ -489,10 +498,10 @@ def test_get_metadata(mocker):
         f"{_MOCK_BASE}load_user_config_schema",
         return_value=exp_meta["user_config_schema"],
     )
-    test_config = ManagerEndpointConfig()
+    test_config = CoreEndpointConfig()
     test_config.source_content = exp_meta["endpoint_config"]
 
-    meta = EndpointManager.get_metadata(pathlib.Path(), test_config)
+    meta = CoreEndpoint.get_metadata(pathlib.Path(), test_config)
 
     assert meta == exp_meta
 
@@ -512,7 +521,7 @@ def test_sets_process_title(
     ep_uuid, mock_gcc = mock_client
     mock_conf.environment = env
 
-    EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     assert mock_spt.setproctitle.called, "Sanity check"
 
     a, *_ = mock_spt.setproctitle.call_args
@@ -534,7 +543,7 @@ def test_sets_process_title(
 def test_sets_user_config_template_and_schema_path(
     mock_client: t.Tuple[uuid.UUID, mock.Mock],
     conf_dir: pathlib.Path,
-    mock_conf: ManagerEndpointConfig,
+    mock_conf: CoreEndpointConfig,
     custom_template_path: bool,
     custom_schema_path: bool,
     mock_reg_info,
@@ -555,7 +564,7 @@ def test_sets_user_config_template_and_schema_path(
     mock_conf.user_config_template_path = template_path
     mock_conf.user_config_schema_path = schema_path
 
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
     assert em.user_config_template_path == template_path
     assert em.user_config_schema_path == schema_path
@@ -569,7 +578,7 @@ def test_mismatched_id_gracefully_exits(
     assert wrong_uuid != ep_uuid, "Verify test setup"
 
     with pytest.raises(MessageSystemExit) as pyt_e:
-        EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+        CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
     assert pyt_e.value.code == os.EX_SOFTWARE, "Expected meaningful exit code"
     assert mock_log.error.called
@@ -618,7 +627,7 @@ def test_handles_invalid_reg_info(
 
     if not should_succeed:
         with pytest.raises(MessageSystemExit) as pyexc:
-            EndpointManager(conf_dir, ep_uuid, mock_conf, received_data[1])
+            CoreEndpoint(conf_dir, ep_uuid, mock_conf, received_data[1])
         assert pyexc.value.code == os.EX_SOFTWARE, "Expected meaningful exit code"
         assert mock_log.error.called
         a = mock_log.error.call_args[0][0]
@@ -627,7 +636,7 @@ def test_handles_invalid_reg_info(
 
     else:
         # "null" test
-        EndpointManager(conf_dir, ep_uuid, mock_conf, received_data[1])
+        CoreEndpoint(conf_dir, ep_uuid, mock_conf, received_data[1])
 
 
 def test_records_user_ep_as_running(successful_exec_from_mocked_root):
@@ -660,8 +669,8 @@ def test_caches_start_cmd_args_if_ep_already_running(
     assert kwargs == command_payload["kwargs"]
 
 
-def test_writes_endpoint_uuid(epmanager_as_root):
-    conf_dir, _mock_conf, mock_client, *_ = epmanager_as_root
+def test_writes_endpoint_uuid(core_ep_as_root):
+    conf_dir, _mock_conf, mock_client, *_ = core_ep_as_root
     _ep_uuid, mock_gcc = mock_client
 
     returned_uuid = mock_gcc.register_endpoint.return_value["endpoint_id"]
@@ -673,17 +682,17 @@ def test_writes_endpoint_uuid(epmanager_as_root):
     assert ep_data["endpoint_id"] == returned_uuid
 
 
-def test_log_contains_sentinel_lines(mock_log, epmanager_as_root, noop, reset_signals):
-    *_, em = epmanager_as_root
+def test_log_contains_sentinel_lines(mock_log, core_ep_as_root, noop, reset_signals):
+    *_, em = core_ep_as_root
 
     em._event_loop = noop
     em.start()
 
     uuid_pat = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    beg_re_sentinel = re.compile(r"\n\n=+ Endpoint Manager begins: ")
-    beg_re_uuid = re.compile(rf"\n\n=+ Endpoint Manager begins: {uuid_pat}\n")
-    end_re_sentinel = re.compile(r"\n-+ Endpoint Manager ends: ")
-    end_re_uuid = re.compile(rf"\n-+ Endpoint Manager ends: {uuid_pat}\n\n")
+    beg_re_sentinel = re.compile(r"\n\n=+ Core Endpoint begins: ")
+    beg_re_uuid = re.compile(rf"\n\n=+ Core Endpoint begins: {uuid_pat}\n")
+    end_re_sentinel = re.compile(r"\n-+ Core Endpoint ends: ")
+    end_re_uuid = re.compile(rf"\n-+ Core Endpoint ends: {uuid_pat}\n\n")
     log_str = "\n".join(a[0] for a, _ in mock_log.info.call_args_list)
     assert log_str.startswith("\n\n"), "Expect visual separation for log trawlers"
     assert beg_re_sentinel.search(log_str) is not None, "Expected visual begin sentinel"
@@ -694,9 +703,9 @@ def test_log_contains_sentinel_lines(mock_log, epmanager_as_root, noop, reset_si
 
 
 def test_title_changes_for_shutdown(
-    epmanager_as_root, noop, mock_setproctitle, reset_signals
+    core_ep_as_root, noop, mock_setproctitle, reset_signals
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
     mock_spt, orig_proc_title = mock_setproctitle
 
     em._event_loop = noop
@@ -712,9 +721,9 @@ def test_title_changes_for_shutdown(
 
 
 def test_children_signaled_at_shutdown(
-    mocker, epmanager_as_root, randomstring, noop, reset_signals
+    mocker, core_ep_as_root, randomstring, noop, reset_signals
 ):
-    *_, mock_os, _, em = epmanager_as_root
+    *_, mock_os, _, em = core_ep_as_root
 
     em._event_loop = mock.Mock()
     em.wait_for_children = noop
@@ -793,8 +802,8 @@ def test_children_signaled_at_shutdown(
             killpg_call_count += 1
 
 
-def test_restarts_running_endpoint_with_cached_args(epmanager_as_root, mock_log):
-    *_, mock_os, _mock_pwd, em = epmanager_as_root
+def test_restarts_running_endpoint_with_cached_args(core_ep_as_root, mock_log):
+    *_, mock_os, _mock_pwd, em = core_ep_as_root
     child_pid = random.randrange(1, 32768 + 1)
     mapped_posix = MappedPosixIdentity(_mock_localuser_rec, [], None)
     args_tup = (
@@ -816,8 +825,8 @@ def test_restarts_running_endpoint_with_cached_args(epmanager_as_root, mock_log)
     assert em.cmd_start_endpoint.call_args.args == args_tup
 
 
-def test_no_cached_args_means_no_restart(epmanager_as_root, mock_log):
-    *_, mock_os, _, em = epmanager_as_root
+def test_no_cached_args_means_no_restart(core_ep_as_root, mock_log):
+    *_, mock_os, _, em = core_ep_as_root
     child_pid = random.randrange(1, 32768 + 1)
 
     mock_os.waitpid.side_effect = [(child_pid, -1), (0, -1)]
@@ -831,8 +840,8 @@ def test_no_cached_args_means_no_restart(epmanager_as_root, mock_log):
     assert not em.cmd_start_endpoint.called
 
 
-def test_emits_endpoint_id_if_isatty(mocker, mock_log, epmanager_as_root):
-    *_, em = epmanager_as_root
+def test_emits_endpoint_id_if_isatty(mocker, mock_log, core_ep_as_root):
+    *_, em = core_ep_as_root
 
     mocker.patch.object(em, "_install_signal_handlers", side_effect=Exception)
 
@@ -885,7 +894,7 @@ def test_as_root_and_no_identity_mapper_configuration_allowed(
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=True)
     ep_uuid, _ = mock_client
     mock_conf.identity_mapping_config_path = None
-    EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
 
 def test_no_identity_mapper_if_unprivileged(
@@ -894,12 +903,12 @@ def test_no_identity_mapper_if_unprivileged(
     mock_privilege = mocker.patch(f"{_MOCK_BASE}is_privileged")
     mock_privilege.return_value = True
 
-    em = EndpointManager(conf_dir, None, mock_conf_root, mock_reg_info)
+    em = CoreEndpoint(conf_dir, None, mock_conf_root, mock_reg_info)
     assert em.identity_mapper is not None
     em.identity_mapper.stop_watching()
 
     mock_privilege.return_value = False
-    em = EndpointManager(conf_dir, None, mock_conf_root, mock_reg_info)
+    em = CoreEndpoint(conf_dir, None, mock_conf_root, mock_reg_info)
     assert em.identity_mapper is None
 
 
@@ -908,11 +917,11 @@ def test_unprivileged_warns_if_identity_conf_specified(
 ):
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=False)
 
-    em = EndpointManager(conf_dir, None, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, None, mock_conf, mock_reg_info)
     assert em.identity_mapper is None
     assert not mock_log.warning.called
 
-    em = EndpointManager(conf_dir, None, mock_conf_root, mock_reg_info)
+    em = CoreEndpoint(conf_dir, None, mock_conf_root, mock_reg_info)
     assert em.identity_mapper is None
 
     a, _ = mock_log.warning.call_args
@@ -921,9 +930,9 @@ def test_unprivileged_warns_if_identity_conf_specified(
 
 
 def test_quits_if_not_privileged_and_no_identity_set(
-    mocker, mock_log, mock_client, mock_auth_client, epmanager_as_root
+    mocker, mock_log, mock_client, mock_auth_client, core_ep_as_root
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
     em.identity_mapper = None
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=False)
     mock_auth_client.userinfo.return_value = {"identity_set": []}
@@ -937,9 +946,9 @@ def test_quits_if_not_privileged_and_no_identity_set(
 
 
 def test_clean_exit_on_identity_collection_error(
-    mocker, mock_log, mock_client, mock_auth_client, epmanager_as_root
+    mocker, mock_log, mock_client, mock_auth_client, core_ep_as_root
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
     em.identity_mapper = None
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=False)
     mock_auth_client.userinfo.return_value = {"not_identity_set": None}
@@ -977,7 +986,7 @@ def test_as_root_gracefully_handles_unreadable_identity_mapper_conf(
     }
     identity_map_path.chmod(mode=0o000)
     with pytest.raises(MessageSystemExit) as pyt_e:
-        EndpointManager(conf_dir, ep_uuid, mock_conf_root, reg_info)
+        CoreEndpoint(conf_dir, ep_uuid, mock_conf_root, reg_info)
 
     assert pyt_e.value.code == os.EX_NOPERM
     assert mock_log.error.called
@@ -992,7 +1001,7 @@ def test_as_root_gracefully_handles_unreadable_identity_mapper_conf(
     identity_map_path.chmod(mode=0o644)
     identity_map_path.write_text("[{asfg")
     with pytest.raises(MessageSystemExit) as pyt_e:
-        EndpointManager(conf_dir, ep_uuid, mock_conf_root, reg_info)
+        CoreEndpoint(conf_dir, ep_uuid, mock_conf_root, reg_info)
 
     assert pyt_e.value.code == os.EX_CONFIG
     assert mock_log.error.called
@@ -1005,8 +1014,8 @@ def test_as_root_gracefully_handles_unreadable_identity_mapper_conf(
         assert mock_print.call_args[0][0] == found_msg
 
 
-def test_iterates_even_if_no_commands(mocker, epmanager_as_root):
-    *_, em = epmanager_as_root
+def test_iterates_even_if_no_commands(mocker, core_ep_as_root):
+    *_, em = core_ep_as_root
 
     em._command_stop_event.set()
     em._event_loop()  # subtest is that it iterates and doesn't block
@@ -1024,20 +1033,20 @@ def test_heartbeat_period_minimum(conf_dir, mock_conf, hb, ep_uuid, mock_reg_inf
     if hb is not None:
         mock_conf._heartbeat_period = hb
         assert mock_conf.heartbeat_period == hb, "Avoid config setter"
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     exp_hb = 30.0 if hb is None else max(MINIMUM_HEARTBEAT, hb)
     assert exp_hb == em._heartbeat_period, "Expected a reasonable minimum heartbeat"
 
 
 def test_send_heartbeat_verifies_thread(mock_conf, conf_dir, ep_uuid, mock_reg_info):
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     f = em.send_heartbeat()
     exc = f.exception()
     assert "publisher is not running" in str(exc)
 
 
 def test_send_heartbeat_honors_shutdown(mock_conf, conf_dir, ep_uuid, mock_reg_info):
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     em._heartbeat_period = random.randint(1, 10000)
     em._heartbeat_publisher = mock.Mock(spec=ResultPublisher)
 
@@ -1056,7 +1065,7 @@ def test_send_heartbeat_shares_exception(
     mock_log, mock_conf, conf_dir, ep_uuid, mock_reg_info, randomstring
 ):
     exc_text = randomstring()
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     em._heartbeat_publisher = mock.Mock(spec=ResultPublisher)
     em._heartbeat_publisher.publish.return_value = Future()
     f = em.send_heartbeat()
@@ -1068,10 +1077,10 @@ def test_send_heartbeat_shares_exception(
     assert exc_text in str(a[0])
 
 
-def test_sends_heartbeat_at_shutdown(epmanager_as_root, noop, reset_signals):
-    *_, em = epmanager_as_root
+def test_sends_heartbeat_at_shutdown(core_ep_as_root, noop, reset_signals):
+    *_, em = core_ep_as_root
     hb_fut = mock.Mock(spec=Future)
-    em.send_heartbeat = mock.Mock(spec=EndpointManager.send_heartbeat)
+    em.send_heartbeat = mock.Mock(spec=CoreEndpoint.send_heartbeat)
     em.send_heartbeat.return_value = hb_fut
     em._event_loop = noop
     em.start()
@@ -1085,10 +1094,8 @@ def test_sends_heartbeat_at_shutdown(epmanager_as_root, noop, reset_signals):
     assert k["shutting_down"] is True
 
 
-def test_heartbeat_publisher_stopped_at_shutdown(
-    epmanager_as_root, noop, reset_signals
-):
-    *_, em = epmanager_as_root
+def test_heartbeat_publisher_stopped_at_shutdown(core_ep_as_root, noop, reset_signals):
+    *_, em = core_ep_as_root
     em._event_loop = noop
     em.start()
 
@@ -1098,9 +1105,9 @@ def test_heartbeat_publisher_stopped_at_shutdown(
 
 @pytest.mark.parametrize("num_iterations", (random.randint(3, 20),))
 def test_heartbeat_sent_periodically(
-    mocker, epmanager_as_root, reset_signals, num_iterations
+    mocker, core_ep_as_root, reset_signals, num_iterations
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
     last_time = time.monotonic()  # anything greater than em._heartbeat_period will do
     iteration_count = 0
 
@@ -1118,7 +1125,7 @@ def test_heartbeat_sent_periodically(
         last_time += em._heartbeat_period + 1
         return last_time
 
-    em.send_heartbeat = mock.Mock(spec=EndpointManager.send_heartbeat)
+    em.send_heartbeat = mock.Mock(spec=CoreEndpoint.send_heartbeat)
     em._command_queue = mock.Mock(spec=queue.SimpleQueue)
     em._command_queue.get.side_effect = mock_q_get
     mock_monotonic.side_effect = increase_time_by_hb
@@ -1126,8 +1133,8 @@ def test_heartbeat_sent_periodically(
     assert em.send_heartbeat.call_count == num_iterations
 
 
-def test_emits_command_requested_debug(mock_log, epmanager_as_root, mock_props):
-    *_, em = epmanager_as_root
+def test_emits_command_requested_debug(mock_log, core_ep_as_root, mock_props):
+    *_, em = core_ep_as_root
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
 
@@ -1158,9 +1165,9 @@ def test_emits_command_requested_debug(mock_log, epmanager_as_root, mock_props):
 
 
 def test_emitted_debug_command_credentials_removed(
-    mock_log, epmanager_as_root, randomstring, mock_props
+    mock_log, core_ep_as_root, randomstring, mock_props
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
 
@@ -1183,8 +1190,8 @@ def test_emitted_debug_command_credentials_removed(
     assert em._command.ack.called, "Command always ACKed"
 
 
-def test_command_verifies_content_type(mock_log, epmanager_as_root, mock_props):
-    *_, em = epmanager_as_root
+def test_command_verifies_content_type(mock_log, core_ep_as_root, mock_props):
+    *_, em = core_ep_as_root
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
 
@@ -1202,9 +1209,9 @@ def test_command_verifies_content_type(mock_log, epmanager_as_root, mock_props):
 
 @pytest.mark.parametrize("bad_ts", (None, "not-a-number", [], True, False, b"1234567"))
 def test_rejects_missing_or_invalid_timestamp(
-    mock_log, epmanager_as_root, mock_props, bad_ts
+    mock_log, core_ep_as_root, mock_props, bad_ts
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
     em.send_failure_notice = mock.Mock()
@@ -1223,8 +1230,8 @@ def test_rejects_missing_or_invalid_timestamp(
     assert em._command.ack.called, "Command always ACKed"
 
 
-def test_ignores_stale_commands(mock_log, epmanager_as_root, mock_props, randomstring):
-    *_, mock_os, _, em = epmanager_as_root
+def test_ignores_stale_commands(mock_log, core_ep_as_root, mock_props, randomstring):
+    *_, mock_os, _, em = core_ep_as_root
     em._command_queue = mock.Mock()
     em._command_stop_event.set()
     em.send_failure_notice = mock.Mock(spec=em.send_failure_notice)
@@ -1254,11 +1261,9 @@ def test_ignores_stale_commands(mock_log, epmanager_as_root, mock_props, randoms
 
 
 @pytest.mark.parametrize("should_fork", (True, False, None))
-def test_send_failure_notice_conditionally_forks(
-    mocker, epmanager_as_root, should_fork
-):
+def test_send_failure_notice_conditionally_forks(mocker, core_ep_as_root, should_fork):
     mocker.patch(f"{_MOCK_BASE}log")
-    *_, mock_os, _, em = epmanager_as_root
+    *_, mock_os, _, em = core_ep_as_root
 
     kw = {}
     if should_fork is not None:
@@ -1271,9 +1276,9 @@ def test_send_failure_notice_conditionally_forks(
 
 
 def test_send_failure_notice_gracefully_ignores_malformed_kwargs(
-    mock_log, epmanager_as_root
+    mock_log, core_ep_as_root
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
 
     with pytest.raises(SystemExit) as pyt_exc:
         em.send_failure_notice({}, fork=False)
@@ -1283,9 +1288,9 @@ def test_send_failure_notice_gracefully_ignores_malformed_kwargs(
 
 
 def test_send_failure_notice_populates_children_structure(
-    epmanager_as_root, randomstring
+    core_ep_as_root, randomstring
 ):
-    *_, mock_os, _, em = epmanager_as_root
+    *_, mock_os, _, em = core_ep_as_root
 
     ep_name = randomstring()
     child_pid = random.randint(2, 1000000)
@@ -1302,9 +1307,9 @@ def test_send_failure_notice_populates_children_structure(
     assert all(ui in fork_args for ui in user_info)
 
 
-def test_send_failure_notice_sends_message(mocker, epmanager_as_root, randomstring):
+def test_send_failure_notice_sends_message(mocker, core_ep_as_root, randomstring):
     mock_send = mocker.patch(f"{_MOCK_BASE}send_endpoint_startup_failure_to_amqp")
-    *_, mock_os, _, em = epmanager_as_root
+    *_, mock_os, _, em = core_ep_as_root
     mock_os.fork.return_value = 0  # test the child process path
 
     err_msg = randomstring()
@@ -1321,8 +1326,8 @@ def test_send_failure_notice_sends_message(mocker, epmanager_as_root, randomstri
     assert k["msg"] is err_msg
 
 
-def test_send_failure_notice_fails_to_send(mock_log, epmanager_as_root, randomstring):
-    *_, mock_os, _, em = epmanager_as_root
+def test_send_failure_notice_fails_to_send(mock_log, core_ep_as_root, randomstring):
+    *_, mock_os, _, em = core_ep_as_root
     mock_os.fork.return_value = 0  # test the child process path
 
     kw = None  # will produce TypeError
@@ -1337,8 +1342,8 @@ def test_send_failure_notice_fails_to_send(mock_log, epmanager_as_root, randomst
     assert "Unable to send user endpoint start up failure" in a[0]
 
 
-def test_handles_invalid_server_msg_gracefully(mock_log, epmanager_as_root, mock_props):
-    *_, em = epmanager_as_root
+def test_handles_invalid_server_msg_gracefully(mock_log, core_ep_as_root, mock_props):
+    *_, em = core_ep_as_root
     em.send_failure_notice = mock.Mock(spec=em.send_failure_notice)
 
     queue_item = (1, mock_props, json.dumps({"asdf": 123}).encode())
@@ -1372,7 +1377,7 @@ def test_handles_invalid_server_msg_gracefully(mock_log, epmanager_as_root, mock
 def test_unprivileged_handles_identity_set_robustly(
     mock_log,
     mock_props,
-    epmanager_as_user,
+    core_ep_as_user,
     is_invalid,
     idset,
     randomstring,
@@ -1385,7 +1390,7 @@ def test_unprivileged_handles_identity_set_robustly(
     }
     queue_item = (1, mock_props, json.dumps(cmd_payload).encode())
 
-    *_, em = epmanager_as_user
+    *_, em = core_ep_as_user
     em.send_failure_notice = mock.Mock(spec=em.send_failure_notice)
     em._command_queue.get.side_effect = (queue_item, queue.Empty())
     em._event_loop()
@@ -1406,9 +1411,9 @@ def test_unprivileged_handles_identity_set_robustly(
 
 
 def test_unprivileged_happy_path(
-    mocker, mock_props, epmanager_as_user, mock_client, mock_auth_client
+    mocker, mock_props, core_ep_as_user, mock_client, mock_auth_client
 ):
-    *_, em = epmanager_as_user
+    *_, em = core_ep_as_user
     ident_rv = mock_auth_client.userinfo.return_value
 
     mocker.patch(f"{_MOCK_BASE}log")
@@ -1430,8 +1435,8 @@ def test_unprivileged_happy_path(
     assert mapped.globus_identity_candidates == [], "Did not map"
 
 
-def test_privileged_happy_path(epmanager_as_root, mock_props, randomstring, ident):
-    *_, em = epmanager_as_root
+def test_privileged_happy_path(core_ep_as_root, mock_props, randomstring, ident):
+    *_, em = core_ep_as_root
     pld = {
         "globus_username": "a" + randomstring(),
         "globus_effective_identity": "abc" + randomstring(),
@@ -1461,9 +1466,9 @@ def test_privileged_happy_path(epmanager_as_root, mock_props, randomstring, iden
 
 
 def test_handles_unknown_identity_gracefully(
-    mock_log, epmanager_as_root, mock_props, randomstring
+    mock_log, core_ep_as_root, mock_props, randomstring
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
 
     pld = {
         "globus_username": "a" + randomstring(),
@@ -1495,9 +1500,9 @@ def test_handles_unknown_identity_gracefully(
 
 
 def test_gracefully_handles_identity_mapping_error(
-    mock_log, epmanager_as_root, randomstring, mock_props
+    mock_log, core_ep_as_root, randomstring, mock_props
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
 
     pld = {
         "globus_username": randomstring(),
@@ -1534,9 +1539,9 @@ def test_gracefully_handles_identity_mapping_error(
     "cmd_name", ("", "_private", "9c", "valid_but_do_not_exist", " ", "a" * 101)
 )
 def test_handles_unknown_or_invalid_command_gracefully(
-    mocker, mock_log, epmanager_as_root, cmd_name, mock_props, randomstring
+    mocker, mock_log, core_ep_as_root, cmd_name, mock_props, randomstring
 ):
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
 
     mocker.patch(f"{_MOCK_BASE}pwd")
     em.identity_mapper = mock.Mock()
@@ -1576,9 +1581,9 @@ def test_handles_unknown_or_invalid_command_gracefully(
 
 
 def test_handles_local_user_not_found_gracefully(
-    mock_log, epmanager_as_root, randomstring, mock_props
+    mock_log, core_ep_as_root, randomstring, mock_props
 ):
-    *_, mock_pwd, em = epmanager_as_root
+    *_, mock_pwd, em = core_ep_as_root
 
     invalid_user_name = "username_that_is_not_on_localhost6_" + randomstring()
     em.identity_mapper = mock.Mock()
@@ -1613,13 +1618,13 @@ def test_handles_local_user_not_found_gracefully(
 
 
 def test_handles_failed_command(
-    mocker, mock_log, epmanager_as_root, mock_props, randomstring
+    mocker, mock_log, core_ep_as_root, mock_props, randomstring
 ):
     mocker.patch(f"{_MOCK_BASE}pwd.getpwnam")
     mocker.patch(
-        f"{_MOCK_BASE}EndpointManager.cmd_start_endpoint", side_effect=Exception()
+        f"{_MOCK_BASE}CoreEndpoint.cmd_start_endpoint", side_effect=Exception()
     )
-    *_, em = epmanager_as_root
+    *_, em = core_ep_as_root
 
     pld = {
         "globus_username": randomstring(),
@@ -2009,14 +2014,14 @@ def test_ha_disallowed_in_uep_conf(
     assert pyt_e.value.code != _GOOD_EC, "Q&D: verify we failed, based on '+= 1'"
 
     (efmt,), _ = mock_log.error.call_args_list[0]
-    assert "`high_assurance` may not be" in efmt, "expect specific to MEP logs"
+    assert "`high_assurance` may not be" in efmt, "expect specific to CEP logs"
     (efmt,), _ = mock_log.error.call_args
-    assert "contact MEP administrator" in efmt, "expect opaque to user"
+    assert "contact EP administrator" in efmt, "expect opaque to user"
 
 
 @pytest.mark.parametrize("mep_ha", (None, True, False))
 def test_ha_aligned(successful_exec_from_mocked_root, user_conf_template, mep_ha):
-    em: EndpointManager
+    em: CoreEndpoint
     mock_os, *_, em = successful_exec_from_mocked_root
     if mep_ha is not None:
         em._config.high_assurance = mep_ha
@@ -2050,11 +2055,11 @@ def test_run_as_same_user_disabled_if_admin(
     mock_prctl.CapState.get_current.return_value.effective = set()
 
     mock_pwd.getpwuid.return_value = namedtuple("getent", "pw_name,pw_uid")("asdf", 0)
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     assert em._allow_same_user is False, "Verify check against UID 0"
 
     mock_pwd.getpwuid.return_value = namedtuple("getent", "pw_name,pw_uid")("root", 999)
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     assert em._allow_same_user is False, "Verify check against 'root' username"
 
 
@@ -2070,7 +2075,7 @@ def test_run_as_same_user_disabled_if_privileged(
     mock_prctl = mocker.patch(f"{_test_mock_base}_pyprctl")
 
     mock_prctl.CapState.get_current.return_value.effective = {cap}
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf_root, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf_root, mock_reg_info)
     assert em._allow_same_user is False
 
 
@@ -2084,7 +2089,7 @@ def test_run_as_same_user_enabled_if_not_admin(
     mocker.patch(f"{_test_mock_base}_pwd")
     mocker.patch(f"{_test_mock_base}_pyprctl")
 
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     assert em._allow_same_user is True, "If not privileged, can only runas same user"
 
 
@@ -2263,6 +2268,60 @@ def test_includes_mapped_identity_in_user_config(
     assert a[3].matched_identity == ident
 
 
+@pytest.mark.parametrize(
+    ("home_env", "ep_env", "user_env", "log_env", "expected_log_path_str"),
+    (
+        ("/home/rob", None, "bob", "$HOME/a.b", "/home/rob/a.b"),
+        #        ("/home/rob", None, "bob", "~/gc-$USER/a.b", "/home/rob/gc-bob/a.b"),
+        #        ("/home/rob", "$HOME/gc", "bob", None, "/home/rob/gc/endpoint.log"),
+        #        ("/home/rob", "~/gc-${USER}", "bob", None, "/home/rob/gc-bob/endpoint.log"),
+        #        ("/opt", None, "root", "~/a/b/gc.log   ", "/opt/a/b/gc.log"),
+        #        ("/", None, "root", "~/a/b/gc.log   ", "/a/b/gc.log"),
+        #        ("/home/jane", "/a/b/gc", "jane", "/tmp/gc.log", "/tmp/gc.log"),
+    ),
+)
+def test_ep_dir_log_path_env_expansion(
+    mocker,
+    successful_exec_from_mocked_root,
+    home_env,
+    ep_env,
+    user_env,
+    log_env,
+    expected_log_path_str,
+):
+    mock_os, conf_dir, _, _, _, em = successful_exec_from_mocked_root
+
+    expected_path = pathlib.Path(expected_log_path_str)
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "HOME": home_env,
+            "USER": user_env,
+            COMPUTE_EP_DIR_ENV: ep_env or "",
+            LOG_PATH_ENV: log_env or "",
+        },
+    ):
+        config = {}
+        if ep_env or log_env:
+            config_path = {}
+            if ep_env:
+                config_path["endpoint_dir"] = ep_env
+            if log_env:
+                config_path["endpoint_log"] = log_env
+            config["paths"] = config_path
+
+        mock_render = mocker.patch(
+            f"{_MOCK_BASE}render_config_user_template", return_value=yaml.dump(config)
+        )
+        m = mock.Mock()
+        mock_os.fdopen.return_value.__enter__.return_value = m
+        with pytest.raises(SystemExit) as pyexc:
+            em._event_loop()
+
+        assert pyexc.value.code == _GOOD_EC, "Q&D: verify we exec'ed, based on '+= 1'"
+
+
 @pytest.mark.parametrize("is_valid", (True, False))
 def test_pipe_size_limit(mocker, mock_log, successful_exec_from_mocked_root, is_valid):
     *_, em = successful_exec_from_mocked_root
@@ -2354,7 +2413,7 @@ def test_redirect_stdstreams_to_user_log(
 
     uep_name = command_payload["kwargs"]["name"]
     uep_dir = mock_ensure_compute_dir() / uep_name
-    ep_log = uep_dir / "endpoint.log"
+    ep_log = mock_ensure_log_path()
 
     with pytest.raises(SystemExit) as pyexc:
         em._event_loop()
@@ -2410,7 +2469,7 @@ def test_port_is_respected(
 
     mock_update_url_port = mocker.patch(f"{_MOCK_BASE}update_url_port")
 
-    EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
     assert mock_update_url_port.call_args[0][1] == port
 
@@ -2429,11 +2488,11 @@ def test_conditional_imports_verified_at_init_for_ux(
     with mock.patch(f"{_MOCK_BASE}{fn_name}") as m:
         m.side_effect = MemoryError("test induced")
         with pytest.raises(MemoryError):
-            EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+            CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
 
 def test_pam_disabled(conf_dir, mock_conf, ep_uuid, mock_reg_info, mock_ctl, mock_pam):
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
     mock_conf.pam.enable = False
     with em.do_host_auth("some user name"):
@@ -2469,7 +2528,7 @@ def test_pam_enabled(conf_dir, mock_conf, ep_uuid, mock_reg_info, mock_ctl, mock
     pamh.pam_close_session.side_effect = AssertionError("Out of order")
     pamh.credentials_delete.side_effect = AssertionError("Out of order")
 
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
     with em.do_host_auth("some user name"):
         assert pamh.pam_open_session.called, "Complete authentication"
         assert not pamh.credentials_delete.called, "PAM session *not* over yet"
@@ -2493,7 +2552,7 @@ def test_pam_enabled(conf_dir, mock_conf, ep_uuid, mock_reg_info, mock_ctl, mock
 def test_pam_error(
     mock_log, conf_dir, mock_conf, ep_uuid, mock_reg_info, fn_name, mock_pam, exc
 ):
-    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+    em = CoreEndpoint(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
     mock_conf.pam.enable = True
     pamh = mock_pam.PamHandle

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 from globus_compute_endpoint.endpoint.config import (
     BaseConfig,
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     PamConfiguration,
     UserEndpointConfig,
 )
@@ -19,7 +19,7 @@ from globus_compute_endpoint.endpoint.config.dispatch import (
     ProviderDispatcher,
 )
 from pydantic import TypeAdapter, ValidationError
-from tests.unit.conftest import known_manager_config_opts, known_user_config_opts
+from tests.unit.conftest import known_core_config_opts, known_user_config_opts
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.config."
 
@@ -56,23 +56,23 @@ def test_mep_config_verifies_path_like_fields(config_dict_mep, field: str):
     conf_p = pathlib.Path("/some/path/not exists file")
     config_dict_mep[field] = conf_p
     with pytest.raises(ValueError) as pyt_e:
-        ManagerEndpointConfig(**config_dict_mep)
+        CoreEndpointConfig(**config_dict_mep)
 
     e_str = str(pyt_e.value)
     assert "not found" in e_str
     assert str(conf_p) in e_str, "expect location in exc to help human out"
 
     del config_dict_mep[field]
-    ManagerEndpointConfig(**config_dict_mep)  # doesn't raise; conditional validation
+    CoreEndpointConfig(**config_dict_mep)  # doesn't raise; conditional validation
 
 
 def test_mep_config_privileged_verifies_idmapping(config_dict_mep):
     p = config_dict_mep["identity_mapping_config_path"]
-    ManagerEndpointConfig(**config_dict_mep)  # Verify for test: doesn't raise!
+    CoreEndpointConfig(**config_dict_mep)  # Verify for test: doesn't raise!
 
     p.unlink(missing_ok=True)
     with pytest.raises(ValueError) as pyt_e:
-        ManagerEndpointConfig(**config_dict_mep)
+        CoreEndpointConfig(**config_dict_mep)
 
     assert "not found" in str(pyt_e)
     assert str(p) in str(pyt_e), "Expect invalid path shared"
@@ -87,9 +87,9 @@ def test_mep_public(public: t.Any):
         ta_bool.validate_python(public)
     except ValidationError:
         with pytest.raises(ValidationError):
-            ManagerEndpointConfig(public=public)
+            CoreEndpointConfig(public=public)
     else:
-        c = ManagerEndpointConfig(public=public)
+        c = CoreEndpointConfig(public=public)
         assert c.public is bool(public), "Verify that public is set to what we expect"
 
 
@@ -121,15 +121,14 @@ def test_provider_container_compatibility(
 def test_configs_repr_default_kwargs():
     assert repr(UserEndpointConfig()) == "UserEndpointConfig()"
     defs = f"pam={PamConfiguration(enable=False)!r}"
-    assert repr(ManagerEndpointConfig()) == f"ManagerEndpointConfig({defs})", (
-        "mep is on base"
-    )
+    assert repr(CoreEndpointConfig()) == f"CoreEndpointConfig({defs})", "CEP is on base"
 
 
 @pytest.mark.parametrize("kw,cls", known_user_config_opts.items())
 def test_userconfig_repr_nondefault_kwargs(
     randomstring, kw, cls, get_random_of_datatype
 ):
+    # Skip optional sections
     if kw == "engine":
         return
 
@@ -144,7 +143,7 @@ def test_userconfig_repr_nondefault_kwargs(
         assert f"{kw}={repr(val)}" in repr_c
 
 
-@pytest.mark.parametrize("kw,cls", known_manager_config_opts.items())
+@pytest.mark.parametrize("kw,cls", known_core_config_opts.items())
 def test_managerconfig_repr_nondefault_kwargs(
     randomstring, fs, kw, cls, get_random_of_datatype
 ):
@@ -152,7 +151,7 @@ def test_managerconfig_repr_nondefault_kwargs(
     if cls == os.PathLike:
         val = pathlib.Path(val)
 
-    repr_c = repr(ManagerEndpointConfig(**{kw: val}))
+    repr_c = repr(CoreEndpointConfig(**{kw: val}))
 
     assert f"{kw}={repr(val)}" in repr_c
 
@@ -236,8 +235,8 @@ def test_dispatcher_excludes_none():
     "cls",
     (
         BaseConfig,
+        CoreEndpointConfig,
         UserEndpointConfig,
-        ManagerEndpointConfig,
     ),
 )
 def test_config_init_validated_with_pydantic(cls):

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -19,15 +19,11 @@ from unittest import mock
 
 import pytest
 import yaml
-from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import (
-    ManagerEndpointConfig,
+    CoreEndpointConfig,
     UserEndpointConfig,
 )
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_compute_endpoint.engines import (
-    ThreadPoolEngine,
-)
 from globus_compute_sdk import Client
 from globus_sdk import NetworkError
 
@@ -70,29 +66,6 @@ def mock_launch():
 
 
 @pytest.fixture
-def mock_get_config():
-    with mock.patch(f"{_mock_base}get_config") as m:
-        yield m
-
-
-@pytest.fixture
-def conf():
-    _conf = UserEndpointConfig(engine=ThreadPoolEngine())
-    _conf.source_content = "# test source content"
-    _conf.source_content += "\nengine:\n  type: ThreadPoolEngine"
-    yield _conf
-
-
-@pytest.fixture
-def mock_ep_data(fs, conf):
-    ep = endpoint.Endpoint()
-    ep_dir = pathlib.Path("/some/path/mock_endpoint")
-    ep_dir.mkdir(parents=True, exist_ok=True)
-    log_to_console = False
-    yield ep, ep_dir, log_to_console, conf
-
-
-@pytest.fixture
 def table_buf():
     buf = io.StringIO()
     partial_print = functools.partial(
@@ -103,18 +76,18 @@ def table_buf():
 
 
 @pytest.fixture
-def mock_ep_get():
-    with mock.patch.object(Endpoint, "get_endpoints") as m:
-        m.return_value = {}
-        yield m
-
-
-@pytest.fixture
 def mock_ep_dir(fs, mock_ep_data, mock_get_config):
     ep, ep_dir, *_, conf = mock_ep_data
     mock_get_config.return_value = conf
     ep._config_file_path(ep_dir).write_text(conf.source_content)
     yield ep, ep_dir
+
+
+@pytest.fixture
+def mock_ep_get():
+    with mock.patch.object(Endpoint, "get_endpoints") as m:
+        m.return_value = {}
+        yield m
 
 
 @pytest.fixture
@@ -973,7 +946,7 @@ def test_migrate_to_template_capable_success(
 
 def test_migrate_to_template_capable_already_template_capable(mock_get_config):
     mock_config_path = pathlib.Path("some/config/dir")
-    mock_get_config.return_value = mock.Mock(spec=ManagerEndpointConfig)
+    mock_get_config.return_value = mock.Mock(spec=CoreEndpointConfig)
 
     with pytest.raises(ValueError) as pyt_exc:
         Endpoint.migrate_to_template_capable(mock_config_path)

--- a/compute_sdk/globus_compute_sdk/sdk/_environments.py
+++ b/compute_sdk/globus_compute_sdk/sdk/_environments.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from urllib.parse import urlparse
 
-# Same UUID for tutorial MEP in all environments
+# Same UUID for tutorial CEP in all environments
 TUTORIAL_EP_UUID = "4b116d3c-1703-4f8f-9f6f-39921e5864df"
 
 

--- a/compute_sdk/globus_compute_sdk/sdk/_environments.py
+++ b/compute_sdk/globus_compute_sdk/sdk/_environments.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from urllib.parse import urlparse
 
-# Same UUID for tutorial CEP in all environments
+# Same UUID for Tutorial endpoint in all environments
 TUTORIAL_EP_UUID = "4b116d3c-1703-4f8f-9f6f-39921e5864df"
 
 

--- a/compute_sdk/globus_compute_sdk/sdk/batch.py
+++ b/compute_sdk/globus_compute_sdk/sdk/batch.py
@@ -23,7 +23,7 @@ _default_serde = ComputeSerializer()
 @dataclass
 class UserRuntime:
     """Information about a user's runtime environment, which is sent along with task
-    submissions to the MEP user config renderer.
+    submissions to the CEP user config renderer.
 
     Parameters
     ----------

--- a/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
+++ b/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 COMPUTE_DIR_ENV = "GLOBUS_COMPUTE_USER_DIR"
+COMPUTE_EP_DIR_ENV = "GLOBUS_COMPUTE_ENDPOINT_DIR"
 
 
 def get_compute_dir() -> Path:

--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -28,7 +28,7 @@ from globus_compute_sdk.sdk._environments import (
     get_web_service_url,
 )
 from globus_compute_sdk.sdk.client import _ComputeWebClient
-from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from globus_compute_sdk.sdk.compute_dir import COMPUTE_DIR_ENV, ensure_compute_dir
 from globus_compute_sdk.sdk.executor import _RESULT_WATCHERS
 from globus_compute_sdk.sdk.hardware_report import hardware_commands_list
 from globus_compute_sdk.sdk.utils import display_name
@@ -529,7 +529,7 @@ def run_all_diags_wrapper(
             else:
                 diagnostic_output.append(cur_output + "\n")
 
-    # Should we provide default UUID as the Tutorial MEP?  It would
+    # Should we provide default UUID as the Tutorial MUEP?  It would
     # likely slow down the diagnostic by 10-20 seconds while starting the UEP
     # if ep_uuid is None:
     #     ep_uuid = TUTORIAL_EP_UUID
@@ -645,7 +645,7 @@ def do_diagnostic_base(diagnostic_args):
         help=(
             "Gather endpoint configuration and log info from the specified"
             " parent directory instead of the default ~/.globus_compute or"
-            " what is set in $GLOBUS_COMPUTE_USER_DIR"
+            f" what is set in ${COMPUTE_DIR_ENV}"
         ),
     )
     parser.add_argument(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3830,7 +3830,7 @@ New Functionality
 
 .. |DillCodeSource| replace:: :class:`~globus_compute_sdk.serialize.DillCodeSource`
 
-.. |audit_log_path| replace:: :class:`audit_log_path <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
+.. |audit_log_path| replace:: :class:`audit_log_path <globus_compute_endpoint.endpoint.config.config.CoreEndpointConfig>`
 .. |detach_endpoint| replace:: :class:`detach_endpoint <globus_compute_endpoint.endpoint.config.config.UserEndpointConfig>`
 .. |GlobusComputeEngine| replace:: :class:`~globus_compute_endpoint.engines.GlobusComputeEngine`
 .. |ThreadPoolEngine| replace:: :class:`~globus_compute_endpoint.engines.thread_pool.ThreadPoolEngine`

--- a/docs/endpoints/config_reference.rst
+++ b/docs/endpoints/config_reference.rst
@@ -3,7 +3,7 @@ Configuration Reference
 
 Globus Compute endpoints require two configuration files:
 
-- ``config.yaml`` for the manager endpoint process
+- ``config.yaml`` for the core endpoint process
 - ``user_config_template.yaml.j2`` for user endpoint processes
 
 These two YAML files serve as convenience interfaces to the Python configuration
@@ -132,6 +132,7 @@ rough equivalent to the ``ProcessPoolEngine`` example would be:
      provider:
        type: LocalProvider
        max_blocks: 4
+
 
 Retries
 ^^^^^^^
@@ -317,15 +318,15 @@ both the |HighThroughputExecutor|_ and the `available providers`_.
 .. _Parsl implements a number of providers: https://parsl.readthedocs.io/en/stable/reference.html#providers
 .. _available providers: https://parsl.readthedocs.io/en/stable/reference.html#providers
 
-.. _endpoint-manager-config:
+.. _core-endpoint-config:
 
-Manager Endpoint Configuration
-==============================
+Core Endpoint Configuration
+===========================
 
-The ``config.yaml`` file contains the YAML configuration for the manager
+The ``config.yaml`` file contains the YAML configuration for the core
 endpoint process, which manages user endpoint processes.  Under the hood, all
 configuration options in this file are used to create an instance of the
-|ManagerEndpointConfig| class.
+|CoreEndpointConfig| class.
 
 - ``public``
 
@@ -386,7 +387,7 @@ configuration options in this file are used to create an instance of the
 
   The path to the user endpoint configuration JSON schema file.  If not
   specified, the default schema path will be used:
-  ``~/.globus_compute/my-mep/user_config_schema.json``.
+  ``~/.globus_compute/my-ep/user_config_schema.json``.
 
   See :ref:`user-config-schema-json` for more information.
 
@@ -494,7 +495,7 @@ available options.
    :inherited-members:
    :show-inheritance:
 
-.. autoclass:: globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig
+.. autoclass:: globus_compute_endpoint.endpoint.config.config.CoreEndpointConfig
    :members:
    :member-order: bysource
    :inherited-members:

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -8,6 +8,8 @@ The Compute Endpoint may be installed via PyPI in the usual manner, as well as
 via system packages.  See :doc:`installation` for more information.
 
 
+.. _endpoint_user_guide_overview:
+
 Overview
 ========
 
@@ -32,6 +34,27 @@ A Globus Compute Endpoint consists of three main process types:
 
 For a detailed look at how a task makes its way to a user endpoint process, see
 :ref:`tracing-a-task`.
+
+
+Disambiguation of "Endpoint"
+----------------------------
+
+The word ``Endpoint`` is overloaded with several meanings, and without context
+it can refer to any of several entities. While the three types of endpoint
+*process* are described above, we may also use "Globus Compute Endpoint" to
+refer to the entirety of the Compute software package: the Python software
+that runs on the login and compute nodes, using CEPs, UEPs, and worker
+processes to receive and execute tasks.
+
+A Core endpoint process started by a privileged user with identity mapping
+enabled is running in *Multi-User* mode.  Without identity mapping, or if
+started by a non-privileged user, it is running in *Single-User* mode.  These
+are sometimes referred to as Multi-User and Single-User endpoints.
+
+This documentation attempts to be as specific as possible when referring to
+the overall 'endpoint', or to its constituent parts, such as Core endpoints
+or User endpoints. However, as language itself is imperfect, please contact
+us with any suggestions if any specific references are unclear.
 
 
 Quickstart

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -32,6 +32,10 @@ A Globus Compute Endpoint consists of three main process types:
   resources (e.g., HPC cluster nodes) according to the rendered configuration
   template.
 
+.. note::
+  The ``Core`` endpoint was previously known as the ``Manager`` endpoint, changed
+  in 4.16.0, released August 2026
+
 For a detailed look at how a task makes its way to a user endpoint process, see
 :ref:`tracing-a-task`.
 

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -19,7 +19,7 @@ leadership‑class HPC systems.
 
 A Globus Compute Endpoint consists of three main process types:
 
-- **Manager endpoint process (MEP)** - Renders a configuration template to
+- **Core endpoint process (CEP)** - Renders a configuration template to
   launch and manage user endpoint processes.
 
 - **User endpoint process (UEP)** - Establishes secure communication with Globus
@@ -93,8 +93,8 @@ via the ``configure`` subcommand:
 ``config.yaml``
 ---------------
 
-The ``config.yaml`` file controls the manager endpoint process.  Please refer
-to :ref:`endpoint-manager-config` for details on each field.
+The ``config.yaml`` file controls the core endpoint process.  Please refer
+to :ref:`core-endpoint-config` for details on each field.
 
 .. code-block:: yaml
    :caption: Default ``config.yaml`` configuration
@@ -112,14 +112,14 @@ to :ref:`endpoint-manager-config` for details on each field.
 ``user_config_template.yaml.j2``
 --------------------------------
 
-The manager endpoint process will render this template with user defined
+The core endpoint process will render this template with user defined
 variables to launch a user endpoint process.  More than simple interpolation,
 the endpoint treats this file as a `Jinja template`_, enabling a good bit of
 flexibility.
 
-The template file lives in the manager endpoint directory by default, but users
+The template file lives in the core endpoint directory by default, but users
 can specify a different template path using the ``user_config_template_path``
-setting in the manager's :ref:`config.yaml <endpoint-manager-config>`.
+setting in the core endpoint's :ref:`config.yaml <core-endpoint-config>`.
 
 The default template includes a basic single-worker configuration and defines
 two variables: ``endpoint_setup`` and ``worker_init``.  Both variables default
@@ -162,10 +162,10 @@ peculiarities.
 ---------------------------
 
 Admins can define a `JSON schema <https://json-schema.org/>`_ to validate
-user-defined variables.  The schema file lives in the manager endpoint directory
+user-defined variables.  The schema file lives in the core endpoint directory
 by default, but users can specify a different schema path using the
-``user_config_schema_path`` variable in the manager's :ref:`config.yaml
-<endpoint-manager-config>`.
+``user_config_schema_path`` variable in the core endpoint's :ref:`config.yaml
+<core-endpoint-config>`.
 
 The default schema is quite permissive, enforcing that the two default template
 variables are strings, then allowing any other user-defined properties:
@@ -252,7 +252,7 @@ Starting the Endpoint
 
 After configuration, start the endpoint instance with the ``start`` subcommand.
 Once started, the endpoint stays attached to the console, with a timer that
-updates every second as a hint that the manager endpoint process is running:
+updates every second as a hint that the core endpoint process is running:
 
 .. code-block:: console
 
@@ -266,7 +266,7 @@ services will request access to your `Globus Auth`_ identity and
 `Globus Groups`_.  Your Globus Auth identity will register as the endpoint owner
 and cannot be changed.
 
-If you start the endpoint as a non-privileged local user, then the manager and
+If you start the endpoint as a non-privileged local user, then the core and
 user endpoint processes will run as the same local user, and the endpoint will
 only accept tasks submitted by the endpoint owner.  We refer to this as a
 single-user endpoint:
@@ -274,7 +274,7 @@ single-user endpoint:
 .. code-block:: text
    :caption: Single-user endpoint process hierarchy
 
-   Manager Endpoint Process (alice, UID: 1001)
+   Core Endpoint Process (alice, UID: 1001)
    └── User Endpoint Process (alice, UID: 1001)
 
 .. hint::
@@ -299,13 +299,13 @@ subcommand:
    $ gce stop my_endpoint
    > Endpoint <my_endpoint> is now stopped
 
-Alternatively, if the PID of the manager endpoint process is handy, then either
+Alternatively, if the PID of the core endpoint process is handy, then either
 will work:
 
 .. code-block:: console
 
-   $ kill -SIGQUIT <manager_pid>    # equivalent to -SIGTERM
-   $ kill -SIGTERM <manager_pid>    # equivalent to -SIGQUIT
+   $ kill -SIGQUIT <core_pid>    # equivalent to -SIGTERM
+   $ kill -SIGTERM <core_pid>    # equivalent to -SIGQUIT
 
 
 Basic User Workflow
@@ -335,7 +335,7 @@ when submitting a task:
    ``Executor`` class; please consult the :doc:`../sdk/executor_user_guide`
    documentation for more information.
 
-The manager endpoint process renders the configuration template with the
+The core endpoint process renders the configuration template with the
 user-defined variables, then launches a user endpoint process.  When these
 values change, a new user endpoint process is launched and can run concurrently
 with existing processes.
@@ -401,8 +401,8 @@ Say there are three custom files in a directory that we want to use during confi
    $ pwd
    /my/compute/config/source/files/directory
    $ ls
-   custom_manager_config.yaml    custom_user_template.yaml.j2     custom_user_schema.json
-   $ cat custom_manager_config.yaml
+   custom_core_config.yaml    custom_user_template.yaml.j2     custom_user_schema.json
+   $ cat custom_core_config.yaml
    display_name: Custom Config Endpoint
    $ cat custom_user_template.yaml.j2
    endpoint_setup: {{ endpoint_setup|default() }}
@@ -417,13 +417,13 @@ Say there are three custom files in a directory that we want to use during confi
    }
 
 The ``gce configure`` command can be told to use those, instead of
-the defaults, using ``--manager-config``, ``--template-config``, and
+the defaults, using ``--core-config``, ``--template-config``, and
 ``--schema-config``, respectively:
 
 .. code-block:: console
 
    $ gce configure \
-      --manager-config custom_manager_config.yaml \
+      --core-config custom_core_config.yaml \
       --template-config custom_user_template.yaml.j2 \
       --schema-config custom_user_schema.json \
       my_custom_endpoint
@@ -723,7 +723,7 @@ and writing a custom ``globus-compute-endpoint`` wrapper:
 
 (The use of ``exec`` is not critical, but keeps the process tree tidy.)
 
-The manager endpoint process exports the following two environment variables that
+The core endpoint process exports the following two environment variables that
 shim‑authors may use to fine‑tune customizations:
 
 - ``GC_USER_PYTHON_VERSION`` - A dotted-decimal Python version (e.g., ``3.13.7``) that
@@ -757,7 +757,7 @@ Debugging User Endpoint Processes
 ---------------------------------
 
 The ``--debug`` flag will not carry-over to the child user endpoint processes.
-In particular, the command executed by the manager endpoint process is:
+In particular, the command executed by the core endpoint process is:
 
 .. code-block:: python
    :caption: arguments to ``os.execvpe``
@@ -1285,7 +1285,7 @@ Audit Logging
 -------------
 
 Audit logging is available only to High-Assurance endpoints, and is enabled by
-the ``audit_log_path`` |ManagerEndpointConfig| item:
+the ``audit_log_path`` |CoreEndpointConfig| item:
 
 .. code-block:: yaml
    :caption: Example ``config.yaml`` showing the ``audit_log_path``
@@ -1305,18 +1305,18 @@ When enabled, task events, if available, will be emitted one record per line:
    :caption: Example ``audit.log`` content; the ``...`` fields are omitted for
       documentation clarity
 
-   2025-04-10T14:44:58.742079-05:00 uid=0 pid=... eid=... Begin MEP session =====
+   2025-04-10T14:44:58.742079-05:00 uid=0 pid=... eid=... Begin CEP session =====
    ...
    2025-04-10T14:45:30.906170-05:00 uid=... pid=... uep=... fid=... tid=... bid= RECEIVED
    2025-04-10T14:45:30.906661-05:00 uid=... pid=... uep=... fid=... tid=... bid= EXEC_START
    2025-04-10T14:45:37.401833-05:00 uid=... pid=... uep=... fid=... tid=... bid=4 jid=2477 RUNNING
    2025-04-10T14:45:37.969570-05:00 uid=... pid=... uep=... fid=... tid=... bid=4 jid=2477 EXEC_END
    ...
-   2025-04-10T14:46:39.689716-05:00 uid=0 pid=... eid=... End MEP session -----
+   2025-04-10T14:46:39.689716-05:00 uid=0 pid=... eid=... End CEP session -----
 
-Each session begins when the MEP starts, and ends when the MEP stops (denoted
-with the sentinel lines ``Begin MEP session =====`` and
-``End MEP session -----``).  Each record contains for the emitting process:
+Each session begins when the CEP starts, and ends when the CEP stops (denoted
+with the sentinel lines ``Begin CEP session =====`` and
+``End CEP session -----``).  Each record contains for the emitting process:
 
 - a local-timezone timestamp in ISO 8601 format
 - ``uid`` -- the POSIX user id
@@ -1497,22 +1497,22 @@ The workflow for a task sent to an endpoint roughly follows these steps:
    it to start a user endpoint process as the user that initiated the REST
    request.
 
-#. If running a :doc:`multi-user endpoint <multi_user>`, the manager endpoint
+#. If running a :doc:`multi-user endpoint <multi_user>`, the core endpoint
    process maps the Globus Auth identity in the start request to a local POSIX
-   username.  If not, the manager endpoint process skips identity mapping
+   username.  If not, the core endpoint process skips identity mapping
    altogether.
 
-#. The manager endpoint process calls |fork(2)|_ to ceate a new process.
+#. The core endpoint process calls |fork(2)|_ to ceate a new process.
 
-#. If running a :doc:`multi-user endpoint <multi_user>`, the manager endpoint
+#. If running a :doc:`multi-user endpoint <multi_user>`, the core endpoint
    process ascertains the host-specific UID based on a |getpwnam(3)|_ call with
    the local username from the previous step, then drops privileges.
 
-#. The manager endpoint process validates the user-defined variables against the
+#. The core endpoint process validates the user-defined variables against the
    JSON schema, if present, then renders the user endpoint configuration
    template.
 
-#. The manager endpoint process calls ``exec()`` to launch the user endpoint
+#. The core endpoint process calls ``exec()`` to launch the user endpoint
    process and passes the generated configuration over ``stdin``.  Each user
    endpoint process creates a dedicated directory in the local user's
    ``$HOME/.globus_compute/`` directory to store logs and other essential files.
@@ -1580,7 +1580,7 @@ reach out to our Team directly by submitting a `support ticket`_.
 .. _MPIExecutor: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.MPIExecutor.html
 .. |SimpleLauncher| replace:: ``SimpleLauncher``
 .. _SimpleLauncher: https://parsl.readthedocs.io/en/stable/stubs/parsl.launchers.SimpleLauncher.html
-.. |ManagerEndpointConfig| replace:: :class:`ManagerEndpointConfig <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
+.. |CoreEndpointConfig| replace:: :class:`CoreEndpointConfig <globus_compute_endpoint.endpoint.config.config.CoreEndpointConfig>`
 .. _Web UI: https://app.globus.org/compute
 .. _Jinja template: https://jinja.palletsprojects.com/en/stable/
 .. _Globus Auth: https://www.globus.org/platform/services/auth

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -177,7 +177,7 @@ fields, to specify the contact email and identity mapping file path respectively
    email: admin@example.edu
    identity_mapping_config_path: /root/.globus_compute/my_mu_ep/example_identity_mapping_config.json
 
-Please refer to :ref:`endpoint-manager-config` for details on each field.
+Please refer to :ref:`core-endpoint-config` for details on each field.
 
 
 .. _example-idmap-config:
@@ -196,7 +196,7 @@ to the regex before searching, so the actual regular expression used would be
 ``^(.*)@example.com$``.  Finally, if a match is found, the first saved group is
 the output (i.e., ``{0}``).  As an example, if a ``username`` field contained
 ``mickey97@example.com``, then this configuration would return ``mickey97``, and
-the MEP would then use |getpwnam(3)|_ to look up ``mickey97``.  But if no
+the CEP would then use |getpwnam(3)|_ to look up ``mickey97``.  But if no
 username field in any of the identities in the set ended with ``@example.com``,
 then it would not match and the start request would fail.
 
@@ -262,9 +262,9 @@ trying multiple avenues to ascertain a proper mapping.
    ``globus-idm-validator`` tool.  This script is installed as part of the
    |globus-identity-mapping|_ dependency.
 
-The manager endpoint process watches this file for changes.  If an administrator
+The core endpoint process watches this file for changes.  If an administrator
 needs to make a live change, simply update the content of the identity mapping
-file specified by the ``config.yaml`` configuration.  The manager endpoint
+file specified by the ``config.yaml`` configuration.  The core endpoint
 process will note the change and atomically apply it: if the new identity
 mapping configuration is invalid, the previously loaded configuration will
 remain in place.  In both cases (valid or invalid), the endpoint will emit a
@@ -407,7 +407,7 @@ Starting the Multi-User Endpoint
 ================================
 
 A multi-user endpoint requires a privileged local user account (e.g., ``root``)
-to start, enabling the manager endpoint process to perform identity mapping and
+to start, enabling the core endpoint process to perform identity mapping and
 drop privileges to mapped user accounts.  Apart from this initial setup
 requirement, multi-user endpoints operate identically to regular endpoints for
 starting and stopping:
@@ -424,7 +424,7 @@ isolation of execution environments:
 .. code-block:: text
    :caption: Multi-user endpoint process hierarchy
 
-   Manager Endpoint Process (root)
+   Core Endpoint Process (root)
    ├── User Endpoint Process (alice, UID: 1001)
    ├── User Endpoint Process (bob, UID: 1002)
    └── User Endpoint Process (eve, UID: 1003)
@@ -548,7 +548,7 @@ As a brief intro to PAM, the architecture is designed with four phases:
 The multi-user endpoint implements *account* and *session management*.  If
 enabled, then the child process will create a PAM session, check the account
 (|pam_acct_mgmt(3)|_), and then open a session (|pam_open_session(3)|_).  If
-these two steps succeed, then the manager endpoint process will continue to drop
+these two steps succeed, then the core endpoint process will continue to drop
 privileges.  But in these two steps is where the administrator can implement
 custom configuration.
 
@@ -855,7 +855,7 @@ Administrator Quickstart
    .. code-block:: console
 
       # globus-compute-endpoint start prod_gpu_large
-      > Endpoint Manager initialization
+      > Core Endpoint initialization
       Please authenticate with Globus here:
       ------------------------------------
       https://auth.globus.org/v2/oauth2/authorize?clie...&prompt=login
@@ -872,8 +872,8 @@ Administrator Quickstart
       # globus-compute-endpoint start prod_gpu_large --log-to-console
       >
 
-      ========== Endpoint Manager begins: 1ed568ab-79ec-4f7c-be78-a704439b2266
-              >>> Multi-User Endpoint ID: 1ed568ab-79ec-4f7c-be78-a704439b2266 <<<
+      ========== Core Endpoint begins: 1ed568ab-79ec-4f7c-be78-a704439b2266
+              >>> Endpoint ID: 1ed568ab-79ec-4f7c-be78-a704439b2266 <<<
 
    Additionally, for even noisier output, there is ``--debug``.
 

--- a/docs/endpoints/templates.rst
+++ b/docs/endpoints/templates.rst
@@ -260,8 +260,8 @@ rendered in user space, the administrator must:
 1. Move the template files to a directory that every mapped local user account
    has read access to.
 2. Specify the main template file path with the ``user_config_template_path``
-   variable in the :ref:`endpoint manager configuration
-   <endpoint-manager-config>`.
+   variable in the :ref:`core endpoint configuration
+   <core-endpoint-config>`.
 
 .. code-block:: yaml+jinja
    :caption: Example usage of ``extends`` and ``include`` in a template

--- a/docs/endpoints/troubleshooting.rst
+++ b/docs/endpoints/troubleshooting.rst
@@ -69,7 +69,7 @@ mapping succeeded.
     ]
 
     # an info-level line containing "Globus effective identity"
-    2026-04-10 21:54:39,313397 INFO MainProcess-112 MainThread-281472913129504 globus_compute_endpoint.endpoint.endpoint_manager:777 _event_loop Command process successfully forked for 'alice' (Globus effective identity: 40322b9a-ccff-4e94-a6f6-4aa684bb3121).
+    2026-08-10 21:54:39,313397 INFO MainProcess-112 MainThread-281472913129504 globus_compute_endpoint.endpoint.core_endpoint:777 _event_loop Command process successfully forked for 'alice' (Globus effective identity: 40322b9a-ccff-4e94-a6f6-4aa684bb3121).
 
 
 
@@ -90,7 +90,7 @@ virtual environment to submit tasks.
 "SystemExit" error
 ==================
 
-This happens when a manager endpoint process is unable to start a user endpoint process
+This happens when a core endpoint process is unable to start a user endpoint process
 for various reasons. The table below combines information from § :ref:`exit_code_table`
 and § :ref:`exit_code_table_admins`; see those sections for additional context.
 

--- a/docs/tutorials/compute_for_lambda.rst
+++ b/docs/tutorials/compute_for_lambda.rst
@@ -323,7 +323,7 @@ cases administrators might want to ensure that *only* this known function is cal
 which can be achieved with a :ref:`function allow list <function-allowlist>`:
 
 .. code-block:: yaml
-  :caption: :ref:`config.yaml <endpoint-manager-config>` with a function allow list
+  :caption: :ref:`config.yaml <core-endpoint-config>` with a function allow list
 
   allowed_functions:
     - eca16448-bfe2-445a-900c-cd46b1426522


### PR DESCRIPTION
# Description

    Rename endpoint manager to core endpoint

    To lessen ambiguity between various meanings of ``MEP``, where the
    "M" can be interpreted as *Multi-User* or *Manager*, we want to
    rename the main class/process that manages user endpoints to
    "Core" endpoints.  This means ``CEP`` and ``UEP`` are more easily
    distinguished from multi-user endpoints if the acronym ``MEP`` is
    used in the future.

    This involves changing wording of variables, classes, tests, and
    documentation on ``readthedocs`` and elsewhere.  PRs for the
    Globus docs and service side will be created separatedly.

    [sc-50197]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
