### PR TITLE
Introduce `make_close_on_exec`

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -52,6 +52,7 @@ from globus_compute_endpoint.endpoint.utils import (
     _redact_url_creds,
     close_all_fds,
     is_privileged,
+    make_close_on_exec,
     send_endpoint_startup_failure_to_amqp,
     update_url_port,
 )
@@ -1003,6 +1004,7 @@ class EndpointManager:
         if not self._audit_log_handler_stop:
             with self._audit_log_lock:
                 audit_r, audit_w = os.pipe2(os.O_DIRECT)
+                make_close_on_exec(audit_r)  # redundant; but layers!
                 self._audit_pipes[audit_r] = {
                     "uid": uid,
                     "endpoint_id": uep_amqp_creds["endpoint_id"],
@@ -1021,13 +1023,14 @@ class EndpointManager:
             raise
 
         if pid > 0:
+            if audit_r:
+                os.close(audit_w)
+                self._audit_pipes[audit_r]["pid"] = pid
+
             proc_args_s = f"({uname}, {ep_name}) {' '.join(proc_args)}"
             self._children[pid] = UserEndpointRecord(
                 ep_name=ep_name, local_user_info=user_record, arguments=proc_args_s
             )
-            if audit_r:
-                os.close(audit_w)
-                self._audit_pipes[audit_r]["pid"] = pid
             log.info(f"Creating new user endpoint (pid: {pid}) [{proc_args_s}]")
             return
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl as _fcntl
 import os as _os
 import pwd as _pwd
 import re as _re
@@ -104,6 +105,11 @@ def _redact_url_creds(raw: _T, redact_user=True, repl="***", count=0) -> _T:
     if isinstance(raw, str):
         return _url_user_pass_re.sub(repl=repl, string=raw, count=count)
     return _urlb_user_pass_re.sub(repl=repl.encode(), string=raw, count=count)
+
+
+def make_close_on_exec(fd: int) -> None:
+    flags = _fcntl.fcntl(fd, _fcntl.F_GETFD)
+    _fcntl.fcntl(fd, _fcntl.F_SETFD, flags | _fcntl.FD_CLOEXEC)
 
 
 def close_all_fds(preserve_fds: t.Iterable[int] = ()) -> None:

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -2218,6 +2218,20 @@ def test_ep_info_not_root_gets_no_matched_identity(
     assert ep_info["posix_ppid"] == mock_os.getppid()
 
 
+def test_audit_pipe_cloexec(successful_exec_from_mocked_root):
+    mock_os, *_, em = successful_exec_from_mocked_root
+    em._audit_log_handler_stop = False
+    audit_r, audit_w = (random.randint(15, 50), random.randint(51, 100))
+    mock_os.pipe2.return_value = audit_r, audit_w
+    with mock.patch(f"{_MOCK_BASE}make_close_on_exec") as mock_cloexec:
+        mock_cloexec.side_effect = SystemExit
+        with pytest.raises(SystemExit):
+            em._event_loop()
+
+    a, _ = mock_cloexec.call_args
+    assert a == (audit_r,), "Expect parent process audit fd cloexec"
+
+
 def test_all_files_closed(successful_exec_from_mocked_root):
     mock_os, *_, em = successful_exec_from_mocked_root
     with pytest.raises(SystemExit) as pyexc:

--- a/compute_endpoint/tests/unit/test_utils.py
+++ b/compute_endpoint/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import fcntl
 import resource
 import sys
 import uuid
@@ -10,6 +11,7 @@ from globus_compute_endpoint.endpoint.utils import (
     _redact_url_creds,
     close_all_fds,
     is_privileged,
+    make_close_on_exec,
     send_endpoint_startup_failure_to_amqp,
     update_url_port,
 )
@@ -154,6 +156,19 @@ def test_cmd_send_failure_publishes_message(mock_mq_chan, randomstring, err_msg)
 
     assert uep_uuid.encode() in k["body"]
     assert err_msg.encode() in k["body"]
+
+
+def test_make_close_on_exec(tmp_path):
+    f_path = tmp_path / "abc"
+    with open(f_path, "w") as f:
+        fcntl.fcntl(f.fileno(), fcntl.F_SETFD, 0)
+        flags = fcntl.fcntl(f.fileno(), fcntl.F_GETFD)
+        assert flags & fcntl.FD_CLOEXEC == 0, "Verify test setup"
+
+        make_close_on_exec(f.fileno())
+        flags = fcntl.fcntl(f.fileno(), fcntl.F_GETFD)
+
+    assert flags & fcntl.FD_CLOEXEC == fcntl.FD_CLOEXEC
 
 
 @pytest.mark.parametrize("preserve", ((15, 16), (3, 5, 6, 11), ()))


### PR DESCRIPTION
In short, a helper function to humanize the flag setting: when set, the flag tells the kernel to close the given file descriptor if the script `exec()`s.  We use it here for the reading-side of the audit-log pipe as a redundancy factor: the code already closes the read-side (the side that UEPs don't need).

This is a minor addition, but pulling out into its own PR to clarify an upcoming PR.

## Type of change

- Code maintenance/cleanup