### PR TITLE
Remove unused logging class

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -251,16 +251,6 @@ def _get_stream_dict_config(debug: bool, no_color: bool) -> dict:
     }
 
 
-class ComputeLogger(logging.Logger):
-    TRACE = logging.DEBUG - 5
-
-    def trace(self, msg, *args, **kwargs):
-        self.log(ComputeLogger.TRACE, msg, args, **kwargs)
-
-
-logging.setLoggerClass(ComputeLogger)
-
-
 def setup_logging(
     *,
     logfile: pathlib.Path | str | None = None,


### PR DESCRIPTION
The last references to `.trace()` were removed in Jan, 2025 (ab700ac07c4b3386cc8cd72be71c8888bedb1d7d, #1784).

## Type of change

- Code maintenance/cleanup