### PR TITLE
Update CI test-matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -84,7 +84,7 @@ jobs:
         options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
We added support for Python 3.14 a couple of months ago (c.f., `tox.ini`), but forgot to update the CI matrix.  Doh!

## Type of change

- Code maintenance/cleanup