### PR TITLE
Fix a dead link to serde issue resolution docs

### DIFF
--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -90,7 +90,7 @@ example, to use globus_compute_sdk.serialize.AllCodeStrategies:
     gcx.serializer = ComputeSerializer(strategy_code=AllCodeStrategies())
 
 For more information, see:
-    https://globus-compute.readthedocs.io/en/latest/sdk.html#specifying-a-serialization-strategy
+    https://globus-compute.readthedocs.io/en/latest/sdk/executor_user_guide.html#specifying-serde-strategy
 """
 
 

--- a/compute_sdk/tests/unit/test_error_types.py
+++ b/compute_sdk/tests/unit/test_error_types.py
@@ -22,6 +22,6 @@ def test_task_execution_failed_serialization_help_msg():
     tef = TaskExecutionFailed(tb)
     assert "This appears to be an error with serialization." in str(tef)
     assert (
-        "https://globus-compute.readthedocs.io/en/latest/sdk.html"
-        "#specifying-a-serialization-strategy" in str(tef)
+        "https://globus-compute.readthedocs.io/en/latest/sdk/executor_user_guide.html"
+        "#specifying-serde-strategy" in str(tef)
     )


### PR DESCRIPTION
# Description

The current error links to [this page](https://globus-compute.readthedocs.io/en/latest/sdk.html#specifying-a-serialization-strategy), which has had its contents updated and is no longer the correct docs page to point to.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
