### PR TITLE
Update env var awareness of new EPDIR var

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -199,49 +199,36 @@ def get_ep_dir_by_name_or_uuid(ctx, param, value, require_local: bool = True):
                              If this is False, an unrecognized UUID is ok,
                              presumably used to interact with the web-service.
     """
+
     if not value:
         ctx.params["ep_dir"] = None
         return
 
-    conf_dir = get_compute_dir()
-    try:
-        uuid.UUID(value)
-    except ValueError:
-        # value is a name
-        path = conf_dir / value
-        uuid_provided = False
+    ep_dir: pathlib.Path | None
+    if _ep_dir := os.environ.get(COMPUTE_EP_DIR_ENV):
+        ep_dir = pathlib.Path(_ep_dir)
     else:
-        uuid_provided = True
-        path = Endpoint.get_endpoint_dir_by_uuid(conf_dir, value)
+        conf_dir = get_compute_dir()
+        try:
+            uuid.UUID(value)
 
-        # pass the UUID value as a param to be used later, but only if
-        # the endpoint isn't necessarily local.  This require_local check
-        # also avoids adding the `ep_uuid` as a param to some endpoint commands
-        if not require_local:
-            ctx.params["ep_uuid"] = value
+            if not require_local:
+                # pass the UUID value as a param to be used later, but only if
+                # the endpoint isn't necessarily local.  This require_local check
+                # also avoids adding the `ep_uuid` as a param to some endpoint commands
+                ctx.params["ep_uuid"] = value
 
-    if (path and not path.exists()) or (path is None and require_local):
-        # If a EP name is given but dir doesn't exist, or if a UUID
-        # is given but a local dir is required but missing, error out.
-        # (Otherwise, proceed with at least one of ep_dir/ep_uuid set)
-        if uuid_provided:
-            ep_info = f"with ID {value}"
-            ep_name = "<endpoint_name>"
-        else:
-            ep_info = f"at {path}"
-            ep_name = value
+            ep_dir = Endpoint.get_endpoint_dir_by_uuid(conf_dir, value)
+            ep_info = value
+        except ValueError:
+            ep_dir = conf_dir / value
+            ep_info = ep_dir
 
-        msg = textwrap.dedent(f"""
-            There is no endpoint configuration on this machine {ep_info}
-
-            1. Please create a configuration template with:
-                globus-compute-endpoint configure {ep_name}
-            2. Update the configuration
-            3. Start the endpoint
-            """)
+    if (ep_dir and not ep_dir.is_dir()) or (ep_dir is None and require_local):
+        msg = textwrap.dedent(f"Failed to find endpoint configuration ({ep_info})")
         raise ClickException(msg)
 
-    ctx.params["ep_dir"] = path
+    ctx.params["ep_dir"] = ep_dir
 
 
 def get_ep_dir_uuid_only_ok(ctx, param, value):

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -67,7 +67,7 @@ def test_non_configured_endpoint(tmp_path):
     with mock.patch.dict(os.environ, env):
         result = CliRunner().invoke(app, ["start", "newendpoint"])
         assert "newendpoint" in result.stderr
-        assert "no endpoint configuration" in result.stderr
+        assert "Failed to find endpoint configuration" in result.stderr
 
 
 def test_stop_remote_endpoint(mocker):

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -358,7 +358,7 @@ def test_init_config_dir_permission_error(fs):
 def test_start_endpoint_no_such_ep(run_line, mock_ep, ep_name):
     res = run_line(f"start {ep_name}", assert_exit_code=1)
     mock_ep.start_endpoint.assert_not_called()
-    assert "no endpoint configuration on this machine at " in res.stderr
+    assert "Failed to find endpoint configuration " in res.stderr
     assert ep_name in res.stderr
 
 
@@ -1300,19 +1300,18 @@ def test_name_or_uuid_decorator(tmp_path, mocker, run_line, name, uuid):
 
 
 @pytest.mark.parametrize(
-    "data",
+    "ep_name, msg",
     [
-        ("foo", "no endpoint configuration on this machine"),
-        (str(uuid.uuid4()), "no endpoint configuration on this machine with ID"),
+        ("foo", "Failed to find endpoint configuration"),
+        (str(uuid.uuid4()), "Failed to find endpoint configuration"),
     ],
 )
-def test_get_endpoint_by_name_or_uuid_error_message(tmp_path, run_line, data):
-    value, error = data
-
+def test_get_endpoint_by_name_or_uuid_error_message(tmp_path, run_line, ep_name, msg):
     with mock.patch(f"{_MOCK_BASE}get_compute_dir", return_value=tmp_path):
-        result = run_line(f"start {value}", assert_exit_code=1)
+        result = run_line(f"start {ep_name}", assert_exit_code=1)
 
-    assert error in result.stderr
+    assert msg in result.stderr
+    assert ep_name in result.stderr
 
 
 @pytest.mark.parametrize("is_tty", [True, False])
@@ -1855,22 +1854,11 @@ def test_delete_endpoint_local_uuid(mocker, run_line, mock_ep):
     assert not mock_ep.delete_endpoint.called
 
 
-@pytest.mark.parametrize(
-    ("delete_args", "err_msg"),
-    [
-        (
-            "--yes fake_uuid",
-            "no endpoint configuration",
-        ),
-    ],
-)
-def test_delete_endpoint_no_local_config(
-    run_line, mock_ep, make_endpoint_dir, delete_args, err_msg
-):
-    line = f"delete --yes {delete_args}"
+def test_delete_endpoint_no_local_config(run_line, mock_ep, make_endpoint_dir):
+    line = f"delete --yes fake_uuid"
     result = run_line(line, assert_exit_code=1)
     assert not mock_ep.delete_endpoint.called
-    assert err_msg in result.stderr
+    assert "Failed to find endpoint configuration" in result.stderr
 
 
 def test_render_user_config_happy_path(


### PR DESCRIPTION
`GLOBUS_COMPUTE_ENDPOINT_DIR` was recently introduced as an avenue for easier information sharing with the UEP.  Now, rather than having to ascertain which directory to consider home base, it can read the environment variable `GLOBUS_COMPUTE_ENDPOINT_DIR` and know directly.  Unfortunately, one spot did not use this new environment variable, so if it was set to a non-default place, the UEP would refuse to startup because it would think that it's directory was not created.

Update the logic in that problem spot to look first to `GLOBUS_COMPUTE_ENDPOINT_DIR`, before falling back to the default directory placement.

For the reviewer, the key conceptual change/addition in `cli.py` is:

```diff
+    ep_dir: pathlib.Path | None
+    if _ep_dir := os.environ.get(COMPUTE_EP_DIR_ENV):
+        ep_dir = pathlib.Path(_ep_dir)
+    else:
+        ...
```

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)