### PR TITLE
Fix an instance of broken RST rendering

### DIFF
--- a/docs/sdk/executor_user_guide.rst
+++ b/docs/sdk/executor_user_guide.rst
@@ -584,8 +584,9 @@ Even a single number difference in Python minor versions (e.g., from 3.12 |rarr|
 can generate issues.  Micro version differences (e.g., from 3.11.8 |rarr| 3.11.9)
 are usually safe, though not universally.
 
-Errors may surface as serialization/deserialization ``Exception``s, Globus
-Compute task workers lost due to ``SEGFAULT``, or even incorrect results.
+Errors may surface as serialization/deserialization ``Exception``\s,
+Globus Compute task workers lost due to ``SEGFAULT``,
+or even incorrect results.
 
 Note that the |Client| class's :func:`~globus_compute_sdk.Client.register_function`
 method can be used to pre-serialize a function using the registering SDK's environment


### PR DESCRIPTION
# Description

The current line of text renders like this:

> <img width="819" height="71" alt="image" src="https://github.com/user-attachments/assets/0084c1ef-0c51-46b8-acfd-7143e6241cba" />

This update resolves the rendering issue:

> <img width="826" height="63" alt="image" src="https://github.com/user-attachments/assets/e0697e0f-1865-4564-8d9d-315da91e30a2" />


I also chose to reflow the paragraph around natural sentence break opportunities.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
