### PR TITLE
Correct handling of log path in record

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -324,15 +324,16 @@ def ensure_paths(ep_name: str | None, custom_paths: dict | None = None) -> pathl
     if ep_dir.exists() and not ep_dir.is_dir():
         raise ValueError(f"{COMPUTE_EP_DIR_ENV} must be a directory: {ep_dir}")
 
-    uep_desc = f" for UEP {ep_name}" if ep_name else ""
-    logger.info(f"Endpoint directory{uep_desc} set to {ep_dir}")
-
     # Now update the ep_dir ENV with the final value
     # Parent directory (default -> ~/.globus_compute but could be anywhere)
     # might have already been created but confirm anyway
     ep_dir = ep_dir.resolve()
     ep_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.environ[COMPUTE_EP_DIR_ENV] = str(ep_dir)
+    ep_dir_str = str(ep_dir)
+    os.environ[COMPUTE_EP_DIR_ENV] = ep_dir_str
+
+    uep_desc = f" for UEP {ep_name}" if ep_name else ""
+    log.info(f"Endpoint directory{uep_desc} set to {ep_dir_str!r}")
 
     if log_path_str:
         log_path = pathlib.Path(os.path.expandvars(log_path_str)).expanduser()
@@ -345,8 +346,9 @@ def ensure_paths(ep_name: str | None, custom_paths: dict | None = None) -> pathl
     # Testing of the path's write access is left to the caller in endpoint_manager.py
     log_path = log_path.resolve()
     log_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    log_path_str = str(log_path)
 
-    os.environ[LOG_PATH_ENV] = str(log_path)
-    log.info(f"{LOG_PATH_ENV} has been set to {log_path_str}")
+    os.environ[LOG_PATH_ENV] = log_path_str
+    log.info(f"{LOG_PATH_ENV} has been set to {log_path_str!r}")
 
     return log_path

--- a/compute_endpoint/tests/unit/test_logging_config.py
+++ b/compute_endpoint/tests/unit/test_logging_config.py
@@ -159,7 +159,9 @@ def test_ensure_path_ep_dir_not_dir(fs):
     ),
 )
 @pytest.mark.parametrize("ep_name", ("some_ep_name", None))
-def test_ensure_paths_expand_resolve_config_overrides_env(fs, env, paths, ep_name):
+def test_ensure_paths_expand_resolve_config_overrides_env(
+    fs, caplog, env, paths, ep_name
+):
     """
     This tests
         1) paths.* overrides env variables
@@ -175,6 +177,7 @@ def test_ensure_paths_expand_resolve_config_overrides_env(fs, env, paths, ep_nam
     exp_ep = paths.get("endpoint_dir", env.get(COMPUTE_EP_DIR_ENV, default_dir))
     exp_log = paths.get("endpoint_log", env.get(LOG_PATH_ENV, f"{exp_ep}/endpoint.log"))
 
+    caplog.set_level(logging.INFO)
     with mock.patch.dict(os.environ, env):
         exp_ep = pathlib.Path(os.path.expandvars(exp_ep)).expanduser().resolve()
         exp_log = pathlib.Path(os.path.expandvars(exp_log)).expanduser().resolve()
@@ -185,6 +188,11 @@ def test_ensure_paths_expand_resolve_config_overrides_env(fs, env, paths, ep_nam
 
         assert exp_ep.stat().st_mode & 0o777 == 0o700
         assert exp_log.parent.stat().st_mode & 0o777 == 0o700
+
+    ep_rec = next(r for r in caplog.records if "Endpoint directory" in r.message)
+    log_rec = next(r for r in caplog.records if "GLOBUS_COMPUTE_LOG_PATH" in r.message)
+    assert str(exp_ep) in ep_rec.message, "Expect log record matches set variable"
+    assert str(exp_log) in log_rec.message, "Expect log record matches set variable"
 
 
 def test_ensure_paths_default_uses_name_and_compute_dir(fs, mock_ensure_compute):


### PR DESCRIPTION
A mild cleanup of the not-yet-released recent log path functionality:

* In the `ep_dir` case, use the *final* value; make sure the logs match the environment variable *exactly*, to avoid any possibility of confusion or mismatch
* In the `log_path`, use a *guaranteed* value; fix the case where the log path is not specified, and so resolves to the default `<ep_dir>/endpoint.log`) and is shown in the log as an empty value; always emit exactly what we set the environment variable to.

  Concretely, this changes:

  ```
  > GLOBUS_COMPUTE_LOG_PATH has been set to
  ```

  to

  ```
  > GLOBUS_COMPUTE_LOG_PATH has been set to '/tmp/y/my_single.log'
  ```