### PR TITLE
More explicitly fail on manual UEP uses

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -565,6 +565,11 @@ def start_endpoint(*, ep_dir: pathlib.Path, die_with_parent: bool, **_kwargs):
     # `gce start --die-with-parent` instead of `gce _start-user-endpoint`.
     # deprecated; to be removed in 6 months (roughly Oct 2026)
     if die_with_parent:
+        if sys.stdin and sys.stdin.isatty():
+            raise ClickException(
+                "The --die-with-parent flag is not meant for manual use; it is for"
+                " internal use only."
+            )
         _start_user_endpoint(
             ep_dir=ep_dir,
             endpoint_uuid=state.endpoint_uuid,
@@ -942,32 +947,33 @@ def _start_user_endpoint(
             no_color=state.no_color,
         )
 
+    if sys.stdin and sys.stdin.isatty():
+        raise ClickException("User endpoints must have a parent Core endpoint")
+    if not sys.stdin or sys.stdin.closed:
+        raise Exception(f"Unable to read from stdin ({sys.stdin=!r})")
+
     _no_fn_list_canary = -15  # an arbitrary random integer; invalid as an allow_list
-    ep_info: dict
-    reg_info: dict
-    config_str: str
-    audit_fd: int | None = None
-    fn_allow_list: list[str] | None | int = _no_fn_list_canary
-    if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
-        try:
-            stdin_data = json.loads(sys.stdin.read())
 
-            ep_info = stdin_data["ep_info"]
-            reg_info = stdin_data["amqp_creds"]
-            config_str = stdin_data["config"]
-            audit_fd = stdin_data.get("audit_fd")
-            fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
+    try:
+        stdin_data = json.loads(sys.stdin.read())
 
-            del stdin_data  # clarity for intended scope
+        ep_info: dict = stdin_data["ep_info"]
+        reg_info: dict = stdin_data["amqp_creds"]
+        config_str: str = stdin_data["config"]
+        audit_fd: int | None = stdin_data.get("audit_fd")
+        fn_allow_list: list[str] | None | int
+        fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
 
-        except Exception as e:
-            exc_type = e.__class__.__name__
-            log.debug("Invalid info on stdin -- (%s) %s", exc_type, e)
-            raise ClickException(
-                "Missing or invalid endpoint information from stdin. (Hint: this"
-                " command is not meant to be invoked manually; it should only be run"
-                " by an endpoint manager process.)"
-            ) from e
+        del stdin_data  # clarity for intended scope
+
+    except Exception as e:
+        exc_type = type(e).__name__
+        log.debug("Invalid info on stdin -- (%s) %s", exc_type, e)
+        raise Exception(
+            "Missing or invalid endpoint information from stdin. (Hint: this"
+            " command is not meant to be invoked manually; it should only be run"
+            " by an endpoint manager process.)"
+        ) from e
 
     with contextlib.ExitStack() as stk:
         stk.enter_context(_SendMessageOnErrorExit(reg_info))

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import inspect
 import io
 import json
@@ -433,6 +434,27 @@ def test_endpoint_uuid_name_not_supported(run_line, cli_cmd):
     )
 
 
+@pytest.mark.parametrize("is_uep", (False, True))
+def test_start_ep_hookup(is_uep, make_endpoint_dir, ep_name):
+    cli_args = ["start", ep_name]
+    if is_uep:
+        cli_args.append("--die-with-parent")
+
+    make_endpoint_dir()
+
+    with contextlib.ExitStack() as stk:
+        pyt_e = stk.enter_context(pytest.raises(SystemExit))
+        m_uep = stk.enter_context(mock.patch(f"{_MOCK_BASE}_start_user_endpoint"))
+        m_cep = stk.enter_context(mock.patch(f"{_MOCK_BASE}_start_endpoint_manager"))
+        stk.enter_context(mock.patch.object(sys.stdin, "isatty", return_value=False))
+
+        cli.app.main(args=cli_args, prog_name=cli.app.name)
+
+    assert pyt_e.value.code == 0, "Basal sanity check"
+    assert m_uep.called is is_uep
+    assert m_cep.called is not is_uep
+
+
 @pytest.mark.parametrize(
     "reg_info,config_str,ep_info,audit_fd",
     [
@@ -523,6 +545,27 @@ def test_start_uep_stdin_allowed_fns_overrides_conf(
     assert k["endpoint_config"].allowed_functions == allowed_fns, (
         "allowed field not overridden!"
     )
+
+
+@pytest.mark.parametrize("has_tty", (False, True))
+def test_start_uep_from_tty_disallowed(ep_name, make_endpoint_dir, has_tty):
+    make_endpoint_dir()
+    stde = io.StringIO()
+    cli_args = ("start", "--die-with-parent", ep_name)
+
+    with contextlib.ExitStack() as stk:
+        pyt_e = stk.enter_context(pytest.raises(SystemExit))
+        mock_start = stk.enter_context(mock.patch(f"{_MOCK_BASE}_start_user_endpoint"))
+        stk.enter_context(mock.patch.object(sys.stdin, "isatty", return_value=has_tty))
+        stk.enter_context(redirect_stderr(stde))
+
+        cli.app.main(args=cli_args, prog_name=cli.app.name)
+
+    exit_exc = pyt_e.value
+
+    assert mock_start.called is not has_tty
+    assert exit_exc.code == int(has_tty)
+    assert (" internal use only" in stde.getvalue()) is has_tty
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The original motivation was to fix a "variable may not be used" lint warning. In refactoring, realize that `_start_user_endpoint` should basically not be called by a user, so try "really hard" to be explicit in this errant case.

In so doing, fulfill the original motivation: guarantee that `reg_info` at least exists (per the if-guards and unindent in `cli.py`)

## Type of change

- Code maintenance/cleanup