### PR TITLE
Implement a shared in-memory file

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -100,6 +100,7 @@ class UserEndpointRecord(BaseModel):
     ep_name: str
     local_user_info: t.Optional[pwd.struct_passwd]
     arguments: str
+    cred_fd: t.Optional[int] = None
 
     @property
     def uid(self) -> int:
@@ -319,6 +320,8 @@ class EndpointManager:
                     rc = -127  # invalid signal number
 
                 uep_record = self._children.pop(pid, None)
+                if uep_record and uep_record.cred_fd is not None:
+                    os.close(uep_record.cred_fd)
 
                 proc_args = f" [{uep_record.arguments}]" if uep_record else ""
                 if not rc:
@@ -1013,9 +1016,20 @@ class EndpointManager:
                     audit_r, selectors.EVENT_READ, self._audit_log_write
                 )
 
+        cred_fd = os.memfd_create("dyn", 0)
+        make_close_on_exec(cred_fd)  # redundant; but layers!
+        cred_fd_path = f"/proc/{os.getpid()}/fd/{cred_fd}"
+        cred_fd_ro = os.open(cred_fd_path, os.O_RDONLY)
+        cred_fd_wo = os.open(cred_fd_path, os.O_WRONLY | os.O_SYNC)
+        make_close_on_exec(cred_fd_wo)  # redundant; but layers!
+        os.close(cred_fd)
+        del cred_fd, cred_fd_path
+
         try:
             pid = os.fork()
         except Exception as e:
+            os.close(cred_fd_wo)
+            os.close(cred_fd_ro)
             if audit_r:
                 self._audit_log_close_reader(audit_r)
                 os.close(audit_w)
@@ -1023,13 +1037,17 @@ class EndpointManager:
             raise
 
         if pid > 0:
+            os.close(cred_fd_ro)
             if audit_r:
                 os.close(audit_w)
                 self._audit_pipes[audit_r]["pid"] = pid
 
             proc_args_s = f"({uname}, {ep_name}) {' '.join(proc_args)}"
             self._children[pid] = UserEndpointRecord(
-                ep_name=ep_name, local_user_info=user_record, arguments=proc_args_s
+                ep_name=ep_name,
+                local_user_info=user_record,
+                arguments=proc_args_s,
+                cred_fd=cred_fd_wo,
             )
             log.info(f"Creating new user endpoint (pid: {pid}) [{proc_args_s}]")
             return
@@ -1037,20 +1055,34 @@ class EndpointManager:
         # Reminder: from this point on, we are now the *child* process.
         pid = os.getpid()
 
+        # tell logging to close it's fds; necessary since we would otherwise pull
+        # the rug out from under it with close_all_fds()
+        logging.shutdown()
+
+        os.close(cred_fd_wo)  # the child process will never need to write this
+        del cred_fd_wo
+
         env = os.environ  # shorthand going forward
         if is_privileged():
             env.clear()
 
         exit_code = 70
         try:
-            # only keep the stdio streams and audit.  We perform this operation
-            # just before exec() as well, but no sense in keeping any parent fds
-            # open for longer than necessary.
-            close_all_fds(preserve_fds=[0, 1, 2, audit_w])
+            assert cred_fd_ro > 4, "Child processes get same fd numbers"
+            assert audit_w == 0 or audit_w > 4, "Child processes get same fd numbers"
+            if (cred_fd_ro := os.dup2(cred_fd_ro, 3)) != 3:
+                raise OSError("Unable to setup credential descriptor")
+            if audit_w > 0 and (audit_w := os.dup2(audit_w, 4)) != 4:
+                raise OSError("Unable to setup audit pipe")
+
+            # only keep the stdio streams, audit, and credential fds.  We perform this
+            # operation just before exec() as well, but no sense in keeping any parent
+            # fds open for longer than necessary.
+            close_all_fds(preserve_fds=[0, 1, 2, audit_w, cred_fd_ro])
 
             os.chdir("/")  # always succeeds, so start from known place
 
-            # in the child process; no need to load this in MUEP space
+            # in the child process; no need to load this in CEP space
             import shutil
             from multiprocessing.process import current_process
 
@@ -1236,6 +1268,7 @@ class EndpointManager:
                 "amqp_creds": kwargs.get("amqp_creds"),
                 "config": user_config,
                 "ep_info": ep_info,
+                "mem_fd": cred_fd_ro,
             }
             if self._config.allowed_functions is not None:
                 stdin_data_dict["allowed_functions"] = self._config.allowed_functions
@@ -1247,8 +1280,9 @@ class EndpointManager:
 
             # Reminder: this is *os*.open, not *open*.  Descriptors will not be closed
             # unless we explicitly do so, so `null_fd =` in loop will work.
+            min_null_fd = max(2, audit_w, cred_fd_ro)
             null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
-            while null_fd < 3:  # reminder 0/1/2 == std in/out/err, so ...
+            while null_fd < min_null_fd:  # 0/1/2 == std in/out/err, so ...
                 # ... overkill, but "just in case": don't step on them
                 null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
             exit_code += 1
