### PR TITLE
Allow EP interchange and workers version to differ

### DIFF
--- a/changelog.d/20260808_000115_kevin_update_parsl.rst
+++ b/changelog.d/20260808_000115_kevin_update_parsl.rst
@@ -1,0 +1,12 @@
+Bug Fixes
+^^^^^^^^^
+
+- The endpoint and worker Parsl versions no longer have to be strictly in sync.
+
+Changed
+^^^^^^^
+
+- Bumped ``parsl`` dependency version from `2026.4.20`_ to at least
+  `2026.7.27`_.  The big change here is the *at least*: Compute is trialing
+  reducing the strict pin to Parsl versions.
+

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -152,8 +152,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.executor.launch_cmd = self._get_compute_launch_cmd()
 
         # This flag serves as a temporary workaround to support different
-        # Python versions at the endpoint and worker layers. We can drop
-        # the flag once Parsl supports modular internal message protocols.
+        # Python and Parsl versions at the endpoint and worker layers.  We
+        # can drop this flag once Parsl supports modular internal message
+        # protocols.
         self.executor._check_python_mismatch = False
 
         self.run_in_sandbox = run_in_sandbox
@@ -306,6 +307,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
     ):
         assert endpoint_id, "GCExecutor requires kwarg:endpoint_id at start"
         assert run_dir, "GCExecutor requires kwarg:run_dir at start"
+        assert self.executor.provider is not None, "GCExecutor requires a provider"
 
         self.set_working_dir(run_dir=run_dir)
 
@@ -508,6 +510,8 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
     @property
     def scaling_enabled(self) -> bool:
         """Indicates whether scaling is possible"""
+        assert self.executor.provider is not None, "much earlier problems if None"
+
         max_blocks = self.executor.provider.max_blocks
         return max_blocks > 0
 
@@ -524,6 +528,8 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         -------
         Object containing info on the current status of the endpoint
         """
+        assert self.executor.provider is not None, "much earlier problems if None"
+
         managers = self.get_connected_managers()
         managers_packages = self.get_connected_managers_packages()
         manager_info: dict[str, list] = {}

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -24,10 +24,7 @@ REQUIRES = [
     "click>=8.3.3,<8.4.0",
     "click-option-group>=0.5.6,<1",
     "pyzmq>=24,<=28",
-    # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
-    # of different features and functions
-    # pin exact versions because it does not use semver
-    "parsl==2026.4.20",
+    "parsl>=2026.7.27",
     # May 2026: Parsl 1.4.0 just released; has an as-yet undiagnosed iteration bug
     "pika>=1.2,<1.5",
     "pyprctl<0.2.0",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3848,6 +3848,7 @@ New Functionality
 .. |SlurmProvider| replace:: ``SlurmProvider``
 .. _SlurmProvider: https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html
 
+.. _2026.7.27: https://pypi.org/project/parsl/2026.7.27/
 .. _2026.4.20: https://pypi.org/project/parsl/2026.4.20/
 .. _2026.2.23: https://pypi.org/project/parsl/2026.2.23/
 .. _2026.1.5: https://pypi.org/project/parsl/2026.1.5/


### PR DESCRIPTION
While the original motivation to keep the interchange and worker Parsl (and Python) versions strictly in sync is still around — there is yet no internal Parsl protocol to ensure enforce correct communication between versions — the pragmatic reality is that Parsl (and specifically the HTEX) is not structurally changing these days.  Consequently, we will attempt relaxing the version constraint while Parsl (as of [2026.5.18](https://pypi.org/project/parsl/2026.5.18/)) is [more lenient about cross-Parsl-version interaction](https://github.com/Parsl/parsl/pull/4098) in the HTEX.  With luck, this will provide some relief for Compute EP administrators and users.

## Type of change

- New feature (non-breaking change that adds functionality)