### PR TITLE
Read credentials from file

### DIFF
--- a/changelog.d/20260909_094338_kevin_sc_51963.rst
+++ b/changelog.d/20260909_094338_kevin_sc_51963.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Long-running UEPs are now able to reconnect to the AMQP service.  They no
+  longer shutdown after a spurious disconnect.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -959,11 +959,14 @@ def _start_user_endpoint(
         stdin_data = json.loads(sys.stdin.read())
 
         ep_info: dict = stdin_data["ep_info"]
-        reg_info: dict = stdin_data["amqp_creds"]
         config_str: str = stdin_data["config"]
         audit_fd: int | None = stdin_data.get("audit_fd")
         fn_allow_list: list[str] | None | int
         fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
+
+        cred_fd: int = stdin_data.get("mem_fd")
+        enckey: str = stdin_data.get("enckey")
+        reg_info: dict | None = stdin_data.get("amqp_creds")
 
         del stdin_data  # clarity for intended scope
 
@@ -1017,7 +1020,7 @@ def _start_user_endpoint(
         pid_path = Endpoint.pid_path(ep_dir)
         stk.enter_context(_pidfile(pid_path, ep_config.heartbeat_period * 3))
 
-        cred_fn = make_credential_provider(reg_info)
+        cred_fn = make_credential_provider(cred_fd, enckey, reg_info)
         get_cli_endpoint(ep_config).start_endpoint(
             endpoint_dir=ep_dir,
             endpoint_uuid=endpoint_uuid,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1296,6 +1296,7 @@ class EndpointManager:
                 "config": user_config,
                 "ep_info": ep_info,
                 "mem_fd": cred_fd_ro,
+                "enckey": cred_key.decode(),
             }
             if self._config.allowed_functions is not None:
                 stdin_data_dict["allowed_functions"] = self._config.allowed_functions

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import fcntl as _fcntl
+import json
+import os
 import os as _os
 import pwd as _pwd
 import re as _re
 import resource as _resource
 import sys
+import time
 import typing as t
 import urllib.parse
 
@@ -211,7 +214,7 @@ def user_input_select(prompt: str, options: list[str]) -> str | None:
 
 
 def make_credential_provider(
-    reg_info: dict | None = None,
+    cred_fd: int | None, key: str | bytes | None, reg_info: dict | None = None
 ) -> t.Callable[[], dict[str, dict]]:
     """
     Dynamically query a credential source.
@@ -220,12 +223,50 @@ def make_credential_provider(
     encapsulated in the SDK by `Client.register_endpoint()`.  It currently contains
     connection information for the task, result, and heartbeat queues.
     """
-    if reg_info is None:
-        raise KeyError("No credential info provided")
+    # The non-"else" branches are only required so long as we support pre-"credential
+    # refreshing" CEPs.  The clock starts ticking from Sep, 2026.
+    if cred_fd is None:
+        if reg_info is None:
+            raise KeyError("No credential info provided")
 
-    amqp_creds: dict = {"amqp_creds": reg_info}
+        amqp_creds: dict = {"amqp_creds": reg_info}
+        del cred_fd, key
 
-    def _credential_provider() -> dict:
-        return amqp_creds
+        def _credential_provider() -> dict:
+            return amqp_creds
+
+    elif not key:
+        raise ValueError("Missing required encryption key")
+
+    else:
+        from cryptography.fernet import Fernet
+
+        _cred_fd = int(cred_fd)  # damnit mypy, we just proved it!
+        del reg_info, cred_fd
+
+        def _credential_provider() -> dict:
+            try_count = 1
+            while True:
+                try:
+                    os.lseek(_cred_fd, 0, os.SEEK_SET)
+                    dyn_data_b = b""
+                    while chunk := os.read(_cred_fd, 2**15):
+                        dyn_data_b += chunk
+
+                    enc = Fernet(key)
+                    creds = json.loads(enc.decrypt(dyn_data_b))
+                    if not creds:
+                        raise ValueError("Credentials empty or not written")
+                    return creds
+                except Exception as exc:
+                    if try_count < 1:
+                        raise
+                    # Maybe we got super unlucky in catching the file mid-truncate
+                    # or write; try one more time after small delay
+                    try_count -= 1
+                    exc_type = type(exc).__name__
+                    msg = f"Failed to collect credentials: ({exc_type}) {exc}"
+                    print(msg, file=sys.stderr, flush=True)
+                    time.sleep(1)
 
     return _credential_provider

--- a/compute_endpoint/tests/unit/test_utils.py
+++ b/compute_endpoint/tests/unit/test_utils.py
@@ -1,4 +1,6 @@
 import fcntl
+import json
+import os
 import resource
 import sys
 import uuid
@@ -7,11 +9,13 @@ from unittest import mock
 
 import pika
 import pytest
+from cryptography.fernet import Fernet
 from globus_compute_endpoint.endpoint.utils import (
     _redact_url_creds,
     close_all_fds,
     is_privileged,
     make_close_on_exec,
+    make_credential_provider,
     send_endpoint_startup_failure_to_amqp,
     update_url_port,
 )
@@ -194,3 +198,99 @@ def test_all_files_closed(preserve):
 
     assert any(0 in r for r in closed_ranges), "Expect all but preserved closed"
     assert any(hard_no in r for r in closed_ranges), "Expect all but preserved closed"
+
+
+@pytest.mark.parametrize(
+    "has_fd,has_key,has_info,exp_exc",
+    (
+        (False, False, False, KeyError),
+        (False, True, False, KeyError),
+        (True, False, False, ValueError),
+        (True, False, True, ValueError),
+    ),
+)
+def test_credential_provider_handles_bad_input(has_fd, has_key, has_info, exp_exc):
+    fd = has_fd and 123 or None
+    key = has_key and "some_key" or None
+    reg_info = has_info and {"some": "creds"} or None
+    with pytest.raises(exp_exc):
+        make_credential_provider(fd, key, reg_info)
+
+
+@pytest.mark.parametrize(
+    "has_fd,has_key,has_info",
+    (
+        (False, False, True),
+        (False, True, True),
+        (True, True, False),
+        (True, True, True),
+    ),
+)
+def test_credential_provider_backwards_compatible(
+    randomstring, has_fd, has_key, has_info
+):
+    exp_creds = {"amqp_creds": {"testval": randomstring()}}
+    fd = has_fd and os.memfd_create("test_utils_cred_provider") or None
+    key = has_key and Fernet.generate_key() or None
+    reg_info = has_info and exp_creds["amqp_creds"] or None
+
+    cred_fn = make_credential_provider(fd, key, reg_info)
+
+    if has_fd:
+        enc = Fernet(key)
+        encrypted = enc.encrypt(json.dumps(exp_creds).encode())
+        os.write(fd, encrypted)
+        os.fsync(fd)
+
+    found_creds = cred_fn()
+    assert found_creds == exp_creds
+
+    if has_fd:
+        os.close(fd)
+
+
+def test_credential_provider_raises_on_empty():
+    fd = os.memfd_create("test_utils_cred_provider")
+    key = Fernet.generate_key()
+    enc = Fernet(key)
+
+    cred_fn = make_credential_provider(fd, key)
+
+    os.write(fd, enc.encrypt(b"null"))  # null == "valid json"
+    with mock.patch(f"{_MOCK_BASE}time.sleep"):  # don't wait in test
+        with pytest.raises(ValueError) as pyt_e:
+            cred_fn()
+    os.close(fd)
+    assert "Credentials empty" in str(pyt_e.value)
+
+
+def test_credential_provider_rereads():
+    fd = os.memfd_create("test_utils_cred_provider")
+    key = Fernet.generate_key()
+
+    cred_fn = make_credential_provider(fd, key)
+
+    def write_creds_now(*a, **k):
+        enc = Fernet(key)
+        os.write(fd, enc.encrypt(b'"test value"'))
+
+    with mock.patch(f"{_MOCK_BASE}time.sleep") as m:
+        m.side_effect = write_creds_now
+        assert "test value" == cred_fn()
+    os.close(fd)
+
+
+def test_credential_provider_reads_large_file():
+    fd = os.memfd_create("test_utils_cred_provider")
+    key = Fernet.generate_key()
+
+    cred_fn = make_credential_provider(fd, key)
+
+    exp_data = "A" * 2**18
+    data = json.dumps(exp_data).encode()
+    enc = Fernet(key)
+    os.write(fd, enc.encrypt(data))
+
+    with mock.patch(f"{_MOCK_BASE}time.sleep"):
+        assert exp_data == cred_fn()
+    os.close(fd)


### PR DESCRIPTION
Building on recent work that dynamically populates an (encrypted) credentials file, this patch implements the reading: UEPs now dynamically read from this file when they need credentials to talk to the AMQP service.

## Type of change

- Bug fix (non-breaking change that fixes an issue)