@@ -1272,6 +1306,7 @@ class EndpointManager:
             exit_code += 1
 
             log.debug("Convey credentials; redirect stdout, stderr (to '%s')", ep_log)
+
             log_fd_flags = os.O_CREAT | os.O_WRONLY | os.O_APPEND | os.O_SYNC
             log_fd = os.open(ep_log, log_fd_flags, mode=0o600)
             with os.fdopen(log_fd, "w") as log_f:
@@ -1307,7 +1342,8 @@ class EndpointManager:
             # all parent process fds are long-since closed; for good measure,
             # ensure any interim fds are also closed.
             exit_code += 1
-            close_all_fds(preserve_fds=[0, 1, 2, audit_w])
+            preserve_fds = tuple(sorted({0, 1, 2, audit_w, cred_fd_ro}))
+            close_all_fds(preserve_fds=preserve_fds)
 
             exit_code += 1
             os.execvpe(proc_args[0], args=proc_args, env=env)

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -174,6 +174,12 @@ def mock_reg_info(ep_uuid) -> str:
 
 
 @pytest.fixture(autouse=True)
+def log_shutdown():
+    with mock.patch(f"{_MOCK_BASE}logging.shutdown") as m:
+        yield m
+
+
+@pytest.fixture(autouse=True)
 def mock_app(mocker: MockFixture) -> UserApp:
     _app = mock.Mock(spec=UserApp)
     mocker.patch(f"{_MOCK_BASE}get_globus_app_with_scopes", return_value=_app)
@@ -256,8 +262,8 @@ def mock_os():
         m.getpid.return_value = 22222222
         m.memfd_create.return_value = 37
 
-        m.dup2.side_effect = (0, 1, 2, AssertionError("dup2: unexpected?"))
-        m.open.side_effect = (4, 5, AssertionError("open: unexpected?"))
+        m.dup2.side_effect = (3, 0, 1, 2, AssertionError("dup2: unexpected?"))
+        m.open.side_effect = (5, 6, 7, 8, AssertionError("open: unexpected?"))
         m.pipe.return_value = 40, 41
         m.waitpid.return_value = (0, 0)
         m.O_RDONLY = os.O_RDONLY
