### PR TITLE
Remove unused variable

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -259,7 +259,6 @@ class ComputeLogger(logging.Logger):
 
 
 logging.setLoggerClass(ComputeLogger)
-logger = logging.getLogger(__name__)
 
 
 def setup_logging(


### PR DESCRIPTION
`log` is created already at the top of the module, and this `logger` variable appears to have been erroneously added; it was never utilized, save for errantly recently between releases.

## Type of change

- Code maintenance/cleanup