### PR TITLE
Write and update shared in-memory file

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -28,6 +28,7 @@ from datetime import datetime
 import setproctitle
 import yaml
 from cachetools import TTLCache
+from cryptography.fernet import Fernet
 from globus_compute_common.messagepack import pack
 from globus_compute_common.messagepack.message_types import EPStatusReport
 from globus_compute_endpoint import __version__
@@ -101,6 +102,7 @@ class UserEndpointRecord(BaseModel):
     local_user_info: t.Optional[pwd.struct_passwd]
     arguments: str
     cred_fd: t.Optional[int] = None
+    enckey: t.Optional[bytes] = None
 
     @property
     def uid(self) -> int:
@@ -950,6 +952,24 @@ class EndpointManager:
             # Regardless, be opaque with user.
             raise PermissionError("see your system administrator") from None
 
+    @staticmethod
+    def _update_uep_credentials(uep: UserEndpointRecord, amqp_creds: dict):
+        if not (uep.cred_fd and uep.enckey):
+            log.info(
+                f"Unable to update cached credentials for {uep.ep_name} (user:"
+                f" {uep.uname}): missing encryption key or credential file"
+            )
+            return
+        payload = {"amqp_creds": amqp_creds}
+        enc = Fernet(uep.enckey)
+        cred_data = json.dumps(payload, separators=(",", ":"))
+        cred_data_enc = enc.encrypt(cred_data.encode())
+
+        os.ftruncate(uep.cred_fd, 0)
+        os.lseek(uep.cred_fd, 0, os.SEEK_SET)
+        os.write(uep.cred_fd, cred_data_enc)
+        os.fsync(uep.cred_fd)
+
     def cmd_start_endpoint(
         self,
         ident: MappedPosixIdentity,
@@ -971,9 +991,11 @@ class EndpointManager:
             if r.ep_name == ep_name:
                 log.info(
                     f"User endpoint {ep_name} is already running (pid: {p}); "
-                    "caching arguments in case it's about to shut down"
+                    "updating credentials then caching arguments in case it's "
+                    "about to shut down"
                 )
                 self._cached_cmd_start_args[p] = (ident, args, kwargs)
+                self._update_uep_credentials(r, uep_amqp_creds)
                 return
 
         user_record = ident.local_user_record
@@ -1025,6 +1047,8 @@ class EndpointManager:
         os.close(cred_fd)
         del cred_fd, cred_fd_path
 
+        cred_key = Fernet.generate_key()
+
         try:
             pid = os.fork()
         except Exception as e:
@@ -1043,12 +1067,15 @@ class EndpointManager:
                 self._audit_pipes[audit_r]["pid"] = pid
 
             proc_args_s = f"({uname}, {ep_name}) {' '.join(proc_args)}"
-            self._children[pid] = UserEndpointRecord(
+            uep_record = UserEndpointRecord(
                 ep_name=ep_name,
                 local_user_info=user_record,
                 arguments=proc_args_s,
                 cred_fd=cred_fd_wo,
+                enckey=cred_key,
             )
+            self._children[pid] = uep_record
+            self._update_uep_credentials(uep_record, uep_amqp_creds)
             log.info(f"Creating new user endpoint (pid: {pid}) [{proc_args_s}]")
             return
 

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,6 +34,7 @@ REQUIRES = [
     "jsonschema>=4.21,<5",
     "cachetools>=5.3.1",
     "types-cachetools>=5.3.0.6",
+    "cryptography>=48",
 ]
 
 TEST_REQUIRES = [

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -20,6 +20,7 @@ from unittest import mock
 import pika
 import pytest as pytest
 import yaml
+from cryptography.fernet import Fernet
 from globus_compute_common.messagepack import unpack
 from globus_compute_common.messagepack.message_types import EPStatusReport
 from globus_compute_endpoint.endpoint.config import (
@@ -36,6 +37,7 @@ from globus_compute_endpoint.endpoint.rabbit_mq import (
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds
 from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_sdk import UserApp
+from pyfakefs.fake_os import use_original_os
 from pytest_mock import MockFixture
 
 try:
@@ -48,6 +50,7 @@ else:
         EndpointManager,
         InvalidUserError,
         MappedPosixIdentity,
+        UserEndpointRecord,
     )
 
 
@@ -678,12 +681,11 @@ def test_records_user_ep_as_running(successful_exec_from_mocked_root, ep_name):
 
 
 def test_caches_start_cmd_args_if_ep_already_running(
-    mocker, successful_exec_from_mocked_root, command_payload, ep_name
+    successful_exec_from_mocked_root, command_payload, ep_name
 ):
     *_, em = successful_exec_from_mocked_root
     child_pid = random.randrange(1, 32768 + 1)
-    mock_uep = mocker.MagicMock()
-    mock_uep.ep_name = ep_name
+    mock_uep = UserEndpointRecord(ep_name=ep_name, local_user_info=None, arguments="")
     em._children[child_pid] = mock_uep
 
     em._event_loop()
@@ -2279,6 +2281,84 @@ def test_all_files_closed(successful_exec_from_mocked_root):
     assert mock_os.dup2.call_count == 4, "Expect to close cred fs and std streams"
     closed = [to_close for (_fd, to_close), _ in mock_os.dup2.call_args_list]
     assert closed == [3, 0, 1, 2], "cred_ro, then std* fds"
+
+
+def test_update_uep_credentials(
+    randomstring, conf_dir, mock_conf, mock_client, mock_reg_info
+):
+    ep_uuid, mock_gcc = mock_client
+    em = EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
+
+    # The `fs` fixture is pulled in by conf_dir, but doesn't handle memfd_create.
+    # This test only needs the EndpointManager() instance, so can turn fs off now.
+    with use_original_os():
+        exp_data = {"some": f"amqp creds {randomstring()}"}
+
+        mfd = os.memfd_create("real_memfd")
+        key = b"A" * 43 + b"="  # test key == base64 of 32 null bytes
+        enc = Fernet(key)
+        uer = UserEndpointRecord(ep_name="abc", local_user_info=None, arguments="")
+        uer.cred_fd = mfd
+        uer.enckey = key
+
+        try:
+            em._update_uep_credentials(uer, exp_data)
+            os.lseek(mfd, 0, os.SEEK_SET)
+            encrypted_data = os.read(mfd, 4096)
+        finally:
+            os.close(mfd)
+
+    found_data_decrypted = enc.decrypt(encrypted_data)
+    found_data = json.loads(found_data_decrypted)
+    assert found_data["amqp_creds"] == exp_data
+
+
+def test_uep_credential_file_written(
+    randomstring, ep_name, successful_exec_from_mocked_root
+):
+    mock_os, *_, em = successful_exec_from_mocked_root
+
+    ident = MappedPosixIdentity(
+        local_user_record=_mock_localuser_rec,
+        globus_identity_candidates=[],  # no mappings, initially
+        matched_identity=None,
+    )
+    exp_data = {"test": f"datastructure {randomstring()}"}
+    kw = {"name": ep_name, "amqp_creds": exp_data}
+
+    mock_os.fork.return_value = 1234  # parent-path, please
+    em.cmd_start_endpoint(ident, None, kwargs=kw)
+
+    uer: UserEndpointRecord = em._children[1234]
+
+    (written_fd, encrypted_data), k = mock_os.write.call_args
+    assert uer.cred_fd == written_fd
+    assert bool(encrypted_data), "Verify test setup: anything written at all?"
+
+    enc = Fernet(uer.enckey)
+    found_data_decrypted = enc.decrypt(encrypted_data)
+    found_data = json.loads(found_data_decrypted)
+    assert found_data["amqp_creds"] == exp_data
+
+
+def test_running_uep_credentials_refreshed(
+    randomstring, successful_exec_from_mocked_root, ep_name
+):
+    *_, em = successful_exec_from_mocked_root
+
+    uer = UserEndpointRecord(ep_name=ep_name, local_user_info=None, arguments="")
+
+    em._children[1234] = uer
+    exp_data = {"test": f"datastructure {randomstring()}"}
+    kw = {"name": ep_name, "amqp_creds": exp_data}
+
+    with mock.patch.object(em, "_update_uep_credentials") as mock_update:
+        em.cmd_start_endpoint(None, None, kwargs=kw)
+
+    assert mock_update.called, "Test namesake"
+
+    a, k = mock_update.call_args
+    assert (uer, exp_data) == a
 
 
 def test_respects_config_template_and_schema(mocker, successful_exec_from_mocked_root):


### PR DESCRIPTION
# Description

When new credentials come in, when either spinning up a new UEP or if the UEP is already running, truncate and write the file.  Of minor note is that this is a credential file, so encrypt the data.  Per discussion, use a growable data structure rather than a raw dump of the incoming data.

Of note that this is still not _used_ by the UEP.  But it exists for follow-up work to utilized.

## Type of change

- New feature (non-breaking change that adds functionality)