### PR TITLE
Store credentials in single place

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -44,6 +44,7 @@ from globus_compute_endpoint.endpoint.identity_mapper import MappedPosixIdentity
 from globus_compute_endpoint.endpoint.utils import has_pyprctl as _has_multi_user
 from globus_compute_endpoint.endpoint.utils import (
     is_privileged,
+    make_credential_provider,
     pyprctl_import_error,
     send_endpoint_startup_failure_to_amqp,
     user_input_select,
@@ -1016,12 +1017,13 @@ def _start_user_endpoint(
         pid_path = Endpoint.pid_path(ep_dir)
         stk.enter_context(_pidfile(pid_path, ep_config.heartbeat_period * 3))
 
+        cred_fn = make_credential_provider(reg_info)
         get_cli_endpoint(ep_config).start_endpoint(
             endpoint_dir=ep_dir,
             endpoint_uuid=endpoint_uuid,
             endpoint_config=ep_config,
             log_to_console=state.log_to_console,
-            reg_info=reg_info,
+            cred_fn=cred_fn,
             ep_info=ep_info,
             audit_fd=audit_fd,
         )

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -481,7 +481,7 @@ class Endpoint:
         endpoint_uuid,
         endpoint_config: UserEndpointConfig,
         log_to_console: bool,
-        reg_info: dict,
+        cred_fn: t.Callable[[], dict[str, dict]],
         ep_info: dict,
         audit_fd: int | None = None,
     ):
@@ -520,6 +520,7 @@ class Endpoint:
             raise
 
         try:
+            reg_info = cred_fn()["amqp_creds"]
             ret_ep_uuid = reg_info["endpoint_id"]
             tq_info, rq_info, hbq_info = (
                 reg_info["task_queue_info"],
@@ -588,7 +589,7 @@ class Endpoint:
             endpoint_uuid,
             endpoint_dir,
             endpoint_config,
-            reg_info,
+            cred_fn,
             result_store,
             parent_pid,
             ep_info,
@@ -600,7 +601,7 @@ class Endpoint:
         endpoint_uuid,
         endpoint_dir,
         endpoint_config: UserEndpointConfig,
-        reg_info,
+        cred_fn: t.Callable[[], dict[str, dict]],
         result_store: ResultStore,
         parent_pid: int,
         ep_info: dict,
@@ -610,7 +611,7 @@ class Endpoint:
 
         interchange = EndpointInterchange(
             config=endpoint_config,
-            reg_info=reg_info,
+            cred_fn=cred_fn,
             endpoint_id=endpoint_uuid,
             endpoint_dir=endpoint_dir,
             result_store=result_store,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -284,7 +284,7 @@ class EndpointManager:
             stop_event=self._command_stop_event,
             thread_name="CQS",
         )
-        self._heartbeat_publisher = ResultPublisher(queue_info=hbq_info)
+        self._heartbeat_publisher = ResultPublisher(cred_fn=lambda: hbq_info)
 
     @staticmethod
     def get_metadata(ep_dir: pathlib.Path, config: ManagerEndpointConfig) -> dict:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -56,7 +56,7 @@ class EndpointInterchange:
     def __init__(
         self,
         config: UserEndpointConfig,
-        reg_info: dict[str, dict],
+        cred_fn: t.Callable[[], dict[str, dict]],
         ep_info: dict,
         logdir=".",
         endpoint_id=None,
@@ -72,11 +72,8 @@ class EndpointInterchange:
         config : globus_compute_sdk.UserEndpointConfig object
              Globus Compute config object describing how compute should be provisioned
 
-        reg_info : dict[str, dict]
-             Dictionary containing connection information for the task, result, and
-             heartbeat queues.  The required data structure is returned from the
-             Endpoint registration API call, encapsulated in the SDK by
-             `Client.register_endpoint()`.
+        cred_fn :
+            A callable to dynamically collect AMQP connection credentials.
 
         logdir : str
              Parsl log directory paths. Logs and temp files go here. Default: '.'
@@ -100,9 +97,15 @@ class EndpointInterchange:
         self._audit_fd = audit_fd
         self.endpoint_dir = endpoint_dir
 
-        self.task_q_info = reg_info["task_queue_info"]
-        self.result_q_info = reg_info["result_queue_info"]
-        self.heartbeat_q_info = reg_info["heartbeat_queue_info"]
+        if cred_fn()["amqp_creds"] is None:
+            # require creds now, for better UX if not provided
+            raise ValueError("No AMQP credentials specified")
+
+        self.task_q_info_fn = lambda: cred_fn()["amqp_creds"]["task_queue_info"]
+        self.result_q_info_fn = lambda: cred_fn()["amqp_creds"]["result_queue_info"]
+        self.heartbeat_q_info_fn = lambda: cred_fn()["amqp_creds"][
+            "heartbeat_queue_info"
+        ]
 
         self.time_to_quit = False
         self.heartbeat_period = self.config.heartbeat_period
@@ -519,12 +522,12 @@ class EndpointInterchange:
             return f
 
         task_q_subscriber = TaskQueueSubscriber(
-            queue_info=self.task_q_info,
+            cred_fn=self.task_q_info_fn,
             pending_task_queue=self.pending_task_queue,
             thread_name="TQS",
         )
-        results_publisher = ResultPublisher(queue_info=self.result_q_info)
-        heartbeat_publisher = ResultPublisher(queue_info=self.heartbeat_q_info)
+        results_publisher = ResultPublisher(cred_fn=self.result_q_info_fn)
+        heartbeat_publisher = ResultPublisher(cred_fn=self.heartbeat_q_info_fn)
         stored_processor_thread = threading.Thread(
             target=process_stored_results, daemon=True, name="Stored Result Handler"
         )

--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/result_publisher.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/result_publisher.py
@@ -27,21 +27,23 @@ log = logging.getLogger(__name__)
 
 class ResultPublisher(threading.Thread):
     """
-    Publish results to the AMQP service, per the routing information in `queue_info`.
+    Publish results to the AMQP service, per the routing information returned by
+    a connection callable.
     """
 
     def __init__(
         self,
         *,
-        queue_info: dict,
+        cred_fn: t.Callable[[], dict],
         poll_period_s: float = 0.5,
         connect_attempt_limit: int = 7200,
         channel_close_window_s: int = 10,
         channel_close_window_limit: int = 3,
     ):
         """
-        :param queue_info: Pika connection parameters to connect to RabbitMQ;
-            typically as returned from the web-service by the web-service
+        :param cred_fn: a callable to dynamically collect Pika connection
+            parameters (e.g., credentials to the AMQP service); typically as
+            returned by the web-service
         :param poll_period_s: [default: 0.5] how frequently to check for and
             handle events.  For example, if the thread should stop or if there
             are results to send along.
@@ -53,6 +55,8 @@ class ResultPublisher(threading.Thread):
         :param channel_close_window_limit: Limit of channel close events (within
             ``channel_close_window_s``) before shutting down the thread.
         """
+        self.cred_fn = cred_fn
+
         # how often to check for work; every `poll_period_s`, the `_event_watcher`
         # method will handle any outstanding work.
         self.poll_period_s = max(0.01, poll_period_s)
@@ -88,7 +92,7 @@ class ResultPublisher(threading.Thread):
         self.status = RabbitPublisherStatus.closed
 
         self._publish_kwargs: dict[str, t.Any] = {}
-        self._queue_info = queue_info
+        self._queue_info: dict[str, t.Any] = {}
 
         super().__init__()
 
@@ -177,6 +181,8 @@ class ResultPublisher(threading.Thread):
             self.join(timeout=timeout)
 
     def _connect(self) -> pika.SelectConnection:
+        self._queue_info = self.cred_fn()
+
         publish_kw = dict(**self._queue_info["queue_publish_kwargs"])
         if "properties" in publish_kw:
             publish_kw["properties"] = BasicProperties(**publish_kw["properties"])

--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -23,7 +23,7 @@ class TaskQueueSubscriber(threading.Thread):
     def __init__(
         self,
         *,
-        queue_info: dict,
+        cred_fn: t.Callable[[], dict],
         pending_task_queue: queue.SimpleQueue,
         poll_period_s: float = 0.5,
         connect_attempt_limit: int = 7200,
@@ -35,10 +35,10 @@ class TaskQueueSubscriber(threading.Thread):
 
         Parameters
         ----------
-        queue_info: dict
-            Dictionary that includes the key "connection_url", as well as
-            exchange and queue declaration information specified by the
-            server.
+        cred_fn
+            A callable to dynamically collect Pika connection parameters (e.g.,
+            credentials to the AMQP service); typically as returned by the
+            web-service
 
         pending_task_queue: queue.SimpleQueue
             Messages from upstream will be placed in this queue. Consumers of
@@ -70,7 +70,8 @@ class TaskQueueSubscriber(threading.Thread):
 
         super().__init__()
 
-        self._queue_info = queue_info
+        self.cred_fn = cred_fn
+        self._queue_info: dict[str, t.Any] = {}
         self.pending_task_queue = pending_task_queue
         self._to_ack: queue.SimpleQueue[int] = queue.SimpleQueue()
         self._stop_event = threading.Event()
@@ -176,6 +177,8 @@ class TaskQueueSubscriber(threading.Thread):
         self._stop_event.set()
 
     def _connect(self) -> pika.SelectConnection:
+        self._queue_info = self.cred_fn()
+
         pika_params = pika.URLParameters(self._queue_info["connection_url"])
         return pika.SelectConnection(
             pika_params,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
@@ -208,3 +208,24 @@ def user_input_select(prompt: str, options: list[str]) -> str | None:
                 if 0 < input_num <= len(options):
                     return options[input_num - 1]
             print(f"Invalid choice: {input_raw}")
+
+
+def make_credential_provider(
+    reg_info: dict | None = None,
+) -> t.Callable[[], dict[str, dict]]:
+    """
+    Dynamically query a credential source.
+
+    The returned data structure is from the Endpoint registration API call,
+    encapsulated in the SDK by `Client.register_endpoint()`.  It currently contains
+    connection information for the task, result, and heartbeat queues.
+    """
+    if reg_info is None:
+        raise KeyError("No credential info provided")
+
+    amqp_creds: dict = {"amqp_creds": reg_info}
+
+    def _credential_provider() -> dict:
+        return amqp_creds
+
+    return _credential_provider

--- a/compute_endpoint/tests/integration/conftest.py
+++ b/compute_endpoint/tests/integration/conftest.py
@@ -233,7 +233,7 @@ def start_task_q_subscriber(
         q_info = task_queue_info if override_params is None else override_params
         ensure_task_queue(queue_opts={"queue": q_info["queue"]})
 
-        qs = TaskQueueSubscriber(queue_info=q_info, pending_task_queue=task_queue)
+        qs = TaskQueueSubscriber(cred_fn=lambda: q_info, pending_task_queue=task_queue)
         qs.start()
         qs_list.append(qs)
         return qs
@@ -300,7 +300,7 @@ def start_result_q_publisher(
             queue_opts = {"queue": queue_name, "durable": True}
             ensure_result_queue(exchange_opts=exchange_opts, queue_opts=queue_opts)
 
-        qp = ResultPublisher(queue_info=q_info)
+        qp = ResultPublisher(cred_fn=lambda: q_info)
         qp.start()
         qp_list.append(qp)
         if queue_purge:  # Make sure queue is empty
@@ -334,7 +334,7 @@ def start_heartbeat_q_publisher(heartbeat_queue_info, ensure_heartbeat_queue):
             queue_opts = {"queue": queue_name, "durable": True}
             ensure_heartbeat_queue(exchange_opts=exchange_opts, queue_opts=queue_opts)
 
-        qp = ResultPublisher(queue_info=q_info)
+        qp = ResultPublisher(cred_fn=lambda: q_info)
         qp.start()
         qp_list.append(qp)
         if queue_purge:  # Make sure queue is empty

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -94,7 +94,7 @@ def ep_ix_factory(endpoint_uuid, mock_conf, mock_quiesce):
         kw = {
             "endpoint_id": endpoint_uuid,
             "config": mock_conf,
-            "reg_info": reg_info,
+            "cred_fn": lambda: {"amqp_creds": reg_info},
             "ep_info": {},
         }
         kw.update(k)
@@ -124,10 +124,12 @@ def test_endpoint_id_conveyed_to_engine(gc_dir, mock_conf, ep_uuid):
     mock_conf.engine = engines.ThreadPoolEngine()
     ic = EndpointInterchange(
         mock_conf,
-        reg_info={
-            "task_queue_info": {},
-            "result_queue_info": {},
-            "heartbeat_queue_info": {},
+        cred_fn=lambda: {
+            "amqp_creds": {
+                "task_queue_info": {},
+                "result_queue_info": {},
+                "heartbeat_queue_info": {},
+            }
         },
         ep_info={},
         endpoint_id=ep_uuid,
@@ -140,7 +142,10 @@ def test_endpoint_id_conveyed_to_engine(gc_dir, mock_conf, ep_uuid):
 def test_start_requires_pre_registered(mock_conf, gc_dir):
     with pytest.raises(TypeError):
         EndpointInterchange(
-            config=mock_conf, reg_info=None, ep_info={}, endpoint_id="mock_endpoint_id"
+            config=mock_conf,
+            cred_fn=None,
+            ep_info={},
+            endpoint_id="mock_endpoint_id",
         )
 
 

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -29,7 +29,7 @@ def _run_ixproc(reg_info: dict, endpoint_uuid, endpoint_dir):
     ix = EndpointInterchange(
         config=UserEndpointConfig(engine=mock_exe),
         endpoint_id=endpoint_uuid,
-        reg_info=reg_info,
+        cred_fn=lambda: {"amqp_creds": reg_info},
         ep_info={},
         endpoint_dir=endpoint_dir,
         logdir=endpoint_dir,

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_result_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_result_q.py
@@ -116,7 +116,7 @@ def test_broken_connection(
 
     q_info = create_result_queue_info(connection_url=conn_url)
 
-    rp = ResultPublisher(queue_info=q_info)
+    rp = ResultPublisher(cred_fn=lambda: q_info)
     mock_cb = mocker.patch.object(rp, "_on_open_failed")
     try:
         rp.start()

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -500,7 +500,7 @@ def test_start_user_ep_reads_stdin(
     config_str_found = mock_load_conf.call_args[0][0]
 
     assert config_str == config_str_found
-    assert reg_info == s_ep_k["reg_info"]
+    assert reg_info == s_ep_k["cred_fn"]()["amqp_creds"]
     assert ep_info == s_ep_k["ep_info"]
     assert audit_fd == s_ep_k["audit_fd"]
 

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -151,11 +151,13 @@ def pword(randomstring):
 @pytest.fixture
 def mock_reg_info(ep_uuid, uname, pword):
     c_url = f"amqp://{uname}:{pword}@some.domain"
-    yield {
-        "endpoint_id": ep_uuid,
-        "task_queue_info": {"connection_url": f"{c_url}:1234"},
-        "result_queue_info": {"connection_url": c_url},
-        "heartbeat_queue_info": {"connection_url": c_url},
+    return {
+        "amqp_creds": {
+            "endpoint_id": ep_uuid,
+            "task_queue_info": {"connection_url": f"{c_url}:1234"},
+            "result_queue_info": {"connection_url": c_url},
+            "heartbeat_queue_info": {"connection_url": c_url},
+        }
     }
 
 
@@ -317,7 +319,7 @@ def test_start_without_engine(caplog, conf_dir, conf):
             endpoint_uuid=None,
             endpoint_config=conf,
             log_to_console=False,
-            reg_info={},
+            cred_fn=lambda: {},
             ep_info={},
         )
     r = caplog.records[-1]
@@ -341,7 +343,7 @@ def test_start_ha_non_compliant(caplog, randomstring, mock_print, conf_dir, conf
             endpoint_uuid=None,
             endpoint_config=conf,
             log_to_console=False,
-            reg_info={},
+            cred_fn=lambda: {},
             ep_info={},
         )
     r = caplog.records[-1]
@@ -357,7 +359,7 @@ def test_endpoint_needs_no_client_if_reg_info(
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
-    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+    ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info={})
     assert not mock_get_client.called, "No need for Client!"
     assert mock_launch.called, "Registration given; should start"
 
@@ -374,7 +376,7 @@ def test_start_endpoint_redacts_url_creds_from_logs(
 ):
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
-    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+    ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info={})
     assert mock_launch.called, "Should launch successfully"
 
     debug_args = "\n".join(str((a, k)) for a, k in mock_log.debug.call_args_list)
@@ -391,7 +393,7 @@ def test_start_endpoint_populates_ep_static_info(
     canary_value = randomstring()
     ep_info = {"canary": canary_value}
     with mock.patch(f"{_mock_base}Endpoint.start_interchange") as mock_launch:
-        ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info=ep_info)
+        ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info=ep_info)
     assert mock_launch.called, "Should launch successfully"
 
     (*_, found, _audit_fd), _k = mock_launch.call_args
@@ -522,7 +524,7 @@ def test_endpoint_sets_process_title(
         mock_spt.getproctitle.return_value = orig_proc_title
         mock_spt.setproctitle.side_effect = StopIteration("Sentinel")
         with pytest.raises(StopIteration, match="Sentinel"):
-            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+            ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info={})
 
     a, _k = mock_spt.setproctitle.call_args
     assert a[0].startswith("Globus Compute Endpoint"), (
@@ -541,15 +543,18 @@ def test_endpoint_respects_port(mock_ep_data, port, mock_reg_info, ep_uuid):
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_conf.amqp_port = port
 
-    tq_url = mock_reg_info["task_queue_info"]["connection_url"]
-    rq_url = mock_reg_info["result_queue_info"]["connection_url"]
-    hbq_url = mock_reg_info["heartbeat_queue_info"]["connection_url"]
+    q_infos = mock_reg_info["amqp_creds"]
+    tq_url = q_infos["task_queue_info"]["connection_url"]
+    rq_url = q_infos["result_queue_info"]["connection_url"]
+    hbq_url = q_infos["heartbeat_queue_info"]["connection_url"]
 
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
-    with mock.patch(f"{_mock_base}update_url_port", spec=True) as mock_upd:
+    with (
+        mock.patch(f"{_mock_base}update_url_port", spec=True) as mock_upd,
+        pytest.raises(StopIteration, match="Sentinel"),
+    ):
         mock_upd.side_effect = (None, None, StopIteration("Sentinel"))
-        with pytest.raises(StopIteration, match="Sentinel"):
-            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+        ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info={})
 
     for (a, _), exp_url in zip(mock_upd.call_args_list, (tq_url, rq_url, hbq_url)):
         assert a == (exp_url, port)
@@ -571,26 +576,23 @@ def test_endpoint_sets_owner_only_access(tmp_path, umask, mask, idmap):
 
 
 def test_always_prints_endpoint_id_to_terminal(
-    mock_launch, mocker, mock_ep_data, mock_reg_info
+    mock_launch, mocker, ep_uuid, mock_ep_data, mock_reg_info
 ):
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
-    ep_id = str(uuid.uuid4())
 
     mock_dup2 = mocker.patch(f"{_mock_base}os.dup2")
     mock_dup2.return_value = 0
     mock_sys = mocker.patch(f"{_mock_base}sys")
 
-    expected_text = f"Starting endpoint; registered ID: {ep_id}"
-
-    reg_info = {**mock_reg_info, "endpoint_id": ep_id}
+    expected_text = f"Starting endpoint; registered ID: {ep_uuid}"
 
     mock_sys.stdout.isatty.return_value = True
     ep.start_endpoint(
         ep_dir,
-        ep_id,
+        ep_uuid,
         ep_conf,
         log_to_console,
-        reg_info,
+        lambda: mock_reg_info,
         ep_info={},
     )
 
@@ -603,10 +605,10 @@ def test_always_prints_endpoint_id_to_terminal(
     mock_sys.stderr.isatty.return_value = True
     ep.start_endpoint(
         ep_dir,
-        ep_id,
+        ep_uuid,
         ep_conf,
         log_to_console,
-        reg_info,
+        lambda: mock_reg_info,
         ep_info={},
     )
 
@@ -617,10 +619,10 @@ def test_always_prints_endpoint_id_to_terminal(
     mock_sys.stderr.isatty.return_value = False
     ep.start_endpoint(
         ep_dir,
-        ep_id,
+        ep_uuid,
         ep_conf,
         log_to_console,
-        reg_info,
+        lambda: mock_reg_info,
         ep_info={},
     )
 
@@ -714,7 +716,7 @@ def test_handles_provided_endpoint_id_no_json(
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
-    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+    ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info={})
 
     a, _k = mock_launch.call_args
     assert a[0] == ep_uuid
@@ -732,7 +734,7 @@ def test_handles_provided_endpoint_id_with_json(
 
     ep_json = ep_dir / "endpoint.json"
     ep_json.write_text(json.dumps({"endpoint_id": str(uuid.uuid4())}))
-    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+    ep.start_endpoint(*ep_args, cred_fn=lambda: mock_reg_info, ep_info={})
 
     a, _k = mock_launch.call_args
     assert a[0] == ep_uuid

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -17,9 +17,11 @@ _mock_base = "globus_compute_endpoint.endpoint.interchange."
 
 def empty_reg_info() -> dict:
     return {
-        "task_queue_info": {},
-        "result_queue_info": {},
-        "heartbeat_queue_info": {},
+        "amqp_creds": {
+            "task_queue_info": {},
+            "result_queue_info": {},
+            "heartbeat_queue_info": {},
+        }
     }
 
 
@@ -68,7 +70,7 @@ def ei(endpoint_uuid, mock_gce, mock_quiesce, mock_ep_info):
     _ei = EndpointInterchange(
         config=UserEndpointConfig(engine=mock_gce),
         endpoint_id=endpoint_uuid,
-        reg_info=empty_reg_info(),
+        cred_fn=empty_reg_info,
         ep_info=mock_ep_info,
     )
     _ei._quiesce_event = mock_quiesce
@@ -202,7 +204,7 @@ def test_audit_func_cleared_if_not_ha(mock_gce, task_uuid, audit_fd, is_ha, mock
     conf = UserEndpointConfig(high_assurance=is_ha, engine=mock_gce)
     f = GCFuture(task_uuid)
     ei = EndpointInterchange(
-        conf, reg_info=empty_reg_info(), ep_info={}, audit_fd=audit_fd
+        conf, cred_fn=empty_reg_info, ep_info={}, audit_fd=audit_fd
     )
     assert not ei.time_to_quit
 
@@ -215,7 +217,7 @@ def test_audit_func_cleared_if_not_ha(mock_gce, task_uuid, audit_fd, is_ha, mock
 def test_amqp_threads_stop_at_quiesce(mock_log, mock_gce, mock_rp, mock_tqs):
     conf = UserEndpointConfig(engine=mock_gce)
     mock_gce.get_status_report.side_effect = MemoryError("bad things!")
-    ei = EndpointInterchange(conf, reg_info=empty_reg_info(), ep_info={})
+    ei = EndpointInterchange(conf, cred_fn=empty_reg_info, ep_info={})
 
     with pytest.raises(MemoryError):
         ei._main_loop()

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -2448,17 +2448,19 @@ def test_ep_dir_log_path_envs_passed_to_render(
 
 
 @pytest.mark.parametrize("is_valid", (True, False))
-def test_pipe_size_limit(mocker, mock_log, successful_exec_from_mocked_root, is_valid):
+def test_pipe_size_limit(mock_log, successful_exec_from_mocked_root, is_valid):
     *_, em = successful_exec_from_mocked_root
 
     stdin_data_size = 235  # Empirically/designed size of `stdin_data` string
     pipe_buffer_size = 255 + stdin_data_size + is_valid  # manufacture error/success
 
     conf_str = "k: v"  # some key, some value; valid YAML string
-    mocker.patch.object(fcntl, "fcntl", return_value=pipe_buffer_size)
-    mocker.patch(f"{_MOCK_BASE}render_config_user_template", return_value=conf_str)
 
-    with pytest.raises(SystemExit) as pyexc:
+    with (
+        mock.patch.object(fcntl, "fcntl", return_value=pipe_buffer_size),
+        mock.patch(f"{_MOCK_BASE}render_config_user_template", return_value=conf_str),
+        pytest.raises(SystemExit) as pyexc,
+    ):
         em._event_loop()
 
     if is_valid:

--- a/compute_endpoint/tests/unit/test_result_publisher.py
+++ b/compute_endpoint/tests/unit/test_result_publisher.py
@@ -32,7 +32,7 @@ def mock_pika():
 
 def test_rp_as_contextmanager(randomstring, mock_pika):
     queue_info = {"queue": randomstring(), **q_info, "connection_url": "amqp:///"}
-    with ResultPublisher(queue_info=queue_info) as rp:
+    with ResultPublisher(cred_fn=lambda: queue_info) as rp:
         try_assert(rp.is_alive, "Context manager starts thread")
 
     try_assert(lambda: not rp.is_alive(), "Context manager stops thread")
@@ -40,7 +40,7 @@ def test_rp_as_contextmanager(randomstring, mock_pika):
 
 def test_rp_callbacks_hooked_up(randomstring, mock_pika):
     queue_info = {"queue": randomstring(), **q_info, "connection_url": "amqp:///"}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
     rp._connect()
 
     assert mock_pika.SelectConnection.called
@@ -55,7 +55,8 @@ def test_rp_verifies_exchange(randomstring):
     mock_channel = mock.Mock()
     queue_info = {"exchange": randomstring(), **q_info}
 
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
+    rp._queue_info = rp.cred_fn()
     rp._on_channel_open(mock_channel)
 
     assert mock_channel.exchange_declare.called
@@ -68,7 +69,8 @@ def test_rp_verifies_queue(randomstring):
     mock_channel = mock.Mock()
     queue_info = {"queue": randomstring(), **q_info}
 
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
+    rp._queue_info = rp.cred_fn()
     rp._mq_chan = mock_channel
     rp._on_exchange_verified(None)
 
@@ -87,7 +89,10 @@ def test_rp_stops_if_unable_to_connect(mocker, randomstring, attempt_limit):
     mock_stop.wait.return_value = None
     queue_info = {"queue": randomstring(), **q_info}
 
-    rp = ResultPublisher(queue_info=queue_info, connect_attempt_limit=attempt_limit)
+    rp = ResultPublisher(
+        cred_fn=lambda: queue_info, connect_attempt_limit=attempt_limit
+    )
+    rp._queue_info = rp.cred_fn()
     rp._connect = mock.Mock(spec=ResultPublisher._connect)
     rp._stop_event = mock_stop
     rp.run()
@@ -98,7 +103,7 @@ def test_rp_stops_if_unable_to_connect(mocker, randomstring, attempt_limit):
 
 def test_rp_connect_limit_very_high_sc30467(randomstring):
     queue_info = {"queue": randomstring(), **q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
     assert rp.connect_attempt_limit >= 5000, (
         "Some very high limit as RMQ can be down for awhile; SC-30467"
     )
@@ -107,7 +112,8 @@ def test_rp_connect_limit_very_high_sc30467(randomstring):
 def test_rp_new_channel_resets_delivery_index():
     mock_channel = mock.Mock()
     queue_info = {"exchange": "some_exchange", **q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
+    rp._queue_info = rp.cred_fn()
     rp._delivery_tag_index = random.randint(-1000, 1000)
     rp._on_channel_open(mock_channel)
 
@@ -117,7 +123,8 @@ def test_rp_new_channel_resets_delivery_index():
 def test_rp_delivery_confirmation_enabled():
     mock_channel = mock.Mock()
     queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
+    rp._queue_info = rp.cred_fn()
     rp._mq_chan = mock_channel
 
     rp._on_queue_verified(None)
@@ -130,7 +137,8 @@ def test_rp_delivery_confirmation_enabled():
 def test_rp_channel_closed_retries_then_shuts_down(mock_log, randomstring):
     exc = Exception(f"some reason: {randomstring()}")
     queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
+    rp._queue_info = rp.cred_fn()
     rp._mq_chan = mock.Mock()
     rp._mq_conn = mock.Mock()
 
@@ -163,7 +171,8 @@ def test_rp_stable_connection_resets_fail_counter(mocker):
     mock_time = mocker.patch(f"{_MOCK_BASE}time")
     mock_time.time.side_effect = [1000, 1061]  # 60 seconds passed
     queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: queue_info)
+    rp._queue_info = rp.cred_fn()
     rp._mq_chan = mock.Mock()
     rp._mq_conn = mock.Mock()
 
@@ -181,7 +190,9 @@ def test_rp_stops_trying_on_unrecoverable(randomstring, mock_log):
     queue_info = {"queue": randomstring(), **q_info}
 
     attempt_limit = random.randint(1_000_000, 2_000_000)  # something large
-    rp = ResultPublisher(queue_info=queue_info, connect_attempt_limit=attempt_limit)
+    rp = ResultPublisher(
+        cred_fn=lambda: queue_info, connect_attempt_limit=attempt_limit
+    )
     rp._on_open_failed(mock_conn, exc)
     assert rp._connection_tries >= attempt_limit, "Expect signal to event loop"
 
@@ -191,8 +202,7 @@ def test_rp_stops_trying_on_unrecoverable(randomstring, mock_log):
 
 
 def test_rp_handles_bulk_ack_deliveries():
-    queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: {**q_info})
     multiple_dtag = rp._delivery_tag_index + random.randint(5, 30)
     mock_frame = mock.Mock()
     mock_frame.method.INDEX = pika.spec.Basic.Ack.INDEX
@@ -217,8 +227,7 @@ def test_rp_handles_bulk_ack_deliveries():
 
 
 def test_rp_handles_bulk_nack_deliveries():
-    queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: {**q_info})
     multiple_dtag = rp._delivery_tag_index + random.randint(5, 30)
     mock_frame = mock.Mock()
     mock_frame.method.INDEX = pika.spec.Basic.Nack.INDEX
@@ -243,8 +252,7 @@ def test_rp_handles_bulk_nack_deliveries():
 
 
 def test_rp_event_watcher_publishes(randomstring):
-    queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: {**q_info})
     rp._connection = mock.Mock()
     rp._mq_conn = mock.Mock()
     rp._mq_chan = mock.Mock()
@@ -273,8 +281,7 @@ def test_rp_event_watcher_publishes(randomstring):
 
 
 def test_rp_publish_enqueues_message(randomstring):
-    queue_info = {**q_info}
-    rp = ResultPublisher(queue_info=queue_info)
+    rp = ResultPublisher(cred_fn=lambda: {**q_info})
     rp._mq_chan = mock.Mock()
     rp.is_alive = mock.Mock()
 
@@ -300,7 +307,7 @@ def test_rp_on_connection_closed_logs(mock_log, attempt_limit):
     assert attempt_limit > 2, "At least 3 states tested"
 
     exc = pika.exceptions.ChannelClosedByClient(200, "Some text")
-    cq = ResultPublisher(queue_info={**q_info})
+    cq = ResultPublisher(cred_fn=lambda: {**q_info})
     mock_conn = mock.Mock(spec=pika.BaseConnection)
     assert not mock_log.debug.called, "Verify test setup"
     cq._on_connection_closed(mock_conn, exc)

--- a/compute_endpoint/tests/unit/test_task_queue_subscriber.py
+++ b/compute_endpoint/tests/unit/test_task_queue_subscriber.py
@@ -26,7 +26,7 @@ def mock_pika():
 def test_tqs_as_contextmanager(randomstring, mock_pika):
     queue_info = {"queue": randomstring(), **q_info, "connection_url": "amqp:///"}
     with TaskQueueSubscriber(
-        queue_info=queue_info,
+        cred_fn=lambda: queue_info,
         pending_task_queue=queue.SimpleQueue(),
     ) as tqs:
         try_assert(tqs.is_alive, "Context manager starts thread")
@@ -37,7 +37,7 @@ def test_tqs_as_contextmanager(randomstring, mock_pika):
 def test_tqs_callbacks_hooked_up(randomstring, mock_pika):
     queue_info = {"queue": randomstring(), **q_info, "connection_url": "amqp:///"}
     tqs = TaskQueueSubscriber(
-        queue_info=queue_info,
+        cred_fn=lambda: queue_info,
         pending_task_queue=queue.SimpleQueue(),
     )
     tqs._connect()


### PR DESCRIPTION
# Description

The focus of this patch is to remove multiple copies of credentials (on each object instance) and replace them with a single function that may be invoked *when credentials are needed*.  There is no external behavior change currently, as the source of the credentials is not yet dynamic, but this patch contains the mundane call-site changes.  An upcoming patch that will make the source dynamic will motivate this changeset retrospectively.

For the reviewer, the main change of consequence is the addition of

```python
def make_credential_provider(
    reg_info: dict | None = None
) -> t.Callable[[], dict[str, dict]]:
```

And then the requisite changes to use this function's return value.  That basically looks like:

```python
cred_fn = make_credential_provider(reg_info)
```

And then uses of it like

```diff
- Class(..., queue_info=q_info, ...)
+ Class(..., cred_fn=cred_fn, ...)
```

(And for tests, which are one-off cases, that's largely something like `lambda: q_info`)

## Type of change

- New feature
- Code maintenance/cleanup