@@ -1722,7 +1728,7 @@ def test_root_clears_environment_immediately_after_fork(
 
     for fd in (0, 1, 2):
         assert fd in k["preserve_fds"], "Expect std streams preserved, for now"
-    assert len(k["preserve_fds"]) == 4, "Expect audit path kept"
+    assert len(k["preserve_fds"]) == 5, "Expect audit and cred_ro fds kept"
 
 
 def test_non_root_keeps_original_environment(
@@ -2235,6 +2241,27 @@ def test_audit_pipe_cloexec(successful_exec_from_mocked_root):
     assert a == (audit_r,), "Expect parent process audit fd cloexec"
 
 
+def test_cred_fd_cloexec(successful_exec_from_mocked_root):
+    mock_os, *_, em = successful_exec_from_mocked_root
+    test_fds = (random.randint(100, 1000000) for _ in range(3))
+    cred_fd, cred_r, cred_w = test_fds
+    exp_open_p = f"/proc/1234/fd/{cred_fd}"
+    mock_os.memfd_create.return_value = cred_fd
+    mock_os.open.side_effect = cred_r, cred_w
+    mock_os.getpid.side_effect = (1234, SystemExit)
+
+    with mock.patch(f"{_MOCK_BASE}make_close_on_exec") as mock_cloexec:
+        with pytest.raises(SystemExit):
+            em._event_loop()
+
+    ro_args = next(a for a, _ in mock_os.open.call_args_list if a[1] == os.O_RDONLY)
+    wo_args = next(a for a, _ in mock_os.open.call_args_list if a[1] & os.O_WRONLY)
+    assert (exp_open_p, os.O_RDONLY) == ro_args, "Verify test setup"
+    assert (exp_open_p, os.O_WRONLY | os.O_SYNC) == wo_args, "Verify test setup"
+    assert mock_os.close.call_args[0][0] == cred_fd, "Expect rw handle closed"
+    assert mock_cloexec.call_args[0][0] == cred_w, "Expect write cred handle cloexec"
+
+
 def test_all_files_closed(successful_exec_from_mocked_root):
     mock_os, *_, em = successful_exec_from_mocked_root
     with pytest.raises(SystemExit) as pyexc:
@@ -2247,11 +2274,11 @@ def test_all_files_closed(successful_exec_from_mocked_root):
     _, k = mock_close.call_args
     for fd in (0, 1, 2):
         assert fd in k["preserve_fds"], "Expect std streams preserved"
-    assert len(k["preserve_fds"]) == 4, "Expect audit path kept"
+    assert len(k["preserve_fds"]) == 4, "Expect audit and cred_ro fds kept"
 
-    assert mock_os.dup2.call_count == 3, "Expect to close 3 std* files"
-    closed = [std_to_close for (_fd, std_to_close), _ in mock_os.dup2.call_args_list]
-    assert closed == [0, 1, 2]
+    assert mock_os.dup2.call_count == 4, "Expect to close cred fs and std streams"
+    closed = [to_close for (_fd, to_close), _ in mock_os.dup2.call_args_list]
+    assert closed == [3, 0, 1, 2], "cred_ro, then std* fds"
 
 
 def test_respects_config_template_and_schema(mocker, successful_exec_from_mocked_root):
@@ -2344,7 +2371,7 @@ def test_ep_dir_log_path_envs_passed_to_render(
 def test_pipe_size_limit(mocker, mock_log, successful_exec_from_mocked_root, is_valid):
     *_, em = successful_exec_from_mocked_root
 
-    stdin_data_size = 224  # Empirically/designed size of `stdin_data` string
+    stdin_data_size = 235  # Empirically/designed size of `stdin_data` string
     pipe_buffer_size = 255 + stdin_data_size + is_valid  # manufacture error/success
 
     conf_str = "k: v"  # some key, some value; valid YAML string
@@ -2454,7 +2481,7 @@ def test_user_debug_emits_ephemeral_config_to_user_log(
             f.write("\ndebug: true")
 
     def duped_first_check(*a, **k):
-        assert mock_os.dup2.call_count == 3, "3 std streams; to log file, not stdout"
+        assert mock_os.dup2.call_count == 4, "cred fd; std streams to log file"
 
     mock_print = mocker.patch(f"{_MOCK_BASE}print")
     mock_print.side_effect = duped_first_check

--- a/compute_endpoint/tests/unit/test_mep_audit_log.py
+++ b/compute_endpoint/tests/unit/test_mep_audit_log.py
@@ -103,8 +103,8 @@ def mock_os():
         m.read = os.read
 
         m.pipe.return_value = 40, 41
-        m.dup2.side_effect = (0, 1, 2, AssertionError("dup2: unexpected?"))
-        m.open.side_effect = (4, 5, AssertionError("open: unexpected?"))
+        m.dup2.side_effect = (3, 4, 0, 1, 2, AssertionError("dup2: unexpected?"))
+        m.open.side_effect = (5, 6, 7, 8, AssertionError("open: unexpected?"))
 
         with mock.patch.object(fcntl, "fcntl", return_value=8192):
             yield m
@@ -202,10 +202,23 @@ def test_audit_log_pipe_hookup(
     mock_log, tmp_path, ep_uuid, conf, reg_info, mock_os, mock_close_fds
 ):
     em = EndpointManager(tmp_path, ep_uuid, conf, reg_info)
+    audit_w = -1
+
+    def test_os_pipe2(*a, **k):
+        # As a measure of not leaking information, the code ensures that all child
+        # UEPs receive the same set of open fds.  Just because the CEP creates audit
+        # pipes of, say, 257 and 258 for the UEP, doesn't mean the UEP also
+        # needs the same fd number.  All UEPs will have fd 4 be their audit pipe.
+        # But this test needs to write to that pipe to show the plumbing is hooked
+        # up, so MitM the creation.
+        nonlocal audit_w
+        r, w = os.pipe2(os.O_DIRECT)
+        audit_w = w
+        return r, w
 
     m = mock.Mock()
     mock_os.fdopen.return_value.__enter__.return_value = m
-    mock_os.pipe2.side_effect = os.pipe2  # need actual pipes ...
+    mock_os.pipe2.side_effect = test_os_pipe2
 
     mpi = MappedPosixIdentity(em._mu_user, [], ep_uuid)
     kwargs = {
@@ -221,7 +234,7 @@ def test_audit_log_pipe_hookup(
 
     (stdin_str,), _ = m.write.call_args
     stdin_data = json.loads(stdin_str)
-    audit_w = stdin_data["audit_fd"]
+    assert stdin_data["audit_fd"] == 4, "Child processes get same fd numbers"
     os.write(audit_w, b"FROM CHILD, THROUGH KERNEL PIPE")
 
     t = threading.Thread(target=em._audit_log_impl, daemon=True)


### PR DESCRIPTION
# Description

The semantics, as setup by the fd, are that the child processes will only read from the file, and the parent process will only write to the file.  For good measure, also ensure that the "close on exec" flag is set for the write-handle of the credential file so that "just in case" we forget to close it (which we do anyway), tell the kernel to ensure it's closed for the UEP.  In `ls`-output, the child process will have a `r-x` (read-only) file descriptor (always fd 3), and the parent process will have a `w-x` (write-only) file descriptor.  For example:

```console
$ ls -l /proc/<uep_pid>/fd | grep dyn
lr-x------ 1 user group 64 [date/time] 3 -> '/memfd:dyn (deleted)'

$ ls -l /proc/<cep_pid>/fd | grep dyn
l-wx------ 1 root root 64 [date/time] 14 -> '/memfd:dyn (deleted)'
```

[sc-51838]

## Type of change

- New feature (non-breaking change that adds functionality; though unusable without some upcoming work not yet complete)