### PR TITLE
Remove deprecated `--endpoint-config` arg to `cofigure`

### DIFF
--- a/changelog.d/20260826_132112_lei_remove_endpoint_config_arg_sc_46927.rst
+++ b/changelog.d/20260826_132112_lei_remove_endpoint_config_arg_sc_46927.rst
@@ -1,0 +1,8 @@
+Removed
+^^^^^^^
+
+- The ``--endpoint-config`` option in ``gce configure`` has been removed.
+  This option has been deprecated since `4.4.0`_.
+
+.. _4.4.0: https://globus-compute.readthedocs.io/en/latest/changelog.html#globus-compute-sdk-globus-compute-endpoint-v4-4-0
+

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -375,11 +375,6 @@ def version_command():
         "Specify a custom identity mapping configuration (identity_mapping_config.json)"
     ),
 )
-@optgroup.option(
-    "--endpoint-config",
-    default=None,
-    help="DEPRECATED: use --manager-config or --template-config",
-)
 @optgroup.group(
     "Authentication Policy Creation",
     help=(
@@ -435,7 +430,6 @@ def version_command():
 def configure_endpoint(
     *,
     name: str,
-    endpoint_config: str | None,
     manager_config: pathlib.Path | None,
     template_config: pathlib.Path | None,
     id_mapping_config: pathlib.Path | None,
@@ -465,24 +459,6 @@ def configure_endpoint(
             "Unable to configure new endpoints; Manager Endpoint Processes are not"
             " supported on this system"
         )
-
-    if endpoint_config is not None:
-        warnings.warn(
-            "--endpoint-config is deprecated; use --manager-config instead."
-            " If you want to configure user endpoint processes, use --template-config.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if manager_config is None:
-            manager_config = pathlib.Path(endpoint_config)
-        else:
-            warnings.warn(
-                "Both --endpoint-config and --manager-config were provided;"
-                " --endpoint-config will be ignored.",
-                UserWarning,
-                stacklevel=2,
-            )
 
     try:
         Endpoint.validate_endpoint_name(name)

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -989,42 +989,6 @@ def test_configure_ep_public_visible_by_default(
     assert exp_public is (conf_dict.get("public") is True)
 
 
-def test_configure_ep_endpoint_config_deprecated(run_line, randomstring, mock_ep):
-    ep_config_arg = randomstring()
-
-    with pytest.warns(DeprecationWarning, match="--endpoint-config is deprecated"):
-        run_line(
-            f"configure {randomstring()} --endpoint-config {ep_config_arg}",
-            assert_exit_code=0,
-        )
-
-    assert (
-        mock_ep.configure_endpoint.call_args.kwargs["endpoint_config"].name
-        == ep_config_arg
-    )
-
-
-def test_configure_ep_manager_config_precedence(
-    run_line, randomstring, mock_ep, gc_dir
-):
-    ep_config_arg = randomstring(5)
-    gc_dir.mkdir(parents=True, exist_ok=True)
-    manager_config_arg = gc_dir / randomstring(4)
-    manager_config_arg.touch()
-
-    with pytest.warns(UserWarning, match="--endpoint-config will be ignored"):
-        run_line(
-            f"configure {randomstring()} --manager-config {manager_config_arg}"
-            f" --endpoint-config {ep_config_arg}",
-            assert_exit_code=0,
-        )
-
-    assert (
-        mock_ep.configure_endpoint.call_args.kwargs["endpoint_config"]
-        == manager_config_arg
-    )
-
-
 @pytest.mark.parametrize("manager_config", ("some-config.yaml", None))
 @pytest.mark.parametrize("template_config", ("some-template.yaml.j2", None))
 @pytest.mark.parametrize("schema_config", ("some-schema.json", None))


### PR DESCRIPTION
We deprecated `--endpoint-config` in favor of `--manager-config` in Jan 2026.  This removes `--endpoint-config` as we are now 7 months post deprecation.

The intent is to separate this  removal from the upcoming manager -> core renaming.

[sc-46927]